### PR TITLE
Use tls_address for HTTPS ThumbnailPublisher

### DIFF
--- a/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
@@ -89,7 +89,7 @@ bool ThumbnailPublisher::Start()
 
 		if (certificate != nullptr)
 		{
-			_https_server = manager->CreateHttpsServer("ThumbnailPublisher", address, certificate);
+			_https_server = manager->CreateHttpsServer("ThumbnailPublisher", tls_address, certificate);
 
 			if (_https_server != nullptr)
 			{


### PR DESCRIPTION
I believe this is the same situation as #261, where `tls_address` should have been used instead of `address`, but it's in ThumbnailPublisher instead of APIServer.