### PR TITLE
AdmissionWebhooks - Add client's user-agent information

### DIFF
--- a/src/projects/base/provider/provider.cpp
+++ b/src/projects/base/provider/provider.cpp
@@ -254,13 +254,13 @@ namespace pvd
 		return _access_controller->SendCloseWebhooks(request_url, client_address);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->VerifyByWebhooks(request_url, client_address);
+		return _access_controller->VerifyByWebhooks(request_url, client_address, user_agent);
 	}
 }

--- a/src/projects/base/provider/provider.cpp
+++ b/src/projects/base/provider/provider.cpp
@@ -244,23 +244,23 @@ namespace pvd
 		return _access_controller->VerifyBySignedPolicy(request_url, client_address);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::SendCloseAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->SendCloseWebhooks(request_url, client_address);
+		return _access_controller->SendCloseWebhooks(request_info);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Provider::VerifyByAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->VerifyByWebhooks(request_url, client_address, user_agent);
+		return _access_controller->VerifyByWebhooks(request_info);
 	}
 }

--- a/src/projects/base/provider/provider.h
+++ b/src/projects/base/provider/provider.h
@@ -38,8 +38,8 @@ namespace pvd
 
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info);
 
 	protected:
 		Provider(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router);

--- a/src/projects/base/provider/provider.h
+++ b/src/projects/base/provider/provider.h
@@ -39,7 +39,7 @@ namespace pvd
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
 
 	protected:
 		Provider(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router);

--- a/src/projects/base/publisher/publisher.cpp
+++ b/src/projects/base/publisher/publisher.cpp
@@ -286,24 +286,24 @@ namespace pub
 		return _access_controller->VerifyBySignedPolicy(request_url, client_address);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::SendCloseAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->SendCloseWebhooks(request_url, client_address);
+		return _access_controller->SendCloseWebhooks(request_info);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::VerifyByAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->VerifyByWebhooks(request_url, client_address, user_agent);
+		return _access_controller->VerifyByWebhooks(request_info);
 	}
 
 	std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedToken>>  Publisher::VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)

--- a/src/projects/base/publisher/publisher.cpp
+++ b/src/projects/base/publisher/publisher.cpp
@@ -296,14 +296,14 @@ namespace pub
 		return _access_controller->SendCloseWebhooks(request_url, client_address);
 	}
 
-	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+	std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> Publisher::VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
 	{
 		if(_access_controller == nullptr)
 		{
 			return {AccessController::VerificationResult::Error, nullptr};
 		}
 
-		return _access_controller->VerifyByWebhooks(request_url, client_address);
+		return _access_controller->VerifyByWebhooks(request_url, client_address, user_agent);
 	}
 
 	std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedToken>>  Publisher::VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)

--- a/src/projects/base/publisher/publisher.h
+++ b/src/projects/base/publisher/publisher.h
@@ -143,8 +143,8 @@ namespace pub
 		// SignedPolicy is an official feature
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		// AdmissionWebhooks is an official feature
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const AccessController::RequestInfo> &request_info);
 		// SingedToken is used only special purposes
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedToken>> VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 

--- a/src/projects/base/publisher/publisher.h
+++ b/src/projects/base/publisher/publisher.h
@@ -144,7 +144,7 @@ namespace pub
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedPolicy>> VerifyBySignedPolicy(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 		// AdmissionWebhooks is an official feature
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
-		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+		std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByAdmissionWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
 		// SingedToken is used only special purposes
 		std::tuple<AccessController::VerificationResult, std::shared_ptr<const SignedToken>> VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 

--- a/src/projects/modules/access_control/access_controller.cpp
+++ b/src/projects/modules/access_control/access_controller.cpp
@@ -71,12 +71,12 @@ std::tuple<AccessController::VerificationResult, std::shared_ptr<const Admission
 		if(_provider_type != ProviderType::Unknown)
 		{
 			admission_webhooks = AdmissionWebhooks::Query(
-				_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url, AdmissionWebhooks::Status::Code::CLOSING);
+				_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url);
 		}
 		else if(_publisher_type != PublisherType::Unknown)
 		{
 			admission_webhooks = AdmissionWebhooks::Query(
-				_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url, AdmissionWebhooks::Status::Code::CLOSING);
+				_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url, nullptr, AdmissionWebhooks::Status::Code::CLOSING);
 		}
 		else
 		{
@@ -108,7 +108,7 @@ std::tuple<AccessController::VerificationResult, std::shared_ptr<const Admission
 	return {AccessController::VerificationResult::Error, nullptr};
 }
 
-std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> AccessController::VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address)
+std::tuple<AccessController::VerificationResult, std::shared_ptr<const AdmissionWebhooks>> AccessController::VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
 {
 	auto orchestrator = ocst::Orchestrator::GetInstance();
 	auto vhost_name = orchestrator->GetVhostNameFromDomain(request_url->Host());
@@ -161,11 +161,11 @@ std::tuple<AccessController::VerificationResult, std::shared_ptr<const Admission
 		std::shared_ptr<AdmissionWebhooks> admission_webhooks;
 		if(_provider_type != ProviderType::Unknown)
 		{
-			admission_webhooks = AdmissionWebhooks::Query(_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url);
+			admission_webhooks = AdmissionWebhooks::Query(_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url, user_agent);
 		}
 		else if(_publisher_type != PublisherType::Unknown)
 		{
-			admission_webhooks = AdmissionWebhooks::Query(_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url);
+			admission_webhooks = AdmissionWebhooks::Query(_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url, user_agent);
 		}
 		else
 		{

--- a/src/projects/modules/access_control/access_controller.cpp
+++ b/src/projects/modules/access_control/access_controller.cpp
@@ -71,12 +71,12 @@ std::tuple<AccessController::VerificationResult, std::shared_ptr<const Admission
 		if(_provider_type != ProviderType::Unknown)
 		{
 			admission_webhooks = AdmissionWebhooks::Query(
-				_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url);
+				_provider_type, control_server_url, timeout_msec, secret_key, client_address, request_url, "", AdmissionWebhooks::Status::Code::CLOSING);
 		}
 		else if(_publisher_type != PublisherType::Unknown)
 		{
 			admission_webhooks = AdmissionWebhooks::Query(
-				_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url, nullptr, AdmissionWebhooks::Status::Code::CLOSING);
+				_publisher_type, control_server_url, timeout_msec, secret_key, client_address, request_url, "", AdmissionWebhooks::Status::Code::CLOSING);
 		}
 		else
 		{

--- a/src/projects/modules/access_control/access_controller.h
+++ b/src/projects/modules/access_control/access_controller.h
@@ -26,6 +26,22 @@ public:
 		Pass = 1		// Check signature and pass
 	};
 
+	class RequestInfo
+	{
+	public:
+		RequestInfo(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+		RequestInfo(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
+
+		std::shared_ptr<const ov::Url> GetRequestUrl() const;
+		std::shared_ptr<ov::SocketAddress> GetClientAddress() const;
+		const ov::String &GetUserAgent() const;
+
+	private:
+		const std::shared_ptr<const ov::Url> _request_url;
+		const std::shared_ptr<ov::SocketAddress> _client_address;
+		const ov::String _user_agent;
+	};
+
 	AccessController(ProviderType provider_type, const cfg::Server &server_config);
 	AccessController(PublisherType publisher_type, const cfg::Server &server_config);
 
@@ -33,9 +49,9 @@ public:
 
 	std::tuple<VerificationResult, std::shared_ptr<const SignedToken>> VerifyBySignedToken(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
-	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseWebhooks(const std::shared_ptr<const RequestInfo> &request_info);
 
-	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
+	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByWebhooks(const std::shared_ptr<const RequestInfo> &request_info);
 	
 private:
 	const ProviderType _provider_type;

--- a/src/projects/modules/access_control/access_controller.h
+++ b/src/projects/modules/access_control/access_controller.h
@@ -35,7 +35,7 @@ public:
 
 	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> SendCloseWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
 
-	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address);
+	std::tuple<VerificationResult, std::shared_ptr<const AdmissionWebhooks>> VerifyByWebhooks(const std::shared_ptr<const ov::Url> &request_url, const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
 	
 private:
 	const ProviderType _provider_type;

--- a/src/projects/modules/access_control/admission_webhooks/admission_webhooks.cpp
+++ b/src/projects/modules/access_control/admission_webhooks/admission_webhooks.cpp
@@ -5,9 +5,8 @@
 std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(ProviderType provider,
 															const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 															const ov::String secret_key,
-															const std::shared_ptr<ov::SocketAddress> &client_address,
 															const std::shared_ptr<const ov::Url> &request_url,
-															const ov::String &user_agent,
+															const std::shared_ptr<const ClientInfo> &client_info,
 															const Status::Code status)
 {
 	auto hooks = std::make_shared<AdmissionWebhooks>();
@@ -16,9 +15,8 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(ProviderType provide
 	hooks->_control_server_url = control_server_url;
 	hooks->_timeout_msec = timeout_msec;
 	hooks->_secret_key = secret_key;
-	hooks->_client_address = client_address;
 	hooks->_requested_url = request_url;
-	hooks->_user_agent = user_agent;
+	hooks->_client_info = client_info;
 	hooks->_status = status;
 
 	hooks->Run();
@@ -29,9 +27,8 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(ProviderType provide
 std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(PublisherType publisher,
 															const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 															const ov::String secret_key,
-															const std::shared_ptr<ov::SocketAddress> &client_address,
 															const std::shared_ptr<const ov::Url> &request_url,
-															const ov::String &user_agent,
+															const std::shared_ptr<const ClientInfo> &client_info,
 															const Status::Code status)
 {
 	auto hooks = std::make_shared<AdmissionWebhooks>();
@@ -40,14 +37,45 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(PublisherType publis
 	hooks->_control_server_url = control_server_url;
 	hooks->_timeout_msec = timeout_msec;
 	hooks->_secret_key = secret_key;
-	hooks->_client_address = client_address;
 	hooks->_requested_url = request_url;
-	hooks->_user_agent = user_agent;
+	hooks->_client_info = client_info;
 	hooks->_status = status;
 
 	hooks->Run();
 
 	return hooks;
+}
+
+AdmissionWebhooks::ClientInfo::ClientInfo(const std::shared_ptr<ov::SocketAddress> &client_address)
+	: _client_address(client_address), _user_agent("")
+{
+
+}
+
+AdmissionWebhooks::ClientInfo::ClientInfo(const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent)
+	: _client_address(client_address), _user_agent(user_agent)
+{
+
+}
+
+std::shared_ptr<ov::SocketAddress> AdmissionWebhooks::ClientInfo::GetClientAddress() const
+{
+	return _client_address;
+}
+
+ov::String AdmissionWebhooks::ClientInfo::GetAddress() const
+{
+	return _client_address->GetIpAddress();
+}
+
+uint16_t AdmissionWebhooks::ClientInfo::GetPort() const
+{
+	return _client_address->Port();
+}
+
+const ov::String &AdmissionWebhooks::ClientInfo::GetUserAgent() const
+{
+	return _user_agent;
 }
 
 AdmissionWebhooks::ErrCode AdmissionWebhooks::GetErrCode() const
@@ -106,13 +134,13 @@ ov::String AdmissionWebhooks::GetMessageBody()
 	Json::Value jv_client;
 	Json::Value jv_request;
 
-	if(_client_address != nullptr)
+	if(_client_info != nullptr)
 	{
-		jv_client["address"] = _client_address->GetIpAddress().CStr();
-		jv_client["port"] = _client_address->Port();
-		if(!_user_agent.IsEmpty())
+		jv_client["address"] = _client_info->GetAddress().CStr();
+		jv_client["port"] = _client_info->GetPort();
+		if(!_client_info->GetUserAgent().IsEmpty())
 		{
-			jv_client["user-agent"] = _user_agent.CStr();
+			jv_client["user-agent"] = _client_info->GetUserAgent().CStr();
 		}
 		jv_root["client"] = jv_client;
 	}
@@ -187,7 +215,7 @@ void AdmissionWebhooks::ParseResponse(const std::shared_ptr<ov::Data> &data)
 	_allowed = jv_allowed.asBool();
 	if(_allowed == false)
 	{
-		_err_reason.Format("ControlServer(%s) denied admission to %s by %s.", _control_server_url->ToUrlString().CStr(), _requested_url->ToUrlString().CStr(), _client_address->ToString(false).CStr());
+		_err_reason.Format("ControlServer(%s) denied admission to %s by %s.", _control_server_url->ToUrlString().CStr(), _requested_url->ToUrlString().CStr(), _client_info->GetClientAddress()->ToString(false).CStr());
 	}
 
 	// Optional data

--- a/src/projects/modules/access_control/admission_webhooks/admission_webhooks.cpp
+++ b/src/projects/modules/access_control/admission_webhooks/admission_webhooks.cpp
@@ -7,6 +7,7 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(ProviderType provide
 															const ov::String secret_key,
 															const std::shared_ptr<ov::SocketAddress> &client_address,
 															const std::shared_ptr<const ov::Url> &request_url,
+															const ov::String &user_agent,
 															const Status::Code status)
 {
 	auto hooks = std::make_shared<AdmissionWebhooks>();
@@ -17,6 +18,7 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(ProviderType provide
 	hooks->_secret_key = secret_key;
 	hooks->_client_address = client_address;
 	hooks->_requested_url = request_url;
+	hooks->_user_agent = user_agent;
 	hooks->_status = status;
 
 	hooks->Run();
@@ -29,6 +31,7 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(PublisherType publis
 															const ov::String secret_key,
 															const std::shared_ptr<ov::SocketAddress> &client_address,
 															const std::shared_ptr<const ov::Url> &request_url,
+															const ov::String &user_agent,
 															const Status::Code status)
 {
 	auto hooks = std::make_shared<AdmissionWebhooks>();
@@ -39,6 +42,7 @@ std::shared_ptr<AdmissionWebhooks> AdmissionWebhooks::Query(PublisherType publis
 	hooks->_secret_key = secret_key;
 	hooks->_client_address = client_address;
 	hooks->_requested_url = request_url;
+	hooks->_user_agent = user_agent;
 	hooks->_status = status;
 
 	hooks->Run();
@@ -84,7 +88,8 @@ ov::String AdmissionWebhooks::GetMessageBody()
 		"client": 
 		{
 			"address": "211.233.58.86",
-			"port": 29291
+			"port": 29291,
+			"user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
 		},
 		"request":
 		{
@@ -105,6 +110,10 @@ ov::String AdmissionWebhooks::GetMessageBody()
 	{
 		jv_client["address"] = _client_address->GetIpAddress().CStr();
 		jv_client["port"] = _client_address->Port();
+		if(!_user_agent.IsEmpty())
+		{
+			jv_client["user-agent"] = _user_agent.CStr();
+		}
 		jv_root["client"] = jv_client;
 	}
 

--- a/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
+++ b/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
@@ -40,21 +40,34 @@ public:
 		};
 	};
 
+	class ClientInfo
+	{
+	public:
+		ClientInfo(const std::shared_ptr<ov::SocketAddress> &client_address);
+		ClientInfo(const std::shared_ptr<ov::SocketAddress> &client_address, const ov::String &user_agent);
+
+		std::shared_ptr<ov::SocketAddress> GetClientAddress() const;
+		ov::String GetAddress() const;
+		uint16_t GetPort() const;
+		const ov::String &GetUserAgent() const;
+
+	private:
+		const std::shared_ptr<ov::SocketAddress> _client_address;
+		const ov::String _user_agent;
+	};
 
 	static std::shared_ptr<AdmissionWebhooks> Query(ProviderType provider,
 													const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 													const ov::String secret_key,
-													const std::shared_ptr<ov::SocketAddress> &client_address,
 													const std::shared_ptr<const ov::Url> &request_url,
-													const ov::String &user_agent = "",
+													const std::shared_ptr<const ClientInfo> &client_info,
 													const Status::Code status = Status::Code::OPENING);
 
 	static std::shared_ptr<AdmissionWebhooks> Query(PublisherType publisher,
 													const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 													const ov::String secret_key,
-													const std::shared_ptr<ov::SocketAddress> &client_address,
 													const std::shared_ptr<const ov::Url> &request_url,
-													const ov::String &user_agent = "",
+													const std::shared_ptr<const ClientInfo> &client_info,
 													const Status::Code status = Status::Code::OPENING);
 
 	ErrCode GetErrCode() const;
@@ -72,15 +85,16 @@ private:
 
 	uint64_t _elapsed_ms = 0;
 
+	// Client
+	std::shared_ptr<const ClientInfo> _client_info;
+
 	// Request
 	std::shared_ptr<ov::Url> _control_server_url = nullptr;
 	uint64_t _timeout_msec = 0;
 	ov::String _secret_key;
 	ProviderType _provider_type = ProviderType::Unknown;
 	PublisherType _publisher_type = PublisherType::Unknown;
-	std::shared_ptr<ov::SocketAddress> _client_address;
 	std::shared_ptr<const ov::Url> _requested_url;
-	ov::String _user_agent;
 	Status::Code _status;
 
 	// Response

--- a/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
+++ b/src/projects/modules/access_control/admission_webhooks/admission_webhooks.h
@@ -46,12 +46,15 @@ public:
 													const ov::String secret_key,
 													const std::shared_ptr<ov::SocketAddress> &client_address,
 													const std::shared_ptr<const ov::Url> &request_url,
+													const ov::String &user_agent = "",
 													const Status::Code status = Status::Code::OPENING);
+
 	static std::shared_ptr<AdmissionWebhooks> Query(PublisherType publisher,
 													const std::shared_ptr<ov::Url> &control_server_url, uint32_t timeout_msec,
 													const ov::String secret_key,
 													const std::shared_ptr<ov::SocketAddress> &client_address,
 													const std::shared_ptr<const ov::Url> &request_url,
+													const ov::String &user_agent = "",
 													const Status::Code status = Status::Code::OPENING);
 
 	ErrCode GetErrCode() const;
@@ -77,6 +80,7 @@ private:
 	PublisherType _publisher_type = PublisherType::Unknown;
 	std::shared_ptr<ov::SocketAddress> _client_address;
 	std::shared_ptr<const ov::Url> _requested_url;
+	ov::String _user_agent;
 	Status::Code _status;
 
 	// Response

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -345,7 +345,7 @@ namespace pvd
 			return false;
 		}
 
-		auto [webhooks_result, _admission_webhooks] = GetProvider()->VerifyByAdmissionWebhooks(_url, _remote->GetRemoteAddress());
+		auto [webhooks_result, _admission_webhooks] = GetProvider()->VerifyByAdmissionWebhooks(_url, _remote->GetRemoteAddress(), "");
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			return true;

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -133,7 +133,9 @@ namespace pvd
 			auto remote_address { _remote->GetRemoteAddress() };
 			if (remote_address)
 			{
-				GetProvider()->SendCloseAdmissionWebhooks(_url, remote_address);
+				auto request_info = std::make_shared<AccessController::RequestInfo>(_url, remote_address);
+
+				GetProvider()->SendCloseAdmissionWebhooks(request_info);
 			}
 		}
 		// the return check is not necessary
@@ -345,7 +347,9 @@ namespace pvd
 			return false;
 		}
 
-		auto [webhooks_result, _admission_webhooks] = GetProvider()->VerifyByAdmissionWebhooks(_url, _remote->GetRemoteAddress(), "");
+		auto request_info = std::make_shared<AccessController::RequestInfo>(_url, _remote->GetRemoteAddress());
+
+		auto [webhooks_result, _admission_webhooks] = GetProvider()->VerifyByAdmissionWebhooks(request_info);
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			return true;

--- a/src/projects/providers/srt/srt_provider.cpp
+++ b/src/projects/providers/srt/srt_provider.cpp
@@ -229,7 +229,7 @@ namespace pvd
 			return;
 		}
 
-		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, nullptr);
+		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, "");
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			// Success

--- a/src/projects/providers/srt/srt_provider.cpp
+++ b/src/projects/providers/srt/srt_provider.cpp
@@ -229,7 +229,7 @@ namespace pvd
 			return;
 		}
 
-		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address);
+		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, nullptr);
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			// Success

--- a/src/projects/providers/srt/srt_provider.cpp
+++ b/src/projects/providers/srt/srt_provider.cpp
@@ -229,7 +229,9 @@ namespace pvd
 			return;
 		}
 
-		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, "");
+		auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address);
+
+		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_info);
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			// Success
@@ -307,7 +309,9 @@ namespace pvd
 			auto remote_address = remote->GetRemoteAddress();
 			if (parsed_url && remote_address)
 			{
-				SendCloseAdmissionWebhooks(parsed_url, remote_address);
+				auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address);
+
+				SendCloseAdmissionWebhooks(request_info);
 			}
 		}
 		// the return check is not necessary

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -293,7 +293,9 @@ namespace pvd
 		}
 
 		// Admission Webhooks
-		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address);
+		auto user_agent = request->GetHeader("USER-AGENT");
+
+		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, user_agent);
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			// Success

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -293,9 +293,9 @@ namespace pvd
 		}
 
 		// Admission Webhooks
-		auto user_agent = request->GetHeader("USER-AGENT");
+		auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address, request->GetHeader("USER-AGENT"));
 
-		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, user_agent);
+		auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_info);
 		if (webhooks_result == AccessController::VerificationResult::Off)
 		{
 			// Success
@@ -491,11 +491,14 @@ namespace pvd
 		logti("Stop command received : %s/%s/%u", vhost_app_name.CStr(), stream_name.CStr(), offer_sdp->GetSessionId());
 
 		// Send Close to Admission Webhooks
-		auto parsed_url{ov::Url::Parse(ws_session->GetRequest()->GetUri())};
-		auto remote_address{ws_session->GetRequest()->GetRemote()->GetRemoteAddress()};
+		auto request = ws_session->GetRequest();
+		auto parsed_url{ov::Url::Parse(request->GetUri())};
+		auto remote_address{request->GetRemote()->GetRemoteAddress()};
 		if (parsed_url && remote_address)
 		{
-			SendCloseAdmissionWebhooks(parsed_url, remote_address);
+			auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address, request->GetHeader("USER-AGENT"));
+
+			SendCloseAdmissionWebhooks(request_info);
 		}
 		// the return check is not necessary
 

--- a/src/projects/publishers/llhls/llhls_publisher.cpp
+++ b/src/projects/publishers/llhls/llhls_publisher.cpp
@@ -290,9 +290,9 @@ std::shared_ptr<LLHlsHttpInterceptor> LLHlsPublisher::CreateInterceptor()
 			}
 
 			// Admission Webhooks
-			auto user_agent = request->GetHeader("USER-AGENT");
+			auto request_info = std::make_shared<AccessController::RequestInfo>(request_url, remote_address, request->GetHeader("USER-AGENT"));
 
-			auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_url, remote_address, user_agent);
+			auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_info);
 			if (webhooks_result == AccessController::VerificationResult::Off)
 			{
 				// Success

--- a/src/projects/publishers/llhls/llhls_publisher.cpp
+++ b/src/projects/publishers/llhls/llhls_publisher.cpp
@@ -290,7 +290,9 @@ std::shared_ptr<LLHlsHttpInterceptor> LLHlsPublisher::CreateInterceptor()
 			}
 
 			// Admission Webhooks
-			auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_url, remote_address);
+			auto user_agent = request->GetHeader("USER-AGENT");
+
+			auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_url, remote_address, user_agent);
 			if (webhooks_result == AccessController::VerificationResult::Off)
 			{
 				// Success

--- a/src/projects/publishers/segment/segment_publisher.cpp
+++ b/src/projects/publishers/segment/segment_publisher.cpp
@@ -679,7 +679,9 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 	}
 
 	// Admission Webhooks
-	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(requested_url, remote_address);
+	auto user_agent = request->GetHeader("USER-AGENT");
+
+	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(requested_url, remote_address, user_agent);
 	if (webhooks_result == AccessController::VerificationResult::Off)
 	{
 		// Success

--- a/src/projects/publishers/segment/segment_publisher.cpp
+++ b/src/projects/publishers/segment/segment_publisher.cpp
@@ -389,7 +389,9 @@ void SegmentPublisher::RequestTableUpdateThread()
 					auto remote_address{std::make_shared<ov::SocketAddress>(ov::SocketAddress::CreateAndGetFirst(request_info->GetIpAddressPort()))};
 					if (request_url && remote_address)
 					{
-						SendCloseAdmissionWebhooks(request_url, remote_address);
+						auto access_controller_request_info = std::make_shared<AccessController::RequestInfo>(request_url, remote_address);
+
+						SendCloseAdmissionWebhooks(access_controller_request_info);
 					}
 					// it is not necessary to check the return
 
@@ -577,7 +579,7 @@ void SegmentPublisher::UpdateWebhooksRequestInfo(const WebhooksRequestInfo &info
 
 bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, ov::String &stream_name,
 										   const std::shared_ptr<http::svr::HttpExchange> &client, const std::shared_ptr<const ov::Url> &request_url,
-										   std::shared_ptr<PlaylistRequestInfo> &request_info)
+										   std::shared_ptr<PlaylistRequestInfo> &playlist_request_info)
 {
 	auto request = client->GetRequest();
 	auto remote_address = request->GetRemote()->GetRemoteAddress();
@@ -596,20 +598,20 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 	}
 
 	auto session_id = remote_address->GetIpAddress();
-	request_info = std::make_shared<PlaylistRequestInfo>(GetPublisherType(),
+	playlist_request_info = std::make_shared<PlaylistRequestInfo>(GetPublisherType(),
 														 vhost_app_name, stream_name,
 														 remote_address->GetIpAddress(),
 														 session_id);
 
 	auto stream{GetStreamAs<SegmentStream>(vhost_app_name, stream_name)};
-	auto segment_duration{(stream == nullptr) ? request_info->GetSegmentDuration() : stream->GetSegmentDuration()};
-	request_info->SetSegmentDuration(segment_duration);
+	auto segment_duration{(stream == nullptr) ? playlist_request_info->GetSegmentDuration() : stream->GetSegmentDuration()};
+	playlist_request_info->SetSegmentDuration(segment_duration);
 
 	// SingedPolicy is first
 	auto [signed_policy_result, signed_policy] = Publisher::VerifyBySignedPolicy(requested_url, remote_address);
 	if (signed_policy_result == AccessController::VerificationResult::Pass)
 	{
-		UpdatePlaylistRequestInfo(request_info);
+		UpdatePlaylistRequestInfo(playlist_request_info);
 		// Check Admission Webhooks
 		//return true;
 	}
@@ -624,10 +626,10 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 			// Because this is chunked streaming publisher,
 			// players will continue to request playlists after token expiration while playing.
 			// Therefore, once authorized session must be maintained.
-			if (IsAuthorizedSession(*request_info))
+			if (IsAuthorizedSession(*playlist_request_info))
 			{
 				// Update the authorized session info
-				UpdatePlaylistRequestInfo(request_info);
+				UpdatePlaylistRequestInfo(playlist_request_info);
 				// Check Admission Webhooks
 				// return true;
 			}
@@ -645,7 +647,7 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 
 		if (signed_token_result == AccessController::VerificationResult::Pass)
 		{
-			UpdatePlaylistRequestInfo(request_info);
+			UpdatePlaylistRequestInfo(playlist_request_info);
 			// Check Admission Webhooks
 		}
 		else if (signed_token_result == AccessController::VerificationResult::Off)
@@ -663,10 +665,10 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 				// Because this is chunked streaming publisher,
 				// players will continue to request playlists after token expiration while playing.
 				// Therefore, once authorized session must be maintained.
-				if (IsAuthorizedSession(*request_info))
+				if (IsAuthorizedSession(*playlist_request_info))
 				{
 					// Update the authorized session info
-					UpdatePlaylistRequestInfo(request_info);
+					UpdatePlaylistRequestInfo(playlist_request_info);
 					// Check Admission Webhooks
 				}
 			}
@@ -679,9 +681,9 @@ bool SegmentPublisher::HandleAccessControl(info::VHostAppName &vhost_app_name, o
 	}
 
 	// Admission Webhooks
-	auto user_agent = request->GetHeader("USER-AGENT");
+	auto request_info = std::make_shared<AccessController::RequestInfo>(requested_url, remote_address, request->GetHeader("USER-AGENT"));
 
-	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(requested_url, remote_address, user_agent);
+	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_info);
 	if (webhooks_result == AccessController::VerificationResult::Off)
 	{
 		// Success

--- a/src/projects/publishers/webrtc/webrtc_publisher.cpp
+++ b/src/projects/publishers/webrtc/webrtc_publisher.cpp
@@ -288,7 +288,9 @@ std::shared_ptr<const SessionDescription> WebRtcPublisher::OnRequestOffer(const 
 	}
 
 	// Admission Webhooks
-	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address);
+	auto user_agent = request->GetHeader("USER-AGENT");
+
+	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, user_agent);
 	if (webhooks_result == AccessController::VerificationResult::Off)
 	{
 		// Success

--- a/src/projects/publishers/webrtc/webrtc_publisher.cpp
+++ b/src/projects/publishers/webrtc/webrtc_publisher.cpp
@@ -288,9 +288,9 @@ std::shared_ptr<const SessionDescription> WebRtcPublisher::OnRequestOffer(const 
 	}
 
 	// Admission Webhooks
-	auto user_agent = request->GetHeader("USER-AGENT");
+	auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address, request->GetHeader("USER-AGENT"));
 
-	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(parsed_url, remote_address, user_agent);
+	auto [webhooks_result, admission_webhooks] = VerifyByAdmissionWebhooks(request_info);
 	if (webhooks_result == AccessController::VerificationResult::Off)
 	{
 		// Success
@@ -578,7 +578,9 @@ bool WebRtcPublisher::OnStopCommand(const std::shared_ptr<http::svr::ws::WebSock
 	auto remote_address{ws_session->GetRequest()->GetRemote()->GetRemoteAddress()};
 	if (parsed_url && remote_address)
 	{
-		SendCloseAdmissionWebhooks(parsed_url, remote_address);
+		auto request_info = std::make_shared<AccessController::RequestInfo>(parsed_url, remote_address, ws_session->GetRequest()->GetHeader("USER-AGENT"));
+
+		SendCloseAdmissionWebhooks(request_info);
 	}
 	// the return check is not necessary
 


### PR DESCRIPTION
The purpose of this P.R. is to add client's user-agent information in the AdmissionWebhook's request message.

**Supported protocols**

[Providers]
- webrtc

[Publishers]
- webrtc
- llhls