### PR TITLE
Tip before run manual installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ OvenMediaEngine-master/misc/prerequisites.sh
 ```
 
 {% hint style="info" %}
-If the prerequisites.sh script fails, proceed with the [manual installation](troubleshooting.md#prerequisites-sh-script-failed).
+If the prerequisites.sh script fails, try to run `sudo apt-get update` and rerun it. If it's not enough proceed with the [manual installation](troubleshooting.md#prerequisites-sh-script-failed).
 {% endhint %}
 
 ### \*\*\*\*


### PR DESCRIPTION
On Google Cloud VM with Ubuntu18+, without running at the first start `sudo apt-get update` the prerequisites.sh run fails.  So I've added an hint to try run it before going on with manual installation.