### PR TITLE
Updated versions of OpenSSL, SRTP and SRT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ARG     PREFIX=/opt/ovenmediaengine
 ARG     MAKEFLAGS="-j16"
 
 ENV     OME_VERSION=master \
-        OPENSSL_VERSION=3.0.0-beta1 \
-        SRTP_VERSION=2.4.0 \
-        SRT_VERSION=1.4.2 \
+        OPENSSL_VERSION=3.0.1 \
+        SRTP_VERSION=2.4.2 \
+        SRT_VERSION=1.4.4 \
         OPUS_VERSION=1.1.3 \
         X264_VERSION=20190513-2245-stable \
         X265_VERSION=3.4 \
@@ -41,6 +41,7 @@ RUN \
 
 ## Build SRTP
 RUN \
+        ln -s ${PREFIX}/lib64 ${PREFIX}/lib && \
         DIR=/tmp/srtp && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \


### PR DESCRIPTION
Resolves some critical security / denial of service issues.
Starting with OPENSSL_VERSION 3.0.0-beta2, the output was written to `/opt/ovenmediaengine/lib64` instead of just `../lib`. The best temporary workaround I found so far was a symlink.