### PR TITLE
Add srt pkg-config in ovlibrary, dtls_srtp, monitoring and orchestrator

### DIFF
--- a/src/projects/base/ovlibrary/AMS.mk
+++ b/src/projects/base/ovlibrary/AMS.mk
@@ -7,5 +7,6 @@ LOCAL_HEADER_FILES := $(LOCAL_HEADER_FILES)
 LOCAL_SOURCE_FILES := $(LOCAL_SOURCE_FILES)
 
 $(call add_pkg_config,openssl)
+$(call add_pkg_config,srt)
 
 include $(BUILD_STATIC_LIBRARY)

--- a/src/projects/modules/dtls_srtp/AMS.mk
+++ b/src/projects/modules/dtls_srtp/AMS.mk
@@ -4,5 +4,6 @@ include $(DEFAULT_VARIABLES)
 LOCAL_TARGET := dtls_srtp
 
 $(call add_pkg_config,openssl)
+$(call add_pkg_config,srt)
 
 include $(BUILD_STATIC_LIBRARY)

--- a/src/projects/monitoring/AMS.mk
+++ b/src/projects/monitoring/AMS.mk
@@ -7,5 +7,6 @@ LOCAL_SOURCE_FILES := $(LOCAL_SOURCE_FILES)
 LOCAL_HEADER_FILES := $(LOCAL_HEADER_FILES)
 
 $(call add_pkg_config,openssl)
+$(call add_pkg_config,srt)
 
 include $(BUILD_STATIC_LIBRARY)

--- a/src/projects/orchestrator/AMS.mk
+++ b/src/projects/orchestrator/AMS.mk
@@ -4,6 +4,7 @@ include $(DEFAULT_VARIABLES)
 LOCAL_TARGET := orchestrator
 
 $(call add_pkg_config,openssl)
+$(call add_pkg_config,srt)
 
 include $(BUILD_STATIC_LIBRARY)
 


### PR DESCRIPTION
When only SRT and FFMpeg libs are installed in `/opt/ovenmediaengine/`, compilation fails saying that `srt/srt.h` is not found. This is due to missing SRT pkg-config call in some projects. It seems to be an unwanted oversight.

One solution to that problem is to add SRT pkg-config to `AMS.mk` when a project requires it.

Regards,