### PR TITLE
Fix GPU Hardware Acceleration not working as expected

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - OME_SIGNALLING_PORT=3333
     - OME_TCP_RELAY_ADDRESS=*:3478
     - OME_ICE_CANDIDATES=*:10006-10010/udp
-    bind:
+    devices:
     # Temporary hack to forward /dev/dri/renderD128
     # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/235
     - /dev/dri:/dev/dri
@@ -39,7 +39,7 @@ services:
     - "3479:3479/tcp"
     - "8090:8090/tcp"
     - "10000-10005:10000-10005/udp"
-    bind:
+    devices:
     # Temporary hack to forward /dev/dri/renderD128
     # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/235
     - /dev/dri:/dev/dri

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
     - OME_SIGNALLING_PORT=3333
     - OME_TCP_RELAY_ADDRESS=*:3478
     - OME_ICE_CANDIDATES=*:10006-10010/udp
+    bind:
+    # Temporary hack to forward /dev/dri/renderD128
+    # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/235
+    - /dev/dri:/dev/dri
     command: /opt/ovenmediaengine/bin/OvenMediaEngine -c origin_conf
 
   edge:
@@ -35,6 +39,10 @@ services:
     - "3479:3479/tcp"
     - "8090:8090/tcp"
     - "10000-10005:10000-10005/udp"
+    bind:
+    # Temporary hack to forward /dev/dri/renderD128
+    # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/235
+    - /dev/dri:/dev/dri
     environment:
     - DEFAULT_ORIGIN_SERVER=192.168.0.160
     - OME_HLS_STREAM_PORT=8090

--- a/src/projects/transcoder/transcoder_gpu.cpp
+++ b/src/projects/transcoder/transcoder_gpu.cpp
@@ -26,7 +26,7 @@ bool TranscodeGPU::Initialze()
 
 	logtd("Trying to initialize a hardware accelerator");
 
-	int ret = ::av_hwdevice_ctx_create(&_device_context, AV_HWDEVICE_TYPE_QSV, "/dev/dri/render128", NULL, 0);
+	int ret = ::av_hwdevice_ctx_create(&_device_context, AV_HWDEVICE_TYPE_QSV, "/dev/dri/renderD128", NULL, 0);
 	if (ret < 0)
 	{
 		av_buffer_unref(&_device_context);
@@ -46,7 +46,7 @@ bool TranscodeGPU::Initialze()
 		return true;
 	}
 
-	ret = ::av_hwdevice_ctx_create(&_device_context, AV_HWDEVICE_TYPE_CUDA, "/dev/dri/render128", NULL, 0);
+	ret = ::av_hwdevice_ctx_create(&_device_context, AV_HWDEVICE_TYPE_CUDA, "/dev/dri/renderD128", NULL, 0);
 	if (ret < 0)
 	{
 		av_buffer_unref(&_device_context);


### PR DESCRIPTION
Currently, Validation Logic for GPU Availability in Oven Media Engine utilizes Linux DRM device nodes.
This PR resolves an issue on GPU Availability check always failing due to typo in DRM Path `render128` ➡️ `renderD128`.
Also This PR updates docker-compose.yml to forward `/dev/dri` inside container manually due to [container-toolkit!235](https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/merge_requests/235) not being merged yet.

