### PR TITLE
Include framerate calculation fix in decoder_hevc

### DIFF
--- a/src/projects/transcoder/codec/decoder/decoder_hevc.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_hevc.cpp
@@ -214,8 +214,11 @@ void DecoderHEVC::CodecThread()
 				}
 
 				// If there is no duration, the duration is calculated by framerate and timebase.
-				_frame->pkt_duration = (_frame->pkt_duration <= 0LL) ? ffmpeg::Conv::GetDurationPerFrame(cmn::MediaType::Video, GetRefTrack()) : _frame->pkt_duration;
-
+				if(_frame->pkt_duration <= 0LL && _context->framerate.num > 0 && _context->framerate.den > 0)
+				{
+					_frame->pkt_duration = (int64_t)( ((double)_context->framerate.den / (double)_context->framerate.num) / ((double) GetRefTrack()->GetTimeBase().GetNum() / (double) GetRefTrack()->GetTimeBase().GetDen()) );
+				}
+				
 				auto decoded_frame = ffmpeg::Conv::ToMediaFrame(cmn::MediaType::Video, _frame);
 				::av_frame_unref(_frame);
 				if (decoded_frame == nullptr)


### PR DESCRIPTION
This same calculation method was applied by @Keukhan to the other decoders, but not decoder_hevc where the memory issue #1172 is still occurring.