### PR TITLE
Fix #259: Use tls_address for HTTPS APIServer

### DIFF
--- a/src/projects/api_server/api_server.cpp
+++ b/src/projects/api_server/api_server.cpp
@@ -73,7 +73,7 @@ namespace api
 
 			if (certificate != nullptr)
 			{
-				_https_server = manager->CreateHttpsServer("APIServer", address, certificate);
+				_https_server = manager->CreateHttpsServer("APIServer", tls_address, certificate);
 
 				if (_https_server != nullptr)
 				{


### PR DESCRIPTION
Fixes #259 by referencing the correct variable when creating an HTTPS APIServer.