### PR TITLE
Bug/stream deletion crash

### DIFF
--- a/src/projects/webrtc/rtc_application.cpp
+++ b/src/projects/webrtc/rtc_application.cpp
@@ -59,9 +59,11 @@ bool RtcApplication::DeleteStream(std::shared_ptr<StreamInfo> info)
 	}
 
 	// 모든 Session의 연결을 종료한다.
-	for(auto const &x : stream->GetAllSessions())
+	const auto& sessions = stream->GetAllSessions();
+	for(auto it = sessions.begin(); it != sessions.end();)
 	{
-		auto session = std::static_pointer_cast<RtcSession>(x.second);
+		auto session = std::static_pointer_cast<RtcSession>(it->second);
+		it++;
 
 		// IcePort에 모든 Session 삭제
 		_ice_port->RemoveSession(session);

--- a/src/projects/webrtc/rtc_application.cpp
+++ b/src/projects/webrtc/rtc_application.cpp
@@ -59,7 +59,7 @@ bool RtcApplication::DeleteStream(std::shared_ptr<StreamInfo> info)
 	}
 
 	// 모든 Session의 연결을 종료한다.
-	const auto& sessions = stream->GetAllSessions();
+	const auto &sessions = stream->GetAllSessions();
 	for(auto it = sessions.begin(); it != sessions.end();)
 	{
 		auto session = std::static_pointer_cast<RtcSession>(it->second);


### PR DESCRIPTION
PR for issue https://github.com/AirenSoft/OvenMediaEngine/issues/56.

Basically what this does it increments the iterator in the for loop to the next valid, so that the call to RemoveSession which will underneath trigger erasing the stream from the map does not invalidate it (this was not clear previously since the `for(const auto &x :` hid the underlaying iterators.