### PR TITLE
Change docker-compose version to add support for Ubuntu 20.04's default docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.6'
 
 services:
   origin:


### PR DESCRIPTION
Changed docker-compose version to add support for Ubuntu 20.04's default docker-compose.

This docker-compose file doesn't make use of any docker-compose 3.7 features, thus setting it to 3.6 doesn't have any disadvantages, but increases range of supported docker-compose versions.