### PR TITLE
Conditional serperator if Base URL has "?"

### DIFF
--- a/misc/signed_policy_url_generator.js
+++ b/misc/signed_policy_url_generator.js
@@ -30,7 +30,9 @@ let policy = POLICY
 let policyBase64 = base64url(Buffer.from(policy,'utf8'))
 // console.log('policyBase64:\t',policyBase64)
 
-let policyUrl = baseUrl + '?' + POLICY_QUERY_KEY_NAME + '=' + policyBase64
+let qsSeperator = baseUrl.includes("?") ? "&" : "?";
+let policyUrl =
+  baseUrl + qsSeperator + POLICY_QUERY_KEY_NAME + "=" + policyBase64;
 // console.log('policyUrl:\t', policyUrl)
 
 let signature = base64url(crypto.createHmac('sha1', HMAC_KEY).update(policyUrl).digest())


### PR DESCRIPTION
The javascript policy generator had a bug. It didn't have the conditional seperator, i.e. "&" or "?". It failed for cases like wss://host:port/app/stream?direction=send, where the Base URL already had a question mark.