### PR TITLE
Detect and clean up dead pull streams after 15 seconds

### DIFF
--- a/src/projects/base/provider/pull_provider/application.cpp
+++ b/src/projects/base/provider/pull_provider/application.cpp
@@ -86,6 +86,14 @@ namespace pvd
 									stream->GetApplicationInfo().GetName().CStr(), stream->GetName().CStr(), stream->GetId(), elapsed_time_from_last_recv);
 						}
 
+						// Abort pull stream when no packets arrived for more than 15 seconds. Most likely the stream source died, thus give OME a chance to correctly create a new stream + playlistis
+						if(elapsed_time_from_last_recv > 15)
+						{
+							logtw("%s/%s(%u) There were no incoming packets. %d seconds have elapsed since the last packet was received. Deleting the stream.", 
+									stream->GetApplicationInfo().GetName().CStr(), stream->GetName().CStr(), stream->GetId(), elapsed_time_from_last_recv);
+							DeleteStream(stream);
+						}
+
 						if(elapsed_time_from_last_sent > MAX_UNUSED_STREAM_AVAILABLE_TIME_SEC)
 						{
 							logtw("%s/%s(%u) stream will be deleted because it hasn't been used for %u seconds", stream->GetApplicationInfo().GetName().CStr(), stream->GetName().CStr(), stream->GetId(), MAX_UNUSED_STREAM_AVAILABLE_TIME_SEC);


### PR DESCRIPTION
In some cases (for example HLS edge pulls from origin over OVT and the rtmp-source "died" without proper disconnect), OME did not properly clean up dead streams and thus only responded the same old playlist.m3u8 and old .ts chunks to hls / dash clients, which then immediately retry to get new chunks, eventually run out of buffer and then just show the loading animation.

Without this change, the only way to be able to reuse the stream url was to manually restart OME on all the edge servers, even when the stream source reconnected to the origin server over rtmp and started pushing new media data again (which the edge server never receive).