### PR TITLE
Stop setting the `display_aspect_ratio` on AVStreams

### DIFF
--- a/src/projects/modules/file/file_writer.cpp
+++ b/src/projects/modules/file/file_writer.cpp
@@ -210,7 +210,6 @@ bool FileWriter::AddTrack(cmn::MediaType media_type, int32_t track_id, std::shar
 				memcpy(codecpar->extradata, track_info->GetExtradata()->GetDataAs<uint8_t>(), codecpar->extradata_size);
 			}
 
-			stream->display_aspect_ratio = AVRational{1, 1};
 			stream->time_base = AVRational{track_info->GetTimeBase().GetNum(), track_info->GetTimeBase().GetDen()};
 
 			_track_map[track_id] = stream->index;

--- a/src/projects/modules/rtmp/rtmp_writer.cpp
+++ b/src/projects/modules/rtmp/rtmp_writer.cpp
@@ -222,7 +222,6 @@ bool RtmpWriter::AddTrack(cmn::MediaType media_type, int32_t track_id, std::shar
 				logte("there is no avc configuration %d", track_info->GetExtradata()->GetLength());
 			}
 
-			stream->display_aspect_ratio = AVRational{1, 1};
 			stream->time_base = AVRational{track_info->GetTimeBase().GetNum(), track_info->GetTimeBase().GetDen()};
 
 			_track_map[track_id] = stream->index;


### PR DESCRIPTION
This was causing a compilation failure on ffmpeg 4.4 on Arch Linux.

This field was moved out of AVStream into a private structure in this commit:
http://git.videolan.org/gitweb.cgi/ffmpeg.git/?a=commit;h=c1b916580ae92abca583d9afa2f9f64165292dd8

Based on the message there, it was not intended to be exposed to begin
with, so we can just stop setting it.