### PR TITLE
set TLS 1.2 as min version for HTTPS (HLS/DASH/API)

### DIFF
--- a/src/projects/base/ovcrypto/openssl/tls.cpp
+++ b/src/projects/base/ovcrypto/openssl/tls.cpp
@@ -155,6 +155,9 @@ namespace ov
 			// https://curl.haxx.se/docs/ssl-ciphers.html
 			// https://wiki.mozilla.org/Security/Server_Side_TLS
 			::SSL_CTX_set_cipher_list(ctx, cipher_list.CStr());
+			
+			// Disable old TLS versions which are neither secure nor needed any more
+			::SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 
 			_ssl_ctx = std::move(ctx);
 


### PR DESCRIPTION
* sets TLS 1.2 as min version for HTTPS

Tested using the ssllabs.com scanner, showed no problem with access from any typically used device, resolves some potential downgrading attack vectors and allows for further cleanup of the ciphers list + performance improvements.
Edit: used this in production for an event with 2500 viewers and no problems reported so far.