### PR TITLE
small Build fixes and enable CentOS 8 building

### DIFF
--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -180,7 +180,7 @@ install_ffmpeg()
     mkdir -p ${DIR} && \
     cd ${DIR} && \
     curl -sLf https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${FFMPEG_VERSION}.tar.gz | tar -xz --strip-components=1 && \
-    PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH} ./configure \
+    PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${PREFIX}/lib64/pkgconfig:${PKG_CONFIG_PATH} ./configure \
     --prefix="${PREFIX}" \
     --enable-gpl \
     --enable-nonfree \
@@ -320,14 +320,16 @@ install_base_fedora()
 
 install_base_centos()
 {
-    # centos-release-scl should be installed before installing devtoolset-7
-    sudo yum install -y centos-release-scl
-    sudo yum install -y bc gcc-c++ cmake autoconf libtool glibc-static tcl bzip2 zlib-devel devtoolset-7 
+    if [[ "${OSVERSION}" != "8" ]]; then
+        # centos-release-scl should be installed before installing devtoolset-7
+        sudo yum install -y centos-release-scl
+        sudo yum install -y glibc-static devtoolset-7
+	source scl_source enable devtoolset-7
+    fi
+    sudo yum install -y bc gcc-c++ cmake autoconf libtool tcl bzip2 zlib-devel libva-devel
 
     # Dependency library for hardware accelerators
-    sudo yum install libdrm-devel libX11-devel
-
-    source scl_source enable devtoolset-7
+    sudo yum install -y libdrm-devel libX11-devel
 }
 
 install_base_macos()
@@ -369,7 +371,7 @@ check_version()
         proceed_yn
     fi
 
-    if [[ "${OSNAME}" == "CentOS" && "${OSVERSION}" != "7" ]]; then
+    if [[ "${OSNAME}" == "CentOS" && "${OSVERSION}" != "7" && "${OSVERSION}" != "8" ]]; then
         proceed_yn
     fi
 
@@ -380,7 +382,7 @@ check_version()
 
 proceed_yn()
 {
-    read -p "This program [$0] is tested on [Ubuntu 18/20.04, CentOS 7, Fedora 28]
+    read -p "This program [$0] is tested on [Ubuntu 18/20.04, CentOS 7/8 q, Fedora 28]
 Do you want to continue [y/N] ? " ANS
     if [[ "${ANS}" != "y" && "$ANS" != "yes" ]]; then
         cd ${CURRENT}

--- a/src/projects/base/ovsocket/socket_utilities.cpp
+++ b/src/projects/base/ovsocket/socket_utilities.cpp
@@ -9,6 +9,7 @@
 #include "socket_utilities.h"
 
 #include <base/ovlibrary/ovlibrary.h>
+#include <sys/ioctl.h>
 
 #include "socket.h"
 

--- a/src/projects/transcoder/transcoder_gpu.cpp
+++ b/src/projects/transcoder/transcoder_gpu.cpp
@@ -6,8 +6,8 @@
 //  Copyright (c) 2020 AirenSoft. All rights reserved.
 //
 //==============================================================================
+#include <libavutil/hwcontext.h>
 #include "transcoder_gpu.h"
-
 #include "transcoder_private.h"
 
 TranscodeGPU::TranscodeGPU()


### PR DESCRIPTION
- ffmpeg configure won't find libmpx cause it is in ${PREFIX}/lib64/pkgconfig
- CentOS 8 doesnt need devtools and glibc-static
- Auto-Install libdrm-devel libX11-devel (the -y was missing, thus prompting)