### PR TITLE
Cleanup and implementation for rtsp provider stream names

### DIFF
--- a/src/projects/base/ovlibrary/bit_reader.h
+++ b/src/projects/base/ovlibrary/bit_reader.h
@@ -12,8 +12,7 @@ public:
     BitReader(const uint8_t *buffer, size_t capacity) : buffer_(buffer),
         position_(buffer),
         capacity_(capacity),
-        bit_offset_(0),
-        mask_(0x80)
+        bit_offset_(0)
     {
     }
 
@@ -88,5 +87,4 @@ private:
     const uint8_t* position_;
     const size_t capacity_;
     int bit_offset_;
-    uint8_t mask_;
 };

--- a/src/projects/providers/rtsp/rtp/rtp_tcp_track.cpp
+++ b/src/projects/providers/rtsp/rtp/rtp_tcp_track.cpp
@@ -28,9 +28,9 @@ bool RtpTcpTrack::AddPacket(uint8_t channel, const std::shared_ptr<std::vector<u
     {
         return AddRtpPacket(packet);
     }
-    else
+    else if (channel == rtcp_channel_)
     {
         return AddRtcpPacket(packet);
     }
-    return true;
+    return false;
 }

--- a/src/projects/providers/rtsp/rtsp.cpp
+++ b/src/projects/providers/rtsp/rtsp.cpp
@@ -2,15 +2,15 @@
 
 #include <string>
 
-bool ExtractApplicationAndStreamNames(const std::string_view &rtsp_uri, std::string_view &application_name, std::string_view &stream_name)
+bool ExtractApplicationAndStreamNames(const std::string_view &rtsp_uri, std::string_view &address, std::string_view &application_name, std::string_view &stream_name)
 {
     std::string_view path;
-    if (ExtractPath(rtsp_uri, path) == false)
+    if (ExtractPath(rtsp_uri, address, path) == false)
     {
         return false;
     }
     const auto application_name_end = path.find('/');
-    if (application_name_end != std::string::npos)
+    if (application_name_end != std::string_view::npos)
     {
         application_name = path.substr(0, application_name_end);
         stream_name = path.substr(application_name_end + 1);
@@ -19,23 +19,35 @@ bool ExtractApplicationAndStreamNames(const std::string_view &rtsp_uri, std::str
     return false;
 }
 
-bool ExtractPath(const std::string_view &rtsp_uri, std::string_view &rtsp_path)
+bool ExtractPath(const std::string_view &rtsp_uri, std::string_view &address, std::string_view &rtsp_path)
 {
-    // With a properly formatted uri we should skip 3 / to get to the application name
+    // With a properly formatted uri we should skip 3 / to get to the application name, e.g rtsp://<address>[:<port>]/<rtsp_path>,
+    // everything else should be treated as a malformed path
     size_t skips = 3;
-    auto delimiter_position = 0;
+    size_t address_start_position = std::string_view::npos, delimiter_position = 0;
     while (skips > 0)
     {
         delimiter_position = rtsp_uri.find('/', delimiter_position + 1);
-        if (delimiter_position == std::string::npos)
+        if (delimiter_position == std::string_view::npos)
         {
             break;
         }
         skips--;
+        if (skips == 1)
+        {
+            address_start_position = delimiter_position;
+        }
     }
-    if (delimiter_position == std::string::npos)
+    if (delimiter_position == std::string_view::npos)
     {
         return false;
+    }
+    address = rtsp_uri.substr(address_start_position + 1, delimiter_position - (address_start_position + 1));
+    // Strip port from address if present
+    auto port_start_position = address.find(':');
+    if (port_start_position != std::string_view::npos)
+    {
+        address = address.substr(0, port_start_position);
     }
     rtsp_path = rtsp_uri.substr(delimiter_position + 1);
     return true;

--- a/src/projects/providers/rtsp/rtsp.h
+++ b/src/projects/providers/rtsp/rtsp.h
@@ -16,8 +16,8 @@ enum class RtspMethod
 };
 
 RtspMethod GetRtspMethod(const std::string_view &method);
-bool ExtractApplicationAndStreamNames(const std::string_view &rtsp_uri, std::string_view &application_name, std::string_view &stream_name);
-bool ExtractPath(const std::string_view &rtsp_uri, std::string_view &rtsp_path);
+bool ExtractApplicationAndStreamNames(const std::string_view &rtsp_uri, std::string_view &address, std::string_view &application_name, std::string_view &stream_name);
+bool ExtractPath(const std::string_view &rtsp_uri, std::string_view &address, std::string_view &rtsp_path);
 
 enum class RtpVideoFlags : uint8_t
 {

--- a/src/projects/providers/rtsp/rtsp_connection.cpp
+++ b/src/projects/providers/rtsp/rtsp_connection.cpp
@@ -100,8 +100,8 @@ void RtspConnection::OnRtspRequest(const RtspRequest &rtsp_request)
         break;
     case RtspMethod::Announce:
         {
-            std::string_view application_name, stream_name;
-            if (ExtractApplicationAndStreamNames(rtsp_request.GetUri(), application_name, stream_name) == false)
+            std::string_view application_name, stream_name, address;
+            if (ExtractApplicationAndStreamNames(rtsp_request.GetUri(), address, application_name, stream_name) == false)
             {
                 // We can't split the uri into application name and stream components, give up and return 400;
                 SendResponse(rtsp_request, 400);
@@ -109,8 +109,7 @@ void RtspConnection::OnRtspRequest(const RtspRequest &rtsp_request)
             }
             RtspMediaInfo rtsp_media_info;
             const auto &sdp = rtsp_request.GetBody();
-            ParseSdp(sdp, rtsp_media_info);
-            bool success = rtsp_server_.OnStreamAnnounced(application_name, stream_name, rtsp_media_info);
+            bool success = ParseSdp(sdp, rtsp_media_info) && rtsp_server_.OnStreamAnnounced(address, application_name, stream_name, rtsp_media_info);
             SendResponse(rtsp_request, success ? 200 : 500);
         }
         break;
@@ -153,8 +152,8 @@ void RtspConnection::OnRtspRequest(const RtspRequest &rtsp_request)
                     return;  
                 }
             }
-            std::string_view rtsp_path;
-            if (ExtractPath(rtsp_request.GetUri(), rtsp_path) == false)
+            std::string_view rtsp_path, address;
+            if (ExtractPath(rtsp_request.GetUri(), address, rtsp_path) == false)
             {
                 SendResponse(rtsp_request, 400);
                 return;              
@@ -233,8 +232,8 @@ void RtspConnection::OnRtspRequest(const RtspRequest &rtsp_request)
         break;
     case RtspMethod::Teardown:
         {
-            std::string_view application_name, stream_name;
-            if (ExtractApplicationAndStreamNames(rtsp_request.GetUri(), application_name, stream_name) == false)
+            std::string_view address, application_name, stream_name;
+            if (ExtractApplicationAndStreamNames(rtsp_request.GetUri(), address, application_name, stream_name) == false)
             {
                 // We can't split the uri into application name and stream components, give up and return 400;
                 SendResponse(rtsp_request, 400);

--- a/src/projects/providers/rtsp/rtsp_observer.h
+++ b/src/projects/providers/rtsp/rtsp_observer.h
@@ -12,7 +12,8 @@ class RtspObserver : public ov::EnableSharedFromThis<RtspObserver>
 {
 public:
 
-    virtual bool OnStreamAnnounced(const ov::String &app_name, 
+    virtual bool OnStreamAnnounced(const std::string_view &address,
+        const ov::String &app_name, 
         const ov::String &stream_name,
         const RtspMediaInfo& rtsp_media_info,
         info::application_id_t &application_id,

--- a/src/projects/providers/rtsp/rtsp_provider.cpp
+++ b/src/projects/providers/rtsp/rtsp_provider.cpp
@@ -60,24 +60,16 @@ namespace pvd
         return provider;
     }
 
-    bool RtspProvider::OnStreamAnnounced(const ov::String &app_name, 
+    bool RtspProvider::OnStreamAnnounced(const std::string_view &address,
+        const ov::String &app_name, 
         const ov::String &stream_name,
         const RtspMediaInfo &media_info,
         info::application_id_t &application_id,
         uint32_t &stream_id)
     {
-        ov::String internal_app_name = app_name;
-
-        // TODO: domain name or vhost_info is needed
-    #if 0
         // Make an internal app name by domain_name
-        ov::String domain_name = "dummy.com";
-        auto internal_app_name = Orchestrator::ResolveApplicationNameFromDomain(domain_name, app);
-
-        // Make an internal app name by cfg::VirtualHost
-        cfg::VirtualHost vhost_config;
-        Orchestrator::ResolveApplicationName(vhost_config.GetName(), app);
-    #endif
+        ov::String domain_name(address.data(), address.size());
+        auto internal_app_name = Orchestrator::GetInstance()->ResolveApplicationNameFromDomain(domain_name, app_name);
 
         auto application = std::dynamic_pointer_cast<RtspApplication>(GetApplicationByName(internal_app_name.CStr()));
         if(application == nullptr)

--- a/src/projects/providers/rtsp/rtsp_provider.h
+++ b/src/projects/providers/rtsp/rtsp_provider.h
@@ -29,7 +29,8 @@ namespace pvd
         static std::shared_ptr<RtspProvider> Create(const cfg::Server &server_config, std::shared_ptr<MediaRouteInterface> router);
 
         // RtspObserver
-        bool OnStreamAnnounced(const ov::String &app_name, 
+        bool OnStreamAnnounced(const std::string_view &address,
+            const ov::String &app_name, 
             const ov::String &stream_name,
             const RtspMediaInfo &media_info,
             info::application_id_t &application_id,

--- a/src/projects/providers/rtsp/rtsp_server.h
+++ b/src/projects/providers/rtsp/rtsp_server.h
@@ -55,7 +55,8 @@ public:
 public:
     bool Disconnect(const ov::String &app_name, uint32_t stream_id);
 
-    bool OnStreamAnnounced(const std::string_view &app_name, 
+    bool OnStreamAnnounced(const std::string_view &address,
+        const std::string_view &app_name, 
         const std::string_view &stream_name,
         const RtspMediaInfo &media_info);
     bool OnUdpStreamTrackSetup(const std::string_view &rtsp_uri,

--- a/src/projects/providers/rtsp/sdp.cpp
+++ b/src/projects/providers/rtsp/sdp.cpp
@@ -304,5 +304,14 @@ bool ParseSdp(const std::vector<uint8_t> &sdp, RtspMediaInfo &rtsp_media_info)
             }
         }
     }
+    // Check if all the payloads have codec ids deduced while parsing,
+    // if not return false since there is not much we can do
+    for (const auto &payload : rtsp_media_info.payloads_)
+    {
+        if (payload.second.GetCodecId() == common::MediaCodecId::None)
+        {
+            return false;
+        }
+    }
     return true;
 }


### PR DESCRIPTION
Cleanup and implementation for rtsp provider stream names

*) bit_reader.h: remove unneeded variable
*) sdp.cpp: fail when codec id's cannot be deduced (ffmpeg will convert h264 to mpeg4 w/o -c:v copy) and for example mpeg4 is useless here since there is no decoder and neither can it be bypassed to any kind of currently supported publisher
*) other files - route domain from the actual rtsp connection to rtsp provider so that app name lookup can be performed