### PR TITLE
Dockerfile.nv: two apt-get update was missing

### DIFF
--- a/Dockerfile.nv
+++ b/Dockerfile.nv
@@ -25,13 +25,13 @@ ENV     OME_VERSION=master \
         PCRE2_VERSION=10.35 
 
 ## Install build utils
-RUN     apt-get -y install build-essential nasm autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc uuid-dev apt-utils
+RUN     apt-get update && apt-get -y install build-essential nasm autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc uuid-dev apt-utils
 
 ##################################################################################################################################
 ## Install Nvidia GPU(NVENC, NVDEC) build envrionment
 
 RUN  \
-        apt-get install -y --no-install-recommends \
+        apt-get update && apt-get install -y --no-install-recommends \
         gnupg2 curl ca-certificates && \
         curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
         echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \


### PR DESCRIPTION
Error when tried to update OME:
```
Get:133 http://archive.ubuntu.com/ubuntu bionic/universe amd64 tcl amd64 8.6.0+9 [5146 B]
Get:134 http://archive.ubuntu.com/ubuntu bionic/main amd64 zlib1g-dev amd64 1:1.2.11.dfsg-0ubuntu2 [176 kB]
Get:135 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 uuid-dev amd64 2.31.1-0.4ubuntu3.7 [33.2 kB]
Fetched 71.7 MB in 6s (12.9 MB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.9_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1-1ubuntu2.1~18.04.9_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.15.0-147.151_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cmake/cmake-data_3.10.2-1ubuntu2.18.04.1_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4_7.58.0-2ubuntu3.13_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cmake/cmake_3.10.2-1ubuntu2.18.04.1_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.58.0-2ubuntu3.13_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get -y install build-essential nasm autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc uuid-dev apt-utils' returned a non-zero code: 100
ERROR: Service 'ovenmediaengine' failed to build
```