### PR TITLE
Typo (add_hitory -> add_history)

### DIFF
--- a/src/projects/modules/dump/dump.cpp
+++ b/src/projects/modules/dump/dump.cpp
@@ -113,7 +113,7 @@ namespace mdl
 		return true;
 	}
 
-	bool Dump::DumpToFile(const ov::String &path, const ov::String &file_name, const std::shared_ptr<const ov::Data> &data, bool add_hitory)
+	bool Dump::DumpToFile(const ov::String &path, const ov::String &file_name, const std::shared_ptr<const ov::Data> &data, bool add_history)
 	{
 		try
 		{
@@ -131,7 +131,7 @@ namespace mdl
 			return false;
 		}
 
-		if (add_hitory == true)
+		if (add_history == true)
 		{
 			_dump_history_map.emplace_back(file_path_name);
 		}

--- a/src/projects/modules/dump/dump.h
+++ b/src/projects/modules/dump/dump.h
@@ -37,7 +37,7 @@ namespace mdl
 		}
 
 	private:
-		bool DumpToFile(const ov::String &path, const ov::String &file_name, const std::shared_ptr<const ov::Data> &data, bool add_hitory=true);
+		bool DumpToFile(const ov::String &path, const ov::String &file_name, const std::shared_ptr<const ov::Data> &data, bool add_history = true);
 		bool MakeDumpInfo(ov::String &dump_info);
 
 		struct DumpHistory
@@ -57,4 +57,4 @@ namespace mdl
 
 		std::map<int32_t, uint32_t> _extra_datas;
 	};
-}
+}  // namespace mdl


### PR DESCRIPTION
Reading dump.cpp and dump.h files, I've found `add_hitory` param. I suppose is add_hi**s**tory. 
Close and ignore this PR if add_hitory was correct and I'm wrong