### PR TITLE
Update systemd-service defaults

### DIFF
--- a/misc/ovenmediaengine.service
+++ b/misc/ovenmediaengine.service
@@ -4,13 +4,13 @@ After=network.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/ovenmediaengine.pid
+PIDFile=/run/ovenmediaengine.pid
 WorkingDirectory=/usr/share/ovenmediaengine
 ExecStart=/usr/bin/OvenMediaEngine -d
 Restart=on-abort
 RestartPreventExitStatus=1
 StandardOutput=null
-StandardError=syslog+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise i see in journald:
```
May 27 19:08:31 fireEmerald systemd[1]: /usr/lib/systemd/system/ovenmediaengine.service:7: PIDFile= references a path below legacy directory /var/run/, updating /var/run/ovenmediaengine.pid → /run/ovenmediaengine.pid; please update the unit file accordingly.
May 27 19:08:31 fireEmerald systemd[1]: /usr/lib/systemd/system/ovenmediaengine.service:13: Standard output type syslog+console is obsolete, automatically updating to journal+console. Please update your unit file, and consider removing the setting altogether.
``