### PR TITLE
fix spaces/tabs not being consistent in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,21 +8,21 @@ services:
     ports:
     - "1935:1935/tcp"
     - "3333:3333/tcp"
-	- "3478:3478/tcp"
+    - "3478:3478/tcp"
     - "8080:8080/tcp"
     - "9000:9000/tcp"
-	- "9999:9999/udp"
+    - "9999:9999/udp"
     - "4000-4005:4000-4005/udp"
     - "10006-10010:10006-10010/udp"
     environment:
     - OME_ORIGIN_PORT=9000
     - OME_RTMP_PROV_PORT=1935
-	- OME_SRT_PROV_PORT=9999
-	- OME_MPEGTS_PROV_PORT=4000-4005/udp
+    - OME_SRT_PROV_PORT=9999
+    - OME_MPEGTS_PROV_PORT=4000-4005/udp
     - OME_HLS_STREAM_PORT=8080
     - OME_DASH_STREAM_PORT=8080
     - OME_SIGNALLING_PORT=3333
-	- OME_TCP_RELAY_ADDRESS=*:3478
+    - OME_TCP_RELAY_ADDRESS=*:3478
     - OME_ICE_CANDIDATES=*:10006-10010/udp
     command: /opt/ovenmediaengine/bin/OvenMediaEngine -c origin_conf
 
@@ -32,7 +32,7 @@ services:
     image: airensoft/ovenmediaengine:latest
     ports:
     - "3334:3334/tcp"
-	- "3479:3479/tcp"
+    - "3479:3479/tcp"
     - "8090:8090/tcp"
     - "10000-10005:10000-10005/udp"
     environment:
@@ -40,6 +40,6 @@ services:
     - OME_HLS_STREAM_PORT=8090
     - OME_DASH_STREAM_PORT=8090
     - OME_SIGNALLING_PORT=3334
-	- OME_TCP_RELAY_ADDRESS=*:3479
+    - OME_TCP_RELAY_ADDRESS=*:3479
     - OME_ICE_CANDIDATES=*:10000-10005/udp
     command: /opt/ovenmediaengine/bin/OvenMediaEngine -c edge_conf


### PR DESCRIPTION
Spaces/tabs were not consistent in docker-compose.yml. This PR replaces the tabs by spaces, according to the usually accepted .yml "standard".
Also fixes missing linebreak at the end of the file. Please fix your local .git config so that your git client does this automatically in the future.