### PR TITLE
Fix typo: publihser -> publisher

### DIFF
--- a/src/projects/base/mediarouter/media_buffer.h
+++ b/src/projects/base/mediarouter/media_buffer.h
@@ -34,7 +34,7 @@ public:
 		_packet_type = packet_type;
 	}
 
-	// This constructor is usually used by the MediaRouter to send media packets to the publihsers.
+	// This constructor is usually used by the MediaRouter to send media packets to the publishers.
 	MediaPacket(cmn::MediaType media_type, int32_t track_id, const std::shared_ptr<ov::Data> &data, int64_t pts, int64_t dts, int64_t duration, MediaPacketFlag flag, cmn::BitstreamFormat bitstream_format, cmn::PacketType packet_type)
 		: _media_type(media_type),
 		  _track_id(track_id),
@@ -49,7 +49,7 @@ public:
 	{
 	}
 
-	// This constructor is usually used by the MediaRouter to send media packets to the publihsers.
+	// This constructor is usually used by the MediaRouter to send media packets to the publishers.
 	MediaPacket(cmn::MediaType media_type, int32_t track_id, const std::shared_ptr<ov::Data> &data, int64_t pts, int64_t dts, int64_t duration, MediaPacketFlag flag)
 		: _media_type(media_type),
 		  _track_id(track_id),

--- a/src/projects/base/publisher/publisher.cpp
+++ b/src/projects/base/publisher/publisher.cpp
@@ -119,7 +119,7 @@ namespace pub
 				}
 			}
 
-			logte("%s publihser hasn't the %s application.", ::StringFromPublisherType(GetPublisherType()).CStr(), app_info.GetName().CStr());
+			logte("%s publisher hasn't the %s application.", ::StringFromPublisherType(GetPublisherType()).CStr(), app_info.GetName().CStr());
 			return false;
 		}
 

--- a/src/projects/monitoring/stream_metrics.cpp
+++ b/src/projects/monitoring/stream_metrics.cpp
@@ -114,7 +114,7 @@ namespace mon
 			// Sending a connection event to application only if it hasn't origin stream to prevent double sum. 
 			GetApplicationMetrics()->OnSessionConnected(type);
 
-			logti("A new session has started playing %s/%s on the %s publihser. %s(%u)/Stream total(%u)/App total(%u)", 
+			logti("A new session has started playing %s/%s on the %s publisher. %s(%u)/Stream total(%u)/App total(%u)", 
 					GetApplicationInfo().GetName().CStr(), GetName().CStr(), 
 					::StringFromPublisherType(type).CStr(), ::StringFromPublisherType(type).CStr(), GetConnections(type), GetTotalConnections(), GetApplicationMetrics()->GetTotalConnections());
 		}
@@ -139,7 +139,7 @@ namespace mon
 			// Sending a connection event to application only if it hasn't origin stream to prevent double sum. 
 			GetApplicationMetrics()->OnSessionDisconnected(type);
 
-			logti("A session has been stopped playing %s/%s on the %s publihser. Concurrent Viewers[%s(%u)/Stream total(%u)/App total(%u)]", 
+			logti("A session has been stopped playing %s/%s on the %s publisher. Concurrent Viewers[%s(%u)/Stream total(%u)/App total(%u)]", 
 					GetApplicationInfo().GetName().CStr(), GetName().CStr(), 
 					::StringFromPublisherType(type).CStr(), ::StringFromPublisherType(type).CStr(), GetConnections(type), GetTotalConnections(), GetApplicationMetrics()->GetTotalConnections());
 		}

--- a/src/projects/publishers/webrtc/rtc_session.cpp
+++ b/src/projects/publishers/webrtc/rtc_session.cpp
@@ -9,7 +9,7 @@
 
 #include <utility>
 
-std::shared_ptr<RtcSession> RtcSession::Create(const std::shared_ptr<WebRtcPublisher> &publihser,
+std::shared_ptr<RtcSession> RtcSession::Create(const std::shared_ptr<WebRtcPublisher> &publisher,
 											   const std::shared_ptr<pub::Application> &application,
                                                const std::shared_ptr<pub::Stream> &stream,
                                                const std::shared_ptr<const SessionDescription> &offer_sdp,
@@ -19,7 +19,7 @@ std::shared_ptr<RtcSession> RtcSession::Create(const std::shared_ptr<WebRtcPubli
 {
 	// Session Id of the offer sdp is unique value
 	auto session_info = info::Session(*std::static_pointer_cast<info::Stream>(stream), offer_sdp->GetSessionId());
-	auto session = std::make_shared<RtcSession>(session_info, publihser, application, stream, offer_sdp, peer_sdp, ice_port, ws_client);
+	auto session = std::make_shared<RtcSession>(session_info, publisher, application, stream, offer_sdp, peer_sdp, ice_port, ws_client);
 	if(!session->Start())
 	{
 		return nullptr;
@@ -28,7 +28,7 @@ std::shared_ptr<RtcSession> RtcSession::Create(const std::shared_ptr<WebRtcPubli
 }
 
 RtcSession::RtcSession(const info::Session &session_info,
-					   const std::shared_ptr<WebRtcPublisher> &publihser,
+					   const std::shared_ptr<WebRtcPublisher> &publisher,
 					   const std::shared_ptr<pub::Application> &application,
 					   const std::shared_ptr<pub::Stream> &stream,
 					   const std::shared_ptr<const SessionDescription> &offer_sdp,
@@ -37,7 +37,7 @@ RtcSession::RtcSession(const info::Session &session_info,
 					   const std::shared_ptr<WebSocketClient> &ws_client)
 	: Session(session_info, application, stream)
 {
-	_publisher = publihser;
+	_publisher = publisher;
 	_offer_sdp = offer_sdp;
 	_peer_sdp = peer_sdp;
 	_ice_port = ice_port;

--- a/src/projects/publishers/webrtc/rtc_session.h
+++ b/src/projects/publishers/webrtc/rtc_session.h
@@ -37,7 +37,7 @@ class RtcStream;
 class RtcSession : public pub::Session
 {
 public:
-	static std::shared_ptr<RtcSession> Create(const std::shared_ptr<WebRtcPublisher> &publihser,
+	static std::shared_ptr<RtcSession> Create(const std::shared_ptr<WebRtcPublisher> &publisher,
 											  const std::shared_ptr<pub::Application> &application,
 	                                          const std::shared_ptr<pub::Stream> &stream,
 	                                          const std::shared_ptr<const SessionDescription> &offer_sdp,
@@ -46,7 +46,7 @@ public:
 											  const std::shared_ptr<WebSocketClient> &ws_client);
 
 	RtcSession(const info::Session &session_info,
-			const std::shared_ptr<WebRtcPublisher> &publihser,
+			const std::shared_ptr<WebRtcPublisher> &publisher,
 			const std::shared_ptr<pub::Application> &application,
 	        const std::shared_ptr<pub::Stream> &stream,
 	        const std::shared_ptr<const SessionDescription> &offer_sdp,


### PR DESCRIPTION
This PR fixes typos where `publisher` was misspelled as `publihser` (note the `s` and `h` transposition), both in comments and code.