### PR TITLE
Little bug in debug mode

### DIFF
--- a/src/projects/main/init_utilities.h
+++ b/src/projects/main/init_utilities.h
@@ -26,9 +26,13 @@
 			{                                                        \
 				if (orchestrator->RegisterModule(variable) == false) \
 				{                                                    \
-					logte("Failed to register" name);                \
+					logte("Failed to register " name);               \
 					succeeded = false;                               \
 				}                                                    \
+			}                                                        \
+			else                                                     \
+			{                                                        \
+				variable.reset();                                    \
 			}                                                        \
 		}                                                            \
 	}
@@ -44,7 +48,7 @@
 		}                                                      \
 		else                                                   \
 		{                                                      \
-			logte("Failed to unregister" name);                \
+			logte("Failed to unregister " name);                \
 		}                                                      \
 	}
 

--- a/src/projects/main/main.cpp
+++ b/src/projects/main/main.cpp
@@ -180,6 +180,7 @@ int main(int argc, char *argv[])
 	RELEASE_MODULE(lldash_publisher, "Low-Latency MPEG-DASH Publisher");
 	RELEASE_MODULE(ovt_publisher, "OVT Publisher");
 	RELEASE_MODULE(file_publisher, "File Publisher");
+	RELEASE_MODULE(mpegtspush_publisher, "MpegtsPush Publisher");
 	RELEASE_MODULE(rtmppush_publisher, "RtmpPush Publisher");
 	RELEASE_MODULE(thumbnail_publisher, "Thumbnail Publisher");
 

--- a/src/projects/providers/file/file_stream.cpp
+++ b/src/projects/providers/file/file_stream.cpp
@@ -334,7 +334,10 @@ namespace pvd
 			return ProcessMediaResult::PROCESS_MEDIA_FAILURE;
 		}
 
-		AVPacket packet = {.data = NULL, .size = 0};
+//		AVPacket packet = {.data = NULL, .size = 0};
+		AVPacket packet;
+		packet.data = NULL;
+		packet.size = 0;
 
 		while (true)
 		{


### PR DESCRIPTION
The first commit fixes a build problem on C++17.

```
[2/5| 40%] [static] libfile_provider.a: C++ projects/providers/file/file_stream.cpp => intermediates/DEBUG/objs/providers/file/file_stream.o
projects/providers/file/file_stream.cpp: In member function ‘virtual pvd::PullStream::ProcessMediaResult pvd::FileStream::ProcessMediaPacket()’:
projects/providers/file/file_stream.cpp:337:45: sorry, unimplemented: non-trivial designated initializers not supported
   AVPacket packet = {.data = NULL, .size = 0};
                                             ^
compilation terminated due to -Wfatal-errors.
```

The second solves the problem of releasing a module that is not in configuration (crash, only debug).

```
[05-12 11:40:30.375] E [OvenMediaEngine:1000] Assertion | orchestrator.cpp:430  | Assertion failed: projects/orchestrator/orchestrator.cpp:430
	Expression: false
	Stack trace:
#0   /develop/OvenMediaEngine/src/bin/DEBUG/OvenMediaEngine 0x55555645c9d7 ocst::Orchestrator::UnregisterModule(std::shared_ptr<ocst::ModuleInterface> const&) + 0x2cf
#1   /develop/OvenMediaEngine/src/bin/DEBUG/OvenMediaEngine 0x555555fb27a2 main + 0x2e2e
#2   /lib/x86_64-linux-gnu/libc.so.6     0x7ffff42a9c87 __libc_start_main + 0xe7
#3   /develop/OvenMediaEngine/src/bin/DEBUG/OvenMediaEngine 0x555555f2ad8a _start + 0x2a
```

Many thanks in advance.