### PR TITLE
Added the sending of the closing of the stream on the webhooks.

### DIFF
--- a/docs/access-control/admission-webhooks.md
+++ b/docs/access-control/admission-webhooks.md
@@ -55,6 +55,7 @@ X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
   {
     "direction": "incoming | outgoing",
     "protocol": "webrtc | rtmp | srt | hls | dash | lldash",
+    "status": "opening | closing",
     "url": "scheme://host[:port]/app/stream/file?query=value&query2=value2",
     "time": ""2021-05-12T13:45:00.000Z"
   }
@@ -73,6 +74,7 @@ Here is a detailed explanation of each element of Json payload:
 | request |             | Information about the client's request                                                                      |
 |         | direction   | <p>incoming : A client requests to publish a stream</p><p>outgoing : A client requests to play a stream</p> |
 |         | protocol    | webrtc, srt, rtmp, hls, dash, lldash                                                                        |
+|         | status      | <p>opening : A client requests to open a stream</p><p>outgoing : A client closed the stream</p>             |
 |         | url         | url requested by the client                                                                                 |
 |         | time        | time requested by the client (ISO8601 format)                                                               |
 
@@ -93,7 +95,21 @@ As shown below, the trigger condition of request is different for each protocol.
 | DASH      | Every time a client requests a playlist                                                                                  |
 | LL-DASH   | Every time a client requests a playlist                                                                                  |
 
-## Response&#x20;
+## Response for closing status&#x20;
+
+The engine in the closing state does not need any parameter in response.
+To the query just answer with empty json object.
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 5
+Content-Type: application/json
+Connection: Closed
+{
+}
+```
+
+## Response for opening status&#x20;
 
 ### Format
 

--- a/src/projects/base/provider/provider.cpp
+++ b/src/projects/base/provider/provider.cpp
@@ -244,6 +244,16 @@ namespace pvd
 		return _access_controller->VerifyBySignedPolicy(request_url, client_address);
 	}
 
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	{
+		if(_access_controller == nullptr)
+		{
+			return {AccessController::VerificationResult::Error, nullptr};
+		}
+
+		return _access_controller->SendCloseWebhooks(request_url, client_address);
+	}
+
 	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
 	{
 		if(_access_controller == nullptr)

--- a/src/projects/base/provider/provider.h
+++ b/src/projects/base/provider/provider.h
@@ -38,6 +38,7 @@ namespace pvd
 
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
 	protected:

--- a/src/projects/base/publisher/publisher.cpp
+++ b/src/projects/base/publisher/publisher.cpp
@@ -270,6 +270,16 @@ namespace pub
 		return _access_controller->VerifyBySignedPolicy(request_url, client_address);
 	}
 
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	{
+		if(_access_controller == nullptr)
+		{
+			return {AccessController::VerificationResult::Error, nullptr};
+		}
+
+		return _access_controller->SendCloseWebhooks(request_url, client_address);
+	}
+
 	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
 	{
 		if(_access_controller == nullptr)

--- a/src/projects/base/publisher/publisher.h
+++ b/src/projects/base/publisher/publisher.h
@@ -141,6 +141,7 @@ namespace pub
 		// SignedPolicy is an official feature
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		// AdmissionWebhooks is an official feature
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		// SingedToken is used only special purposes
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedToken>> VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);

--- a/src/projects/modules/access_control/access_controller.h
+++ b/src/projects/modules/access_control/access_controller.h
@@ -33,6 +33,8 @@ public:
 
 	std::tuple<VerificationResult, std::shared_ptr<const SignedToken>> VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
+	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+
 	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 	
 private:

--- a/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
+++ b/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
@@ -19,16 +19,40 @@ public:
 		INTERNAL_ERROR,
 	};
 
+	class Status
+	{
+	public:
+		enum class Code : uint8_t
+		{
+			OPENING,
+			CLOSING
+		};
+
+		static inline ov::String Description(Code code)
+		{
+			return _description[static_cast<std::size_t>(code)];
+		}
+
+	private:
+		static inline const std::vector<ov::String> _description {
+			"opening",
+			"closing"
+		};
+	};
+
+
 	static std::shared_ptr<AdmissionWebhooks> Query(ProviderType provider,
 													const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 													const ov::String secret_key,
 													const std::shared_ptr<ov::SocketAddress> &client_address,
-													const std::shared_ptr<const ov::Url> &request_url);
+													const std::shared_ptr<const ov::Url> &request_url,
+													const Status::Code status = Status::Code::OPENING);
 	static std::shared_ptr<AdmissionWebhooks> Query(PublisherType publisher,
 													const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 													const ov::String secret_key,
 													const std::shared_ptr<ov::SocketAddress> &client_address,
-													const std::shared_ptr<const ov::Url> &request_url);
+													const std::shared_ptr<const ov::Url> &request_url,
+													const Status::Code status = Status::Code::OPENING);
 
 	ErrCode GetErrCode() const;
 	ov::String GetErrReason() const;
@@ -53,6 +77,7 @@ private:
 	PublisherType _publisher_type = PublisherType::Unknown;
 	std::shared_ptr<ov::SocketAddress> _client_address;
 	std::shared_ptr<const ov::Url> _requested_url;
+	Status::Code _status;
 
 	// Response
 	bool _allowed = false;

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -124,6 +124,17 @@ namespace pvd
 			return true;
 		}
 
+		// Send Close to Admission Webhooks
+		if (_url && _remote)
+		{
+			auto remote_address { _remote->GetRemoteAddress() };
+			if (remote_address)
+			{
+				GetProvider()->SendCloseAdmissionWebhooks(_url, remote_address);
+			}
+		}
+		// the return check is not necessary
+
 		if(_remote->GetState() == ov::SocketState::Connected)
 		{
 			_remote->Close();
@@ -227,13 +238,13 @@ namespace pvd
 				object_encoding = object->GetNumber(index);
 			}
 
-			// app 설정
+			// app name set
 			if ((index = object->FindName("app")) >= 0 && object->GetType(index) == AmfDataType::String)
 			{
 				_app_name = object->GetString(index);
 			}
 
-			// app 설정
+			// app url set
 			if ((index = object->FindName("tcUrl")) >= 0 && object->GetType(index) == AmfDataType::String)
 			{
 				_tc_url = object->GetString(index);

--- a/src/projects/providers/srt/srt_provider.cpp
+++ b/src/projects/providers/srt/srt_provider.cpp
@@ -237,6 +237,18 @@ namespace pvd
 			return;
 		}
 
+		// Send Close to Admission Webhooks
+		if (remote)
+		{
+			auto parsed_url = ov::Url::Parse(ov::Url::Decode(remote->GetStreamId()));
+			auto remote_address = remote->GetRemoteAddress();
+			if (parsed_url && remote_address)
+			{
+				SendCloseAdmissionWebhooks(parsed_url, remote_address);
+			}
+		}
+		// the return check is not necessary
+
 		logti("The SRT client has disconnected: [%s/%s], remote: %s", channel->GetApplicationName(), channel->GetName().CStr(), remote->ToString().CStr());
 
 		PushProvider::OnChannelDeleted(remote->GetNativeHandle());

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -471,6 +471,15 @@ namespace pvd
 					const std::shared_ptr<const SessionDescription> &peer_sdp)
 	{
 		logti("Stop command received : %s/%s/%u", vhost_app_name.CStr(), stream_name.CStr(), offer_sdp->GetSessionId());
+
+		// Send Close to Admission Webhooks
+		auto parsed_url { ov::Url::Parse(ws_client->GetClient()->GetRequest()->GetUri()) };
+		auto remote_address { ws_client->GetClient()->GetRequest()->GetRemote()->GetRemoteAddress() };
+		if (parsed_url && remote_address)
+		{
+			SendCloseAdmissionWebhooks(parsed_url, remote_address);
+		}
+		// the return check is not necessary
 		
 		// Find Stream
 		auto stream = std::static_pointer_cast<WebRTCStream>(GetStreamByName(vhost_app_name, stream_name));

--- a/src/projects/publishers/segment/cmaf/cmaf_application.cpp
+++ b/src/projects/publishers/segment/cmaf/cmaf_application.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<pub::Stream> CmafApplication::CreateStream(const std::shared_ptr
 				_utc_timing_scheme, _utc_timing_value,
 				video_track, audio_track,
 				_chunked_transfer);
-		});
+		}, _segment_duration);
 }
 
 bool CmafApplication::DeleteStream(const std::shared_ptr<info::Stream> &info)

--- a/src/projects/publishers/segment/dash/dash_application.cpp
+++ b/src/projects/publishers/segment/dash/dash_application.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<pub::Stream> DashApplication::CreateStream(const std::shared_ptr
 				_utc_timing_scheme, _utc_timing_value,
 				video_track, audio_track,
 				nullptr);
-		});
+		}, _segment_duration);
 }
 
 bool DashApplication::DeleteStream(const std::shared_ptr<info::Stream> &info)

--- a/src/projects/publishers/segment/hls/hls_application.cpp
+++ b/src/projects/publishers/segment/hls/hls_application.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<pub::Stream> HlsApplication::CreateStream(const std::shared_ptr<
 				_segment_count, _segment_duration,
 				video_track, audio_track,
 				nullptr);
-		});
+		}, _segment_duration);
 }
 
 bool HlsApplication::DeleteStream(const std::shared_ptr<info::Stream> &info)

--- a/src/projects/publishers/segment/segment_stream/segment_stream.cpp
+++ b/src/projects/publishers/segment/segment_stream/segment_stream.cpp
@@ -14,13 +14,12 @@
 #include "packetizer/packetizer.h"
 #include "segment_stream_private.h"
 
-SegmentStream::SegmentStream(
-	const std::shared_ptr<pub::Application> application,
-	const info::Stream &info,
-	PacketizerFactory packetizer_factory)
-	: Stream(application, info),
+SegmentStream::SegmentStream(const std::shared_ptr<pub::Application> application, const info::Stream &info,
+							 PacketizerFactory packetizer_factory, int segment_duration)
+	: Stream(application, info)
+	, _packetizer_factory(packetizer_factory)
+	, _segment_duration(segment_duration)
 
-	  _packetizer_factory(packetizer_factory)
 {
 	OV_ASSERT2(_packetizer_factory != nullptr);
 }

--- a/src/projects/publishers/segment/segment_stream/segment_stream.h
+++ b/src/projects/publishers/segment/segment_stream/segment_stream.h
@@ -24,13 +24,15 @@ public:
 	SegmentStream(
 		const std::shared_ptr<pub::Application> application,
 		const info::Stream &info,
-		PacketizerFactory packetizer_factory);
+		PacketizerFactory packetizer_factory,
+		int segment_duration);
 
 	static std::shared_ptr<SegmentStream> Create(const std::shared_ptr<pub::Application> &application,
 												 const info::Stream &info,
-												 PacketizerFactory packetizer_factory)
+												 PacketizerFactory packetizer_factory,
+												 int segment_duration)
 	{
-		return std::make_shared<SegmentStream>(application, info, packetizer_factory);
+		return std::make_shared<SegmentStream>(application, info, packetizer_factory, segment_duration);
 	}
 
 	bool GetPlayList(ov::String &play_list);
@@ -47,6 +49,7 @@ public:
 
 	void SendVideoFrame(const std::shared_ptr<MediaPacket> &media_packet) override;
 	void SendAudioFrame(const std::shared_ptr<MediaPacket> &media_packet) override;
+	int GetSegmentDuration() { return _segment_duration; }
 
 protected:
 	virtual bool CheckCodec(cmn::MediaType type, cmn::MediaCodecId codec_id);
@@ -59,4 +62,6 @@ protected:
 	std::shared_ptr<MediaTrack> _audio_track;
 
 	int _last_msid = 0;
+	int _segment_duration;
+
 };


### PR DESCRIPTION
Added a 'status' parameter to the webhooks request, this allows you to send the status of the stream: "opening" or "closing".
In this PR the sending of the streams closure has been implemented.
Opening example:
```
{                                                                                                                                                                                                                                     
  "client": {                                                                                                                                                                                                                         
    "address": "192.168.122.1",                                                                                                                                                                                                       
    "port": 44032                                                                                                                                                                                                                     
  },                                                                                                                                                                                                                                  
  "request": {                                                                                                                                                                                                                        
    "direction": "incoming",                                                                                                                                                                                                          
    "protocol": "WebRTC",                                                                                                                                                                                                             
    "status": "opening",                                                                                                                                                                                                              
    "time": "2022-02-22T11:12:03.037+01:00",                                                                                                                                                                                          
    "url": "wss://desktop-origin.local:3334/app/stream-00?direction=send&transport=tcp"                                                                                                                                               
  }                                                                                                                                                                                                                                   
}    
```
Closing example: 
```
{
  "client": {
    "address": "192.168.122.1",
    "port": 44032
  },
  "request": {
    "direction": "incoming",
    "protocol": "WebRTC",
    "status": "closing",
    "time": "2022-02-22T11:12:08.065+01:00",
    "url": "wss://desktop-origin.local:3334/app/stream-00?direction=send&transport=tcp"
  }
}
```
To the query just answer with empty json object:
```
{
}
```
Thanks in advance.