### PR TITLE
Video stream bypass

### DIFF
--- a/src/projects/base/application/media_track.cpp
+++ b/src/projects/base/application/media_track.cpp
@@ -46,6 +46,8 @@ MediaTrack::MediaTrack(const MediaTrack &media_track)
 
 	_start_frame_time = 0;
 	_last_frame_time = 0;
+
+	_bypass = media_track._bypass;
 }
 
 MediaTrack::~MediaTrack()
@@ -121,4 +123,9 @@ void MediaTrack::SetLastFrameTime(int64_t time)
 int64_t MediaTrack::GetLastFrameTime() const
 {
 	return _last_frame_time;
+}
+
+void MediaTrack::SetBypass(bool bypass)
+{
+	_bypass = bypass;
 }

--- a/src/projects/base/application/media_track.h
+++ b/src/projects/base/application/media_track.h
@@ -44,6 +44,8 @@ public:
 	void SetLastFrameTime(int64_t time);
 	int64_t GetLastFrameTime() const;
 
+	void SetBypass(bool bypass);
+
 private:
 	uint32_t _id;
 
@@ -57,4 +59,6 @@ private:
 
 	// Time of last frame(packet)
 	int64_t _last_frame_time;
+
+	bool _bypass = false;
 };

--- a/src/projects/base/application/stream_info.cpp
+++ b/src/projects/base/application/stream_info.cpp
@@ -172,3 +172,15 @@ void StreamInfo::ShowInfo()
 
 	logti("%s", out_str.CStr());
 }
+
+std::shared_ptr<MediaTrack> StreamInfo::FindFirstTrack(common::MediaType media_type)
+{
+	for(auto it = _tracks.begin(); it != _tracks.end(); ++it)
+	{
+		if (it->second->GetMediaType() == media_type)
+		{
+			return it->second;
+		}
+	}
+	return nullptr;
+}

--- a/src/projects/base/application/stream_info.h
+++ b/src/projects/base/application/stream_info.h
@@ -31,6 +31,8 @@ public:
 
 	void ShowInfo();
 
+	std::shared_ptr<MediaTrack> FindFirstTrack(common::MediaType media_type);
+
 protected:
 	uint32_t _id;
 	ov::String _name;

--- a/src/projects/base/media_route/media_buffer.h
+++ b/src/projects/base/media_route/media_buffer.h
@@ -117,14 +117,14 @@ public:
 		return _flag;
 	}
 
-	void SetFragHeader(const FragmentationHeader *header)
+	void SetFragHeader(std::unique_ptr<FragmentationHeader> frag_hdr)
 	{
-		::memcpy(&_frag_hdr, header, sizeof(_frag_hdr));
+		_frag_hdr = std::move(frag_hdr);
 	}
 
-	const FragmentationHeader *GetFragHeader() const
+	const std::unique_ptr<FragmentationHeader> &GetFragHeader() const
 	{
-		return &_frag_hdr;
+		return _frag_hdr;
 	}
 
 	std::unique_ptr<MediaPacket> ClonePacket()
@@ -138,7 +138,10 @@ public:
 			GetDuration(),
 			GetFlag());
 
-		packet->_frag_hdr = _frag_hdr;
+		if (_frag_hdr)
+		{
+			packet->_frag_hdr = std::make_unique<FragmentationHeader>(*_frag_hdr);
+		}
 
 		return packet;
 	}
@@ -154,7 +157,7 @@ protected:
 	int64_t _duration = -1LL;
 	MediaPacketFlag _flag = MediaPacketFlag::NoFlag;
 
-	FragmentationHeader _frag_hdr;
+	std::unique_ptr<FragmentationHeader> _frag_hdr;
 };
 
 class MediaFrame

--- a/src/projects/media_router/media_route_stream.h
+++ b/src/projects/media_router/media_route_stream.h
@@ -18,12 +18,9 @@
 #include "base/media_route/media_type.h"
 #include "base/application/stream_info.h"
 
-#include "bitstream/bitstream_to_annexb.h"
-#include "bitstream/bitstream_to_adts.h"
-#include "bitstream/bitstream_to_annexa.h"
-
 class MediaRouteStream
 {
+	friend class MediaRouteApplication;
 public:
 	MediaRouteStream(std::shared_ptr<StreamInfo> stream_info);
 	~MediaRouteStream();
@@ -42,7 +39,7 @@ private:
 
 public:
 	// 패킷 관리
-	bool Push(std::unique_ptr<MediaPacket> buffer, bool convert_bitstream);
+	bool Push(std::unique_ptr<MediaPacket> buffer);
 	std::unique_ptr<MediaPacket> Pop();
 	uint32_t Size();
 
@@ -51,13 +48,6 @@ private:
 	std::queue<std::unique_ptr<MediaPacket>> _queue;
 
 private:
-	////////////////////////////
-	// 비트 스트림 필터
-	////////////////////////////
-	BitstreamToAnnexB _bsfv;
-	BitstreamToADTS _bsfa;
-	BitstreamAnnexA _bsf_vp8;
-
 	// 마지막으로 받은 패킷의 시간
 	time_t _last_rb_time;
 };

--- a/src/projects/publishers/dash/dash_packetizer.h
+++ b/src/projects/publishers/dash/dash_packetizer.h
@@ -71,7 +71,7 @@ protected:
 
 	virtual bool UpdatePlayList();
 
-	virtual void SetReadyForStreaming() noexcept;
+	virtual void SetReadyForStreaming() noexcept override;
 
 	int _avc_nal_header_size = 0;
 	ov::String _start_time;

--- a/src/projects/publishers/hls/hls_publisher.h
+++ b/src/projects/publishers/hls/hls_publisher.h
@@ -23,7 +23,7 @@ protected:
 	//--------------------------------------------------------------------
 	// Implementation of SegmentPublisher
 	//--------------------------------------------------------------------
-	bool Start(std::map<int, std::shared_ptr<HttpServer>> &http_server_manager);
+	bool Start(std::map<int, std::shared_ptr<HttpServer>> &http_server_manager) override;
 
 	//--------------------------------------------------------------------
 	// Implementation of Publisher
@@ -35,7 +35,7 @@ protected:
 		return cfg::PublisherType::Hls;
 	}
 
-	const char *GetPublisherName() const
+	const char *GetPublisherName() const override
 	{
 		return "HLS";
 	}

--- a/src/projects/relay/relay_client.h
+++ b/src/projects/relay/relay_client.h
@@ -58,7 +58,8 @@ protected:
 		int64_t duration = 0LL;
 		uint32_t track_id;
 		ov::Data data;
-		uint8_t flag = 0U;
+		uint8_t flag;
+		bool had_first_packet = false;
 
 		std::unique_ptr<MediaPacket> CreatePacket() const
 		{

--- a/src/projects/relay/relay_datastructure.cpp
+++ b/src/projects/relay/relay_datastructure.cpp
@@ -1,0 +1,172 @@
+#include "relay_datastructure.h"
+
+RelayPacket::RelayPacket(RelayPacketType type)
+{
+    this->type = type;
+}
+
+RelayPacket::RelayPacket(const ov::Data *data)
+{
+    if(data->GetLength() == sizeof(RelayPacket))
+    {
+        ::memcpy(this, data->GetData(), sizeof(RelayPacket));
+
+        if(GetDataSize() > RelayPacketDataSize)
+        {
+            OV_ASSERT(GetDataSize() <= RelayPacketDataSize, "Data size %d exceedes %d", GetDataSize(), RelayPacketDataSize);
+            _data_size = ov::HostToBE16(RelayPacketDataSize);
+        }
+    }
+    else
+    {
+        OV_ASSERT(data->GetLength() == sizeof(RelayPacket), "Invalid data size: %zu, expected: %zu", data->GetLength(), sizeof(RelayPacket));
+    }
+}
+
+RelayPacketType RelayPacket::GetType() const
+{
+    return type;
+}
+
+void RelayPacket::SetTransactionId(uint32_t transaction_id)
+{
+    _transaction_id = ov::HostToBE32(transaction_id);
+}
+
+uint32_t RelayPacket::GetTransactionId() const
+{
+    return ov::BE32ToHost(_transaction_id);
+}
+
+void RelayPacket::SetApplicationId(uint32_t app_id)
+{
+    _application_id = ov::HostToBE32(app_id);
+}
+
+uint32_t RelayPacket::GetApplicationId() const
+{
+    return ov::BE32ToHost(_application_id);
+}
+
+void RelayPacket::SetStreamId(uint32_t stream_id)
+{
+    _stream_id = ov::HostToBE32(stream_id);
+}
+
+uint32_t RelayPacket::GetStreamId() const
+{
+    return ov::BE32ToHost(_stream_id);
+}
+
+void RelayPacket::SetMediaType(int8_t media_type)
+{
+    _media_type = media_type;
+}
+
+int8_t RelayPacket::GetMediaType() const
+{
+    return _media_type;
+}
+
+void RelayPacket::SetTrackId(uint32_t track_id)
+{
+    _track_id = ov::HostToBE32(track_id);
+}
+
+uint32_t RelayPacket::GetTrackId() const
+{
+    return ov::BE32ToHost(_track_id);
+}
+
+void RelayPacket::SetPts(uint64_t pts)
+{
+    _pts = ov::HostToBE64(pts);
+}
+
+uint64_t RelayPacket::GetPts() const
+{
+    return ov::BE64ToHost(_pts);
+}
+
+void RelayPacket::SetDts(int64_t dts)
+{
+    _dts = ov::HostToBE64(dts);
+}
+
+int64_t RelayPacket::GetDts() const
+{
+    return ov::BE64ToHost(_dts);
+}
+
+void RelayPacket::SetDuration(uint64_t duration)
+{
+    _duration = ov::HostToBE64(duration);
+}
+
+uint64_t RelayPacket::GetDuration() const
+{
+    return ov::BE64ToHost(_duration);
+}
+
+void RelayPacket::SetFlag(uint8_t flag)
+{
+    _flag = flag;
+}
+
+uint8_t RelayPacket::GetFlag() const
+{
+    return _flag;
+}
+
+void RelayPacket::SetData(const void *data, uint16_t length)
+{
+    if(length <= RelayPacketDataSize)
+    {
+        ::memcpy(_data, data, length);
+        _data_size = ov::HostToBE16(length);
+    }
+    else
+    {
+        OV_ASSERT2(length <= RelayPacketDataSize);
+    }
+}
+
+const void *RelayPacket::GetData() const
+{
+    return _data;
+}
+
+void *RelayPacket::GetData()
+{
+    return _data;
+}
+
+void RelayPacket::SetDataSize(uint16_t data_size)
+{
+    _data_size = ov::HostToBE16(data_size);
+}
+
+const uint16_t RelayPacket::GetDataSize() const
+{
+    return ov::BE16ToHost(_data_size);
+}
+
+void RelayPacket::SetStart(bool start)
+{
+    _start_indicator = static_cast<uint8_t>(start ? 1 : 0);
+}
+
+void RelayPacket::SetEnd(bool end)
+{
+    _end_indicator = static_cast<uint8_t>(end ? 1 : 0);
+}
+
+bool RelayPacket::IsEnd() const
+{
+    return (_end_indicator == 1);
+}
+
+bool RelayPacket::IsStart() const
+{
+    return (_start_indicator == 1);
+}

--- a/src/projects/relay/relay_datastructure.h
+++ b/src/projects/relay/relay_datastructure.h
@@ -12,6 +12,7 @@
 
 #include <base/common_types.h>
 #include <base/ovlibrary/ovlibrary.h>
+#include <base/ovsocket/socket.h>
 
 enum class RelayPacketType : uint8_t
 {
@@ -22,188 +23,9 @@ enum class RelayPacketType : uint8_t
 	Error
 };
 
-constexpr const int RelayPacketDataSize = 1190;
-
 #pragma pack(push, 1)
-struct RelayPacket
+struct RelayPacketHeader
 {
-	explicit RelayPacket(RelayPacketType type)
-	{
-		this->type = type;
-	}
-
-	explicit RelayPacket(const ov::Data *data)
-	{
-		if(data->GetLength() == sizeof(RelayPacket))
-		{
-			::memcpy(this, data->GetData(), sizeof(RelayPacket));
-
-			if(GetDataSize() > RelayPacketDataSize)
-			{
-				OV_ASSERT(GetDataSize() <= RelayPacketDataSize, "Data size %d exceedes %d", GetDataSize(), RelayPacketDataSize);
-				_data_size = ov::HostToBE16(RelayPacketDataSize);
-			}
-		}
-		else
-		{
-			OV_ASSERT(data->GetLength() == sizeof(RelayPacket), "Invalid data size: %zu, expected: %zu", data->GetLength(), sizeof(RelayPacket));
-		}
-	}
-
-	RelayPacketType GetType() const
-	{
-		return type;
-	}
-
-	void SetTransactionId(uint32_t transaction_id)
-	{
-		_transaction_id = ov::HostToBE32(transaction_id);
-	}
-
-	uint32_t GetTransactionId() const
-	{
-		return ov::BE32ToHost(_transaction_id);
-	}
-
-	void SetApplicationId(uint32_t app_id)
-	{
-		_application_id = ov::HostToBE32(app_id);
-	}
-
-	uint32_t GetApplicationId() const
-	{
-		return ov::BE32ToHost(_application_id);
-	}
-
-	void SetStreamId(uint32_t stream_id)
-	{
-		_stream_id = ov::HostToBE32(stream_id);
-	}
-
-	uint32_t GetStreamId() const
-	{
-		return ov::BE32ToHost(_stream_id);
-	}
-
-	void SetMediaType(int8_t media_type)
-	{
-		_media_type = media_type;
-	}
-
-	int8_t GetMediaType() const
-	{
-		return _media_type;
-	}
-
-	void SetTrackId(uint32_t track_id)
-	{
-		_track_id = ov::HostToBE32(track_id);
-	}
-
-	uint32_t GetTrackId() const
-	{
-		return ov::BE32ToHost(_track_id);
-	}
-
-	void SetPts(int64_t pts)
-	{
-		_pts = ov::HostToBE64(pts);
-	}
-
-	int64_t GetPts() const
-	{
-		return ov::BE64ToHost(_pts);
-	}
-
-	void SetDts(int64_t dts)
-	{
-		_dts = ov::HostToBE64(dts);
-	}
-
-	int64_t GetDts() const
-	{
-		return ov::BE64ToHost(_dts);
-	}
-
-	void SetDuration(uint64_t duration)
-	{
-		_duration = ov::HostToBE64(duration);
-	}
-
-	uint64_t GetDuration() const
-	{
-		return ov::BE64ToHost(_duration);
-	}
-
-	void SetFlag(uint8_t flag)
-	{
-		_flag = flag;
-	}
-
-	uint8_t GetFlag() const
-	{
-		return _flag;
-	}
-
-	void SetFragmentHeader(const FragmentationHeader *header)
-	{
-		::memcpy(&_frag_header, header, sizeof(_frag_header));
-	}
-
-	const FragmentationHeader *GetFragmentHeader() const
-	{
-		return &_frag_header;
-	}
-
-	void SetData(const void *data, uint16_t length)
-	{
-		if(length <= RelayPacketDataSize)
-		{
-			::memcpy(_data, data, length);
-			_data_size = ov::HostToBE16(length);
-		}
-		else
-		{
-			OV_ASSERT2(length <= RelayPacketDataSize);
-		}
-	}
-
-	const void *GetData() const
-	{
-		return _data;
-	}
-
-	void *GetData()
-	{
-		return _data;
-	}
-
-	void SetDataSize(uint16_t data_size)
-	{
-		_data_size = ov::HostToBE16(data_size);
-	}
-
-	const uint16_t GetDataSize() const
-	{
-		return ov::BE16ToHost(_data_size);
-	}
-
-	void SetStart(bool start)
-	{
-		_start_indicator = static_cast<uint8_t>(start ? 1 : 0);
-	}
-
-	void SetEnd(bool end)
-	{
-		_end_indicator = static_cast<uint8_t>(end ? 1 : 0);
-	}
-
-	bool IsEnd() const
-	{
-		return (_end_indicator == 1);
-	}
-
-protected:
 	// TODO(dimiden): The endian between the RelayServer and the RelayClient must match
 	// (Currently, it uses little endian)
 
@@ -230,11 +52,62 @@ protected:
 	// MediaPacketFlag
 	uint8_t _flag = 0U;
 
-	FragmentationHeader _frag_header;
-
 	uint16_t _data_size = 0;
-	uint8_t _data[RelayPacketDataSize] = {};
 };
 
-static_assert(sizeof(RelayPacket) < 1316, "sizeof(RelayPacket) must be less than 1316");
+struct RelayPacket : RelayPacketHeader
+{
+
+	explicit RelayPacket(RelayPacketType type);
+	explicit RelayPacket(const ov::Data *data);
+
+	RelayPacketType GetType() const;
+
+	void SetTransactionId(uint32_t transaction_id);
+	uint32_t GetTransactionId() const;
+
+	void SetApplicationId(uint32_t app_id);
+	uint32_t GetApplicationId() const;
+
+	void SetStreamId(uint32_t stream_id);
+	uint32_t GetStreamId() const;
+
+	void SetMediaType(int8_t media_type);
+	int8_t GetMediaType() const;
+
+	void SetTrackId(uint32_t track_id);
+	uint32_t GetTrackId() const;
+
+	void SetPts(uint64_t pts);
+	uint64_t GetPts() const;
+
+	void SetDts(int64_t dts);
+	int64_t GetDts() const;
+
+	void SetDuration(uint64_t duration);
+	uint64_t GetDuration() const;
+
+	void SetFlag(uint8_t flag);
+	uint8_t GetFlag() const;
+
+	void SetData(const void *data, uint16_t length);
+	const void *GetData() const;
+	void *GetData();
+
+	void SetDataSize(uint16_t data_size);
+	const uint16_t GetDataSize() const;
+
+	void SetStart(bool start);
+	void SetEnd(bool end);
+
+	bool IsEnd() const;
+	bool IsStart() const;
+
+protected:
+	uint8_t _data[ov::MaxSrtPacketSize - sizeof(RelayPacketHeader)];
+};
+
+constexpr size_t RelayPacketDataSize = ov::MaxSrtPacketSize - sizeof(RelayPacketHeader);
+
+static_assert(sizeof(RelayPacket) <= ov::MaxSrtPacketSize, "sizeof(RelayPacket) must be less or equal to maximum srt packet size");
 #pragma pack(pop)

--- a/src/projects/relay/relay_server.cpp
+++ b/src/projects/relay/relay_server.cpp
@@ -369,8 +369,6 @@ void RelayServer::SendMediaPacket(const std::shared_ptr<MediaRouteStream> &media
 
 	RelayPacket relay_packet(RelayPacketType::Packet);
 
-	relay_packet.SetFragmentHeader(packet->GetFragHeader());
-
 	relay_packet.SetMediaType(static_cast<int8_t>(packet->GetMediaType()));
 	relay_packet.SetTrackId(static_cast<uint32_t>(packet->GetTrackId()));
 	relay_packet.SetPts(static_cast<uint64_t>(packet->GetPts()));
@@ -378,5 +376,8 @@ void RelayServer::SendMediaPacket(const std::shared_ptr<MediaRouteStream> &media
 	relay_packet.SetDuration(static_cast<uint64_t>(packet->GetDuration()));
 	relay_packet.SetFlag(static_cast<uint8_t>(packet->GetFlag()));
 
-	Send(stream_info->GetId(), relay_packet, packet->GetData().get());
+	const auto &frag_hdr = packet->GetFragHeader();
+	ov::Data data(frag_hdr ? frag_hdr->Serialize() : FragmentationHeader().Serialize());
+	data.Append(packet->GetData().get());
+	Send(stream_info->GetId(), relay_packet, &data);
 }

--- a/src/projects/rtmp/avc_video_packet_fragmentizer.cpp
+++ b/src/projects/rtmp/avc_video_packet_fragmentizer.cpp
@@ -1,0 +1,149 @@
+#include "avc_video_packet_fragmentizer.h"
+
+// https://www.adobe.com/content/dam/acom/en/devnet/flv/video_file_format_spec_v10.pdf
+
+#define OV_LOG_TAG "avcvideopacketfragmentizer"
+
+constexpr size_t avc_video_packet_payload_offset = 5;
+constexpr size_t avc_decoder_configuration_nal_length_offset = 4;
+constexpr size_t avc_decoder_configuration_sps_count_offset = 5;
+
+static uint32_t UnpackNalLength(const uint8_t *buffer, uint8_t nal_length_size)
+{
+    uint32_t nal_length = 0;
+    uint8_t nal_length_bytes_remaining = nal_length_size;
+    while (nal_length_bytes_remaining > 0)
+    {
+        nal_length <<= 8;
+        nal_length += *(buffer++);
+        --nal_length_bytes_remaining;
+    }
+    return nal_length;
+}
+
+static const uint8_t *ParseNalUnits(const uint8_t *nal_unit_buffer,
+    size_t length,
+    uint8_t nal_length_size,
+    std::vector<std::pair<size_t, size_t>> &fragments, 
+    size_t offset,
+    size_t &continuation_length,
+    size_t nal_unit_count = 0)
+{
+    if (nal_length_size == 0) return nullptr;
+    size_t nal_units_parsed = 0;
+
+    while (length && (nal_unit_count == 0 || nal_units_parsed < nal_unit_count))
+    {
+        if (length < nal_length_size)
+        {
+            return nullptr;
+        }
+        const auto nal_length = UnpackNalLength(nal_unit_buffer, nal_length_size);
+        length -= nal_length_size;
+        offset += nal_length_size;
+        nal_unit_buffer += nal_length_size;
+        if (length < nal_length)
+        {
+            continuation_length = nal_length - length;
+            fragments.emplace_back(offset, length);
+            return nal_unit_buffer + length;
+        }
+        fragments.emplace_back(offset, nal_length);
+        length -= nal_length;
+        offset += nal_length;
+        nal_unit_buffer += nal_length;
+        ++nal_units_parsed;
+    }
+    return nal_unit_buffer;
+}
+
+std::unique_ptr<FragmentationHeader> AvcVideoPacketFragmentizer::FromAvcVideoPacket(const uint8_t *packet, size_t length)
+{
+    if (length < 5) return nullptr; // No need to even parse the packet header, since there is no payload
+
+    size_t base_offset = 0;
+    const uint8_t frame_type = (packet[0] >> 4) & 0xf, codec_id = packet[0] & 0xf; 
+    std::unique_ptr<FragmentationHeader> fragmentation_header;
+    std::vector<std::pair<size_t, size_t>> fragments;
+    bool last_fragment_complete = true;
+    if (codec_id == 7 && (frame_type == 1 || frame_type == 2))
+    {
+        const uint8_t avc_packet_type = packet[1];
+        base_offset += avc_video_packet_payload_offset;
+        const uint8_t *avc_packet_payload = packet + avc_video_packet_payload_offset;
+        switch (avc_packet_type)
+        {
+        case 0:
+            // AVCDecoderConfigurationRecord
+            //
+            // The record starts with configuration version, the box type/size fields are not present
+            {
+                nal_length_size_ = ((*(avc_packet_payload + avc_decoder_configuration_nal_length_offset)) & 0b11) + 1;
+                const uint8_t sps_count = (*(avc_packet_payload + avc_decoder_configuration_sps_count_offset)) & 0b11111;
+                base_offset += avc_decoder_configuration_sps_count_offset;
+                avc_packet_payload += avc_decoder_configuration_sps_count_offset + 1;
+                size_t continuation_length = 0;
+                if (sps_count)
+                {
+                    const auto *result = ParseNalUnits(avc_packet_payload, length - base_offset, 2, fragments, base_offset, continuation_length, sps_count);
+                    if (result == nullptr)
+                    {
+                        OV_ASSERT2(false);
+                        return nullptr;
+                    }
+                    base_offset += result - avc_packet_payload;
+                    avc_packet_payload = result;
+                }
+                const uint8_t pps_count = *(avc_packet_payload);
+                base_offset += 1;
+                avc_packet_payload += 1;
+                if (pps_count)
+                {
+                    if (ParseNalUnits(avc_packet_payload, length - base_offset, 2, fragments, base_offset, continuation_length, pps_count) == nullptr)
+                    {
+                        OV_ASSERT2(false);
+                        return nullptr;
+                    }
+
+                }
+            }
+            break;
+        case 1:
+            // One or more NALUs
+            if (nal_length_size_ == 0) return nullptr;
+
+            if (continuation_length_)
+            {
+                size_t continuation_length = std::min(continuation_length_, length - base_offset);
+                fragments.emplace_back(base_offset, continuation_length);
+                avc_packet_payload += continuation_length;
+                base_offset += continuation_length;
+                continuation_length_ -= continuation_length;
+                last_fragment_complete = continuation_length_ == 0;
+                if (continuation_length_ !=0 || continuation_length == length - base_offset)
+                {
+                    break;
+                }
+            }
+
+            if (ParseNalUnits(avc_packet_payload, length - base_offset, nal_length_size_, fragments, base_offset, continuation_length_) == nullptr)
+            {
+                OV_ASSERT2(false);
+                return nullptr;
+            }
+            last_fragment_complete = continuation_length_ == 0;
+            break;
+        }    
+    }
+    if (fragments.empty() == false)
+    {
+        fragmentation_header = std::make_unique<FragmentationHeader>();
+        for (size_t fragment_index = 0; fragment_index < fragments.size(); ++fragment_index)
+        {
+            fragmentation_header->fragmentation_offset.emplace_back(fragments[fragment_index].first);
+            fragmentation_header->fragmentation_length.emplace_back(fragments[fragment_index].second);
+        }
+        fragmentation_header->last_fragment_complete = last_fragment_complete;
+    }
+    return fragmentation_header;
+}

--- a/src/projects/rtmp/avc_video_packet_fragmentizer.h
+++ b/src/projects/rtmp/avc_video_packet_fragmentizer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <base/common_types.h>
+
+#include <cstdint>
+#include <memory>
+class AvcVideoPacketFragmentizer
+{
+public:
+	std::unique_ptr<FragmentationHeader> FromAvcVideoPacket(const uint8_t *packet, size_t length);
+
+private:
+    uint8_t nal_length_size_ = 0;
+    size_t continuation_length_ = 0;
+};

--- a/src/projects/rtmp/rtmp_chunk_stream.cpp
+++ b/src/projects/rtmp/rtmp_chunk_stream.cpp
@@ -1059,16 +1059,19 @@ bool RtmpChunkStream::ReceiveVideoMessage(const std::shared_ptr<const RtmpMessag
 		return false;
 	}
 
+	std::unique_ptr<FragmentationHeader> fragmentation_header;
 	const std::shared_ptr<const ov::Data> &payload = message->payload;
 
 	// Frame Type 확인 (I/P(B) Frame)
 	if (payload->At(RTMP_VIDEO_CONTROL_HEADER_INDEX) == RTMP_H264_I_FRAME_TYPE)
 	{
-		frame_type = RtmpFrameType::VideoIFrame;  //I-Frame
+		frame_type = RtmpFrameType::VideoIFrame; //I-Frame
+		fragmentation_header = std::move(_avc_video_packet_fragmentizer.FromAvcVideoPacket(static_cast<const uint8_t*>(payload->GetData()), payload->GetLength()));
 	}
 	else if (payload->At(RTMP_VIDEO_CONTROL_HEADER_INDEX) == RTMP_H264_P_FRAME_TYPE)
 	{
-		frame_type = RtmpFrameType::VideoPFrame;  //P-Frame
+		frame_type = RtmpFrameType::VideoPFrame; //P-Frame
+		fragmentation_header = std::move(_avc_video_packet_fragmentizer.FromAvcVideoPacket(static_cast<const uint8_t*>(payload->GetData()), payload->GetLength()));
 	}
 	else
 	{
@@ -1126,11 +1129,13 @@ bool RtmpChunkStream::ReceiveVideoMessage(const std::shared_ptr<const RtmpMessag
 	if (_media_info->video_streaming)
 	{
 		_stream_interface->OnChunkStreamVideoData(_remote,
-												  _app_id,
-												  _stream_id,
-												  message->header->completed.timestamp,
-												  frame_type,
-												  message->payload);
+		                                          _app_id,
+		                                          _stream_id,
+		                                          message->header->completed.timestamp,
+		                                          frame_type,
+		                                          message->payload,
+												  std::move(fragmentation_header));
+
 
 		if (frame_type == RtmpFrameType::VideoIFrame)
 		{

--- a/src/projects/rtmp/rtmp_chunk_stream.h
+++ b/src/projects/rtmp/rtmp_chunk_stream.h
@@ -22,6 +22,7 @@
 #include "chunk/rtmp_export_chunk.h"
 #include "chunk/rtmp_handshake.h"
 #include "chunk/rtmp_import_chunk.h"
+#include "avc_video_packet_fragmentizer.h"
 
 class IRtmpChunkStream
 {
@@ -35,7 +36,8 @@ public:
 										info::application_id_t application_id, uint32_t stream_id,
 										uint64_t timestamp,
 										RtmpFrameType frame_type,
-										const std::shared_ptr<const ov::Data> &data) = 0;
+										const std::shared_ptr<const ov::Data> &data,
+										std::unique_ptr<FragmentationHeader> fragmentation_header = nullptr) = 0;
 
 	virtual bool OnChunkStreamAudioData(ov::ClientSocket *remote,
 										info::application_id_t application_id, uint32_t stream_id,
@@ -197,4 +199,7 @@ protected:
 	uint32_t _audio_frame_count = 0;
 
 	time_t _last_packet_time;
+
+	AvcVideoPacketFragmentizer _avc_video_packet_fragmentizer;
+
 };

--- a/src/projects/rtmp/rtmp_observer.h
+++ b/src/projects/rtmp/rtmp_observer.h
@@ -21,7 +21,7 @@ public:
 	virtual bool OnStreamReadyComplete(const ov::String &app_name, const ov::String &stream_name, std::shared_ptr<RtmpMediaInfo> &media_info, info::application_id_t &application_id, uint32_t &stream_id) = 0;
 
 	// video 스트림 데이트 수신
-	virtual bool OnVideoData(info::application_id_t application_id, uint32_t stream_id, int64_t timestamp, RtmpFrameType frame_type, const std::shared_ptr<const ov::Data> &data) = 0;
+	virtual bool OnVideoData(info::application_id_t application_id, uint32_t stream_id, int64_t timestamp, RtmpFrameType frame_type, const std::shared_ptr<const ov::Data> &data, std::unique_ptr<FragmentationHeader> fragmentation_header = nullptr) = 0;
 
 	// audio 스트림 데이터 수신
 	virtual bool OnAudioData(info::application_id_t application_id, uint32_t stream_id, int64_t timestamp, RtmpFrameType frame_type, const std::shared_ptr<const ov::Data> &data) = 0;

--- a/src/projects/rtmp/rtmp_provider.cpp
+++ b/src/projects/rtmp/rtmp_provider.cpp
@@ -208,7 +208,8 @@ bool RtmpProvider::OnVideoData(info::application_id_t application_id,
 							   uint32_t stream_id,
 							   int64_t timestamp,
 							   RtmpFrameType frame_type,
-							   const std::shared_ptr<const ov::Data> &data)
+							   const std::shared_ptr<const ov::Data> &data,
+                               std::unique_ptr<FragmentationHeader> fragmentation_header)
 {
 	auto application = std::dynamic_pointer_cast<RtmpApplication>(GetApplicationById(application_id));
 
@@ -234,6 +235,7 @@ bool RtmpProvider::OnVideoData(info::application_id_t application_id,
 											  // RTMP doesn't know frame's duration
 											  -1LL,
 											  frame_type == RtmpFrameType::VideoIFrame ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag);
+	pbuf->SetFragHeader(std::move(fragmentation_header));
 
 	application->SendFrame(stream, std::move(pbuf));
 

--- a/src/projects/rtmp/rtmp_provider.h
+++ b/src/projects/rtmp/rtmp_provider.h
@@ -61,7 +61,8 @@ public:
                      uint32_t stream_id,
                      int64_t timestamp,
                      RtmpFrameType frame_type,
-                     const std::shared_ptr<const ov::Data> &data) override;
+                     const std::shared_ptr<const ov::Data> &data,
+                     std::unique_ptr<FragmentationHeader> fragmentation_header) override;
 
     bool OnAudioData(info::application_id_t application_id,
                      uint32_t stream_id,

--- a/src/projects/rtmp/rtmp_server.cpp
+++ b/src/projects/rtmp/rtmp_server.cpp
@@ -237,12 +237,13 @@ bool RtmpServer::OnChunkStreamVideoData(ov::ClientSocket *remote,
 										info::application_id_t application_id, uint32_t stream_id,
 										uint64_t timestamp,
 										RtmpFrameType frame_type,
-										const std::shared_ptr<const ov::Data> &data)
+										const std::shared_ptr<const ov::Data> &data,
+										std::unique_ptr<FragmentationHeader> fragmentation_header)
 {
 	// Notify the video data to the observers
 	for (auto &observer : _observers)
 	{
-		if (observer->OnVideoData(application_id, stream_id, timestamp, frame_type, data) == false)
+		if (observer->OnVideoData(application_id, stream_id, timestamp, frame_type, data, std::move(fragmentation_header)) == false)
 		{
 			logte("Could not send video data to observer %p: (%u/%u), remote: %s",
 				  observer.get(),

--- a/src/projects/rtmp/rtmp_server.h
+++ b/src/projects/rtmp/rtmp_server.h
@@ -57,7 +57,8 @@ protected:
 								info::application_id_t application_id, uint32_t stream_id,
 								uint64_t timestamp,
 								RtmpFrameType frame_type,
-								const std::shared_ptr<const ov::Data> &data) override;
+								const std::shared_ptr<const ov::Data> &data,
+								std::unique_ptr<FragmentationHeader> fragmentation_header = nullptr) override;
 
 	bool OnChunkStreamAudioData(ov::ClientSocket *remote,
 								info::application_id_t application_id, uint32_t stream_id,

--- a/src/projects/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -51,21 +51,30 @@ RtpPacketizerH264::~RtpPacketizerH264() {}
 
 RtpPacketizerH264::Fragment::~Fragment() = default;
 
-RtpPacketizerH264::Fragment::Fragment(const uint8_t* buffer, size_t length)
-	: buffer(buffer), length(length) {}
+RtpPacketizerH264::Fragment::Fragment(const uint8_t* buffer, size_t length, bool complete)
+	: buffer(buffer), length(length), complete(complete) {}
 RtpPacketizerH264::Fragment::Fragment(const Fragment& fragment)
-	: buffer(fragment.buffer), length(fragment.length) {}
+	: buffer(fragment.buffer), length(fragment.length), complete(fragment.complete) {}
 
 size_t RtpPacketizerH264::SetPayloadData(
 	const uint8_t* payload_data,
 	size_t payload_size,
 	const FragmentationHeader* fragmentation) {
-	for (int i = 0; i < fragmentation->fragmentation_vector_size; ++i) {
+	for (int i = 0; i < fragmentation->fragmentation_offset.size(); ++i) {
 		const uint8_t* buffer =
 			&payload_data[fragmentation->fragmentation_offset[i]];
 		size_t length = fragmentation->fragmentation_length[i];
 
-		input_fragments_.push_back(Fragment(buffer, length));
+		bool complete = true;
+		if (i == 0)
+		{
+			complete = last_fragment_complete_;
+		}
+		if (i == fragmentation->fragmentation_offset.size())
+		{
+			complete = fragmentation->last_fragment_complete;
+		}
+		input_fragments_.push_back(Fragment(buffer, length, complete));
 	}
 	if (!GeneratePackets()) {
 		num_packets_left_ = 0;
@@ -90,7 +99,7 @@ bool RtpPacketizerH264::GeneratePackets() {
 				if (i + 1 == input_fragments_.size()) {
 					fragment_len += last_packet_reduction_len_;
 				}
-				if (fragment_len > max_payload_len_) {
+				if (last_fragment_complete_ == false || fragment_len > max_payload_len_) {
 					PacketizeFuA(i);
 					++i;
 				} else {
@@ -104,7 +113,7 @@ bool RtpPacketizerH264::GeneratePackets() {
 
 void RtpPacketizerH264::PacketizeFuA(size_t fragment_index) {
 	const Fragment& fragment = input_fragments_[fragment_index];
-	bool is_last_fragment = fragment_index + 1 == input_fragments_.size();
+	bool is_last_fragment = fragment_index + 1 == input_fragments_.size() && last_fragment_complete_;
 	size_t payload_left = fragment.length - kNalHeaderSize;
 	size_t offset = kNalHeaderSize;
 	size_t per_packet_capacity = max_payload_len_ - kFuAHeaderSize;
@@ -127,10 +136,11 @@ void RtpPacketizerH264::PacketizeFuA(size_t fragment_index) {
 				--packet_length;
 			}
 		}
-		packets_.push(PacketUnit(Fragment(fragment.buffer + offset, packet_length),
-		                         offset - kNalHeaderSize == 0,
-		                         payload_left == packet_length, false,
+		packets_.push(PacketUnit(Fragment(fragment.buffer + offset, packet_length, fragment.complete),
+		                         (offset - kNalHeaderSize == 0) && last_fragment_complete_,
+		                         (payload_left == packet_length) && fragment.complete, false,
 		                         fragment.buffer[0]));
+		last_fragment_complete_ = fragment.complete;
 		offset += packet_length;
 		payload_left -= packet_length;
 		--num_packets;

--- a/src/projects/rtp_rtcp/rtp_packetizer_h264.h
+++ b/src/projects/rtp_rtcp/rtp_packetizer_h264.h
@@ -66,11 +66,12 @@ public:
 
 private:
 	struct Fragment {
-		Fragment(const uint8_t* buffer, size_t length);
+		Fragment(const uint8_t* buffer, size_t length, bool complete);
 		Fragment(const Fragment& fragment);
 		~Fragment();
 		const uint8_t* buffer = nullptr;
 		size_t length = 0;
+		bool complete = true;
 	};
 
 	struct PacketUnit {
@@ -104,5 +105,6 @@ private:
 	size_t num_packets_left_;
 	const H264PacketizationMode packetization_mode_;
 	std::deque<Fragment> input_fragments_;
+	bool last_fragment_complete_ = true;
 	std::queue<PacketUnit> packets_;
 };

--- a/src/projects/transcode/transcode_application.h
+++ b/src/projects/transcode/transcode_application.h
@@ -36,12 +36,12 @@ public:
 	explicit TranscodeApplication(const info::Application *application_info);
 	~TranscodeApplication() override;
 
-	MediaRouteApplicationObserver::ObserverType GetObserverType()
+	MediaRouteApplicationObserver::ObserverType GetObserverType() override
 	{
 		return MediaRouteApplicationObserver::ObserverType::Transcoder;
 	}
 
-	MediaRouteApplicationConnector::ConnectorType GetConnectorType()
+	MediaRouteApplicationConnector::ConnectorType GetConnectorType() override
 	{
 		return MediaRouteApplicationConnector::ConnectorType::Transcoder;
 	}

--- a/src/projects/transcode/transcode_stream.h
+++ b/src/projects/transcode/transcode_stream.h
@@ -29,6 +29,10 @@
 
 #include <base/application/application.h>
 
+#include <media_router/bitstream/bitstream_to_annexb.h>
+#include <media_router/bitstream/bitstream_to_adts.h>
+#include <media_router/bitstream/bitstream_to_annexa.h>
+
 class TranscodeApplication;
 
 typedef int32_t MediaTrackId;
@@ -113,12 +117,14 @@ private:
 
 	// 출력(변화된) 스트림 정보
 	bool AddStreamInfoOutput(ov::String stream_name);
+	uint8_t GetTrackId(common::MediaType media_type);
 	std::map<ov::String, std::shared_ptr<StreamInfo>> _stream_info_outputs;
 
 	// Transcoding information
 	uint8_t AddOutputContext(common::MediaType media_type, std::shared_ptr<TranscodeContext> output_context);
 
 	std::map<MediaTrackId, std::shared_ptr<TranscodeContext>> _output_contexts;
+	std::map<MediaTrackId, uint8_t> _bypass_routes;
 
 	// Create output streams
 	void CreateStreams();
@@ -128,6 +134,7 @@ private:
 
 	// Send frame with output stream's information
 	void SendFrame(std::unique_ptr<MediaPacket> packet);
+	void SendFrame(std::unique_ptr<MediaPacket> packet, uint8_t track_id);
 
 	// 통계 정보
 private:
@@ -136,5 +143,12 @@ private:
 	uint8_t _stats_queue_full_count;
 
 	uint64_t _max_queue_size;
+
+	////////////////////////////
+	// 비트 스트림 필터
+	////////////////////////////
+	BitstreamToAnnexB _bsfv;
+	BitstreamToADTS _bsfa;
+	BitstreamAnnexA _bsf_vp8;
 };
 

--- a/src/projects/webrtc/webrtc_publisher.h
+++ b/src/projects/webrtc/webrtc_publisher.h
@@ -49,7 +49,7 @@ public:
 	                   const std::shared_ptr<SessionDescription> &offer_sdp,
 	                   const std::shared_ptr<SessionDescription> &peer_sdp) override;
 
-    uint32_t OnGetBitrate(const ov::String &application_name, const ov::String &stream_name);
+    uint32_t OnGetBitrate(const ov::String &application_name, const ov::String &stream_name) override;
 
     bool GetMonitoringCollectionData(std::vector<std::shared_ptr<MonitoringCollectionData>> &collections) override;
 


### PR DESCRIPTION
Here is an implementation of video bypass - Ill follow with more details but I am opening this PR now so that others can look at this.

So the main things done here:
1) The fragmentation header is routed through from RTMP so that bypassed streams have a valid fragmentation header (which would normally come from the transcoder)
2) To implement 1) an AVC video packet parser has been added
3) The bypassed streams are still sent to the transcoder, but the transcoder now keeps a bypass list - if a packet that comes in has a stream that is bypassed it gets routed directly to the next component (still checking if there are attached transcoders that need to get it)
4) The RTP packetizers now have a signalling field that states that the last fragment is incomplete (which can happen with RTMP input) so that Fu-A units are properly created
5) The fragmentation header structure has been made dynamic (to support more than 3 entries, since I had a lot of test streams where this was the case)
6) I took the fragmentation header out of the relay packet, since it does not make sense to send it in each packet, but instead it is sent as contents of the media packet
7) Due to 6) I reorganized the relay packet class, moved out the fragmentation header and improved the way how the max data size is determined (since the relay packet must simply fit in the srt packet, and now that the header has been taken out as a separate struct this can be reduced to a constexpr)
8) The bitstream conversions (annex-b) are now done in the transcoder only for the packets that actually go to encoding (not to mess up the fragmentation header from the source)