### PR TITLE
Add apt-get update before every apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV     OME_VERSION=master \
         PCRE2_VERSION=10.35
 
 ## Install build utils
-RUN     apt-get -y install build-essential nasm autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc
+RUN     apt-get update && apt-get -y install build-essential nasm autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc
 
 ## Build OpenSSL
 RUN \


### PR DESCRIPTION
apt-get update must be included with every apt-get, else, Docker build will use previous cache and will fail to get new packages correctly.
Build failed for me without it.
