### PR TITLE
fix decoder name

### DIFF
--- a/src/projects/transcoder/codec/decoder/decoder_hevc_nv.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_hevc_nv.cpp
@@ -20,7 +20,7 @@ bool DecoderHEVCxNV::Configure(std::shared_ptr<TranscodeContext> context)
 		return false;
 	}
 
-	AVCodec *_codec = ::avcodec_find_decoder_by_name("hevc_nvdec");
+	AVCodec *_codec = ::avcodec_find_decoder_by_name("hevc_cuvid");
 	if (_codec == nullptr)
 	{
 		logte("Codec not found: %s (%d)", ::avcodec_get_name(GetCodecID()), GetCodecID());


### PR DESCRIPTION
This uses the correct decoder name for hevc on nvidia hardware which allows hardware decoding to work.