### PR TITLE
Fix potential memory leak

### DIFF
--- a/misc/oven_rtc_tester/OvenRtcTester.go
+++ b/misc/oven_rtc_tester/OvenRtcTester.go
@@ -45,11 +45,12 @@ func main() {
 	clientChan := make(chan *omeClient)
 	quit := make(chan bool)
 	go func() {
+		tf := time.After(time.Millisecond * time.Duration(*connectionInterval))
 		for i := 0; i < *numberOfClient; i++ {
 			select {
 			case <- quit:
 				return
-			case <- time.After(time.Millisecond * time.Duration(*connectionInterval)):
+			case <- tf:
 				client := omeClient{}
 
 				client.name = fmt.Sprintf("client_%d", i)


### PR DESCRIPTION
When using time.After in a loop, it should be defined outside the loop, otherwise memory leaks will occur due to non-stop creation of new variables to apply for memory