### PR TITLE
README.md: remove trailing space in Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We have tested OME on the platforms listed below. However, we think it can work 
 ### Docker
 
 ```bash
-docker run -d \ 
+docker run -d \
 -p 1935:1935 \
 -p 3333:3333 \
 -p 8080:8080 \


### PR DESCRIPTION
Trying to copy this command into a terminal for convenience won't work due to the trailing whitespace after the escape character. Figured this was a simple enough change to make and convenient for users :)