### PR TITLE
Make more video options usable from xml

### DIFF
--- a/src/projects/base/info/video_track.cpp
+++ b/src/projects/base/info/video_track.cpp
@@ -18,6 +18,8 @@ VideoTrack::VideoTrack()
 	  _b_frames(0),
 	  _has_bframe(false),
 	  _preset(""),
+	  _profile(""),
+	  _tune(""),
 	  _thread_count(0)
 
 {
@@ -117,6 +119,26 @@ void VideoTrack::SetPreset(ov::String preset)
 ov::String VideoTrack::GetPreset() const
 {
 	return _preset;
+}
+
+void VideoTrack::SetProfile(ov::String profile)
+{
+	_profile = profile;
+}
+
+ov::String VideoTrack::GetProfile() const
+{
+	return _profile;
+}
+
+void VideoTrack::SetTune(ov::String tune)
+{
+	_tune = tune;
+}
+
+ov::String VideoTrack::GetTune() const
+{
+	return _tune;
 }
 
 void VideoTrack::SetHasBframes(bool has_bframe)

--- a/src/projects/base/info/video_track.h
+++ b/src/projects/base/info/video_track.h
@@ -45,6 +45,10 @@ public:
 	//@Set by Configuration
 	void SetPreset(ov::String preset);
 	ov::String GetPreset() const;
+	void SetProfile(ov::String profile);
+	ov::String GetProfile() const;
+	void SetTune(ov::String tune);
+	ov::String GetTune() const;
 
 	//@Set by mediarouter
 	void SetHasBframes(bool has_bframe);
@@ -73,6 +77,8 @@ protected:
 	bool _has_bframe;
 
 	ov::String _preset;
+	ov::String _profile;
+	ov::String _tune;
 	std::shared_ptr<ov::Data> _h264_sps_pps_annexb_data = nullptr;
 	std::shared_ptr<ov::Data> _h264_sps_data = nullptr;
 	std::shared_ptr<ov::Data> _h264_pps_data = nullptr;

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/video_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/video_profile.h
@@ -30,6 +30,8 @@ namespace cfg
 					ov::String _bitrate_string;
 					double _framerate = 0.0;
 					ov::String _preset;
+					ov::String _profile;
+					ov::String _tune;
 					int _thread_count = -1;
 					int _key_frame_interval = 0;
 					int _b_frames = 0;
@@ -46,6 +48,8 @@ namespace cfg
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetBitrateString, _bitrate_string)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetFramerate, _framerate)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetPreset, _preset)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetProfile, _profile)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetTune, _tune)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetThreadCount, _thread_count)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetKeyFrameInterval, _key_frame_interval)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetBFrames, _b_frames)
@@ -61,6 +65,8 @@ namespace cfg
 					void SetBitrateString(const ov::String &bitrate_string){_bitrate_string = bitrate_string;}
 					void SetFramerate(double framerate){_framerate = framerate;}
 					void SetPreset(const ov::String &preset){_preset = preset;}
+					void SetProfile(const ov::String &profile){_profile = profile;}
+					void SetTune(const ov::String &tune){_tune = tune;}
 					void SetThreadCount(int thread_count){_thread_count = thread_count;}
 					void SetKeyFrameInterval(int key_frame_interval){_key_frame_interval = key_frame_interval;}
 					void SetBFrames(int b_frames){_b_frames = b_frames;}
@@ -101,6 +107,8 @@ namespace cfg
 						Register<Optional>("Height", &_height);
 						Register<Optional>("Framerate", &_framerate);
 						Register<Optional>("Preset", &_preset);
+						Register<Optional>("Profile", &_profile);
+						Register<Optional>("Tune", &_tune);
 						Register<Optional>("ThreadCount", &_thread_count);
 						Register<Optional>("KeyFrameInterval", &_key_frame_interval, [=]() -> std::shared_ptr<ConfigError> {
 								return (_key_frame_interval >= 0 && _key_frame_interval <= 600) ? nullptr : CreateConfigErrorPtr("KeyFrameInterval must be between 0 and 600");

--- a/src/projects/transcoder/codec/encoder/encoder_avc_nv.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_nv.cpp
@@ -59,9 +59,53 @@ bool EncoderAVCxNV::SetCodecParams()
 		// Default
 		::av_opt_set(_codec_context->priv_data, "preset", "p7", 0);
 	}
-	
-	::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
-	::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+
+	// Tune
+	if (GetRefTrack()->GetTune() == "hq")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "hq", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "ll")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "ll", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "ull")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "lossless")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "lossless", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
+	}
+
+	// Profile
+	if (GetRefTrack()->GetProfile() == "baseline")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "main")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "high")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "high", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "high444p")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "high444p", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	}
+
 	::av_opt_set(_codec_context->priv_data, "rc", "cbr", 0);
 
 	return true;

--- a/src/projects/transcoder/codec/encoder/encoder_avc_openh264.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_openh264.cpp
@@ -41,8 +41,25 @@ bool EncoderAVCxOpenH264::SetCodecParams()
 	::av_opt_set(_codec_context->priv_data, "rc_mode", "bitrate", 0);
 	::av_opt_set(_codec_context->priv_data, "allow_skip_frames", "false", 0);
 
-	// - B-frame must be disabled. because, WEBRTC does not support B-Frame.
-	::av_opt_set(_codec_context->priv_data, "profile", "constrained_baseline", 0);
+	
+	// Profile
+	if (GetRefTrack()->GetProfile() == "constrained_baseline")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "constrained_baseline", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "main")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "high")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "high", 0);
+	}
+	else
+	{
+		// Default - B-frame must be disabled. because, WEBRTC does not support B-Frame.
+		::av_opt_set(_codec_context->priv_data, "profile", "constrained_baseline", 0);
+	}
 	::av_opt_set(_codec_context->priv_data, "coder", "default", 0);
 
 	if (GetRefTrack()->GetPreset() == "slower" || GetRefTrack()->GetPreset() == "slow")

--- a/src/projects/transcoder/codec/encoder/encoder_avc_qsv.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_qsv.cpp
@@ -34,7 +34,24 @@ bool EncoderAVCxQSV::SetCodecParams()
 	_codec_context->height = GetRefTrack()->GetHeight();
 	_codec_context->gop_size = (GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec_context->framerate.num / _codec_context->framerate.den) : GetRefTrack()->GetKeyFrameInterval();
 
-	::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	// Profile
+	if (GetRefTrack()->GetProfile() == "baseline")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "main")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "high")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "high", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	}
 
 	return true;
 }

--- a/src/projects/transcoder/codec/encoder/encoder_hevc_nv.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_hevc_nv.cpp
@@ -57,8 +57,49 @@ bool EncoderHEVCxNV::SetCodecParams()
 		// Default
 		::av_opt_set(_codec_context->priv_data, "preset", "p7", 0);
 	}
-	
-	::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
+
+	// Tune
+	if (GetRefTrack()->GetTune() == "hq")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "hq", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "ll")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "ll", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "ull")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
+	}
+	else if (GetRefTrack()->GetTune() == "lossless")
+	{
+		::av_opt_set(_codec_context->priv_data, "tune", "lossless", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "tune", "ull", 0);
+	}
+
+	// Profile
+	if (GetRefTrack()->GetProfile() == "main")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "main10")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main10", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "rext")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "rext", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+
 	::av_opt_set(_codec_context->priv_data, "rc", "cbr", 0);
 
 	return true;

--- a/src/projects/transcoder/codec/encoder/encoder_hevc_qsv.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_hevc_qsv.cpp
@@ -32,6 +32,29 @@ bool EncoderHEVCxQSV::SetCodecParams()
 	_codec_context->height = GetRefTrack()->GetHeight();
 	_codec_context->gop_size = (GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec_context->framerate.num / _codec_context->framerate.den) : GetRefTrack()->GetKeyFrameInterval();
 
+	// Profile
+	if (GetRefTrack()->GetProfile() == "main")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "main10")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "main10", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "mainsp")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "mainsp", 0);
+	}
+	else if (GetRefTrack()->GetProfile() == "rext")
+	{
+		::av_opt_set(_codec_context->priv_data, "profile", "rext", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "profile", "main", 0);
+	}
+
 	return true;
 }
 

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -386,6 +386,8 @@ std::shared_ptr<MediaTrack> TranscoderStream::CreateOutputTrack(const std::share
 		output_track->SetFrameRate(profile.GetFramerate());
 		output_track->SetTimeBase(GetDefaultTimebaseByCodecId(output_track->GetCodecId()));
 		output_track->SetPreset(profile.GetPreset());
+		output_track->SetProfile(profile.GetProfile());
+		output_track->SetTune(profile.GetTune());
 		output_track->SetThreadCount(profile.GetThreadCount());
 		output_track->SetKeyFrameInterval(profile.GetKeyFrameInterval());
 		output_track->SetBFrames(profile.GetBFrames());


### PR DESCRIPTION
The purpose of this PR is to allow the use of Profile and Tune XML tags to define encoding settings.  For example:
```
<OutputProfile>
	<Name>1080p60</Name>
	<OutputStreamName>${OriginStreamName}_1080p60</OutputStreamName>
	<Encodes>
		<Video>
			<Codec>h264</Codec>
			<Bitrate>6000000</Bitrate>
			<Framerate>60</Framerate>
			<Width>1920</Width>
			<Height>1080</Height>
			<Preset>slower</Preset>
			<Profile>high</Profile>
			<Tune>hq</Tune>
		</Video>
		<Audio>
			<Codec>aac</Codec>
			<Bitrate>320000</Bitrate>
			<Samplerate>48000</Samplerate>
			<Channel>2</Channel>
		</Audio>
	</Encodes>
</OutputProfile>
```
  I know that it says in many places that WebRTC does not support b-frames, but what if the stream will not be used with WebRTC?  My inspiration was noticing lower quality output when push publishing to twitch.