### PR TITLE
Update install_nvidia_driver.sh for Ubuntu Server

### DIFF
--- a/misc/install_nvidia_driver.sh
+++ b/misc/install_nvidia_driver.sh
@@ -70,6 +70,7 @@ install_base_ubuntu()
         # Install Nvidia Driver and Nvidia Toolkit
         sudo add-apt-repository ppa:graphics-drivers/ppa
         sudo apt -y update
+        sudo apt-get install -y ubuntu-drivers-common
         sudo apt-get install -y $(ubuntu-drivers devices | grep recommended | awk '{print $3}')
         sudo apt-get install -y nvidia-cuda-toolkit curl make
         


### PR DESCRIPTION
```ubuntu-drivers``` command is not available on Ubuntu Server because the ```ubuntu-drivers-common``` package is not installed by default.

This commit resolves this issue by installing the ```ubuntu-drivers-common``` package.