### PR TITLE
Fix macOS compilation

### DIFF
--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -21,7 +21,9 @@
 #include <chrono>
 
 /// 임시 코드
+#if !defined(__APPLE__)
 #include <linux/sockios.h>
+#endif
 #include <sys/ioctl.h>
 
 #define USE_STATS_COUNTER 0

--- a/src/projects/config/item.cpp
+++ b/src/projects/config/item.cpp
@@ -13,6 +13,10 @@
 #include <unistd.h>
 #include <regex>
 
+#if defined(__APPLE__)
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 namespace cfg
 {
 	static ov::String MakeIndentString(int indent)

--- a/src/projects/main/signals.cpp
+++ b/src/projects/main/signals.cpp
@@ -157,7 +157,12 @@ bool InitializeSignals()
 
 	sa.sa_flags = SA_SIGINFO;
 	sa.sa_sigaction = AbortHandler;
+	// sigemptyset is a macro on macOS, so :: breaks compilation 
+#if defined(__APPLE__)
+	sigemptyset(&sa.sa_mask);
+#else
 	::sigemptyset(&sa.sa_mask);
+#endif
 
 	// Intentional signals (ignore)
 	//     SIGQUIT, SIGINT, SIGTERM, SIGTRAP, SIGHUP, SIGKILL

--- a/src/projects/modules/h264/h264_sps.cpp
+++ b/src/projects/modules/h264/h264_sps.cpp
@@ -164,8 +164,8 @@ bool H264Sps::Parse(const uint8_t *sps_bitstream, size_t length, H264Sps &sps)
                 {
                     uint8_t video_format = 0, bit;
                     if (!(sps_bitstream_parser.ReadBit(bit) &&
-                        (video_format |= bit, video_format << 1, sps_bitstream_parser.ReadBit(bit)) &&
-                        (video_format |= bit, video_format << 1, sps_bitstream_parser.ReadBit(bit))))
+                        (video_format |= bit, video_format <<= 1, sps_bitstream_parser.ReadBit(bit)) &&
+                        (video_format |= bit, video_format <<= 1, sps_bitstream_parser.ReadBit(bit))))
                     {
                         return false;
                     }


### PR DESCRIPTION
*) sigemptyset is a macro on macOS thus cannot be prefixed with ::
*) HOST_NAME_MAX is not available on macOS but _POSIX_HOST_NAME_MAX is
*) do not include <linux/sockios.h> on macOS