### PR TITLE
Fix typos in file_session

### DIFF
--- a/src/projects/publishers/file/file_session.cpp
+++ b/src/projects/publishers/file/file_session.cpp
@@ -369,7 +369,7 @@ ov::String FileSession::ConvertMacro(ov::String src)
 	ov::String replaced_string = ov::String(raw_string.c_str());
 
 	// =========================================
-	// Deifinitino of Macro
+	// Definition of Macro
 	// =========================================
 	// ${StartTime:YYYYMMDDhhmmss}
 	// ${EndTime:YYYYMMDDhhmmss}
@@ -383,7 +383,7 @@ ov::String FileSession::ConvertMacro(ov::String src)
 	// ${Application} : Application Name
 	// ${Stream} : Stream name
 	// ${Sequence} : Sequence number
-	// ${Id} : Idenficiation Code
+	// ${Id} : Identification Code
 
 	std::regex reg_exp("\\$\\{([a-zA-Z0-9:]+)\\}");
 	const std::sregex_iterator it_end;


### PR DESCRIPTION
This PR just fixes a couple typos in the file_session implementation where the ConvertMacro replacements are detailed.

(Related: Recording seems to work well! I've configured the File publisher and used the start/stop recording API with success.)