### PR TITLE
Add ability to disable custom library paths at build

### DIFF
--- a/src/core/config.mk
+++ b/src/core/config.mk
@@ -32,8 +32,10 @@ CONFIG_C_HEADER_EXTENSION := .h
 CONFIG_CXX_EXTENSION := .cpp
 CONFIG_CXX_HEADER_EXTENSION := .h
 
-CONFIG_LIBRARY_PATHS := /opt/ovenmediaengine/lib:/opt/ovenmediaengine/lib64
-CONFIG_PKG_PATHS := /opt/ovenmediaengine/lib/pkgconfig:/opt/ovenmediaengine/lib64/pkgconfig
+ifneq ($(DISABLE_CUSTOM_LIBRARY_PATHS),true)
+    CONFIG_LIBRARY_PATHS := /opt/ovenmediaengine/lib:/opt/ovenmediaengine/lib64
+    CONFIG_PKG_PATHS := /opt/ovenmediaengine/lib/pkgconfig:/opt/ovenmediaengine/lib64/pkgconfig
+endif
 
 ifeq (${OS_VERSION},darwin)
     CONFIG_CORE_COUNT := $(shell sysctl -n hw.ncpu)


### PR DESCRIPTION
When one builds OME against shared system libraries they might not use `/opt/ovenmediaengine/lib` at all. In that case not disabling it completly can be a security risk.