### PR TITLE
fix check if scheme of ovtStream is equals OVT.

### DIFF
--- a/src/projects/providers/ovt/ovt_stream.cpp
+++ b/src/projects/providers/ovt/ovt_stream.cpp
@@ -140,7 +140,7 @@ namespace pvd
 		}
 
 		auto scheme = _curr_url->Scheme();
-		if (scheme == "OVT")
+		if (scheme != "OVT")
 		{
 			_state = State::ERROR;
 			logte("The scheme is not OVT : %s", scheme.CStr());

--- a/src/projects/providers/ovt/ovt_stream.cpp
+++ b/src/projects/providers/ovt/ovt_stream.cpp
@@ -140,7 +140,7 @@ namespace pvd
 		}
 
 		auto scheme = _curr_url->Scheme();
-		if (scheme != "OVT")
+		if (scheme.UpperCaseString() != "OVT")
 		{
 			_state = State::ERROR;
 			logte("The scheme is not OVT : %s", scheme.CStr());


### PR DESCRIPTION
The code threw an error if the scheme of an OVT stream is `OVT`, but it should only throw the error if the opposite is the case.

This replaces a `==` by `!=` and also makes the check case-insensitive.