### PR TITLE
Add "lastThroughputIn" and "lastThroughputOut" to Stream Stats API

### DIFF
--- a/docs/rest-api/v1/statistics/current.md
+++ b/docs/rest-api/v1/statistics/current.md
@@ -58,6 +58,8 @@ Content-Type: application/json
         "lastRecvTime": "2023-03-15T19:46:13.728+09:00",
         "lastSentTime": "2023-03-15T19:46:13.728+09:00",
         "lastUpdatedTime": "2023-03-15T19:46:13.728+09:00",
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0,
         "maxTotalConnectionTime": "2023-03-15T19:46:13.728+09:00",
         "maxTotalConnections": 0,
         "totalBytesIn": 0,
@@ -66,9 +68,7 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0,
-        "lastThroughputIn": 0,
-        "lastThroughputOut": 0
+        "maxThroughputOut": 0
     }
 }
 ```
@@ -171,6 +171,8 @@ Content-Type: application/json
         "lastRecvTime": "2023-03-15T19:46:13.728+09:00",
         "lastSentTime": "2023-03-15T19:46:13.728+09:00",
         "lastUpdatedTime": "2023-03-15T19:46:13.728+09:00",
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0,
         "maxTotalConnectionTime": "2023-03-15T19:46:13.728+09:00",
         "maxTotalConnections": 0,
         "totalBytesIn": 0,
@@ -179,9 +181,7 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0,
-        "lastThroughputIn": 0,
-        "lastThroughputOut": 0      
+        "maxThroughputOut": 0   
     }
 }
 ```
@@ -284,6 +284,8 @@ Content-Type: application/json
         "lastRecvTime": "2023-03-15T19:46:13.728+09:00",
         "lastSentTime": "2023-03-15T19:46:13.728+09:00",
         "lastUpdatedTime": "2023-03-15T19:46:13.728+09:00",
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0,
         "maxTotalConnectionTime": "2023-03-15T19:46:13.728+09:00",
         "maxTotalConnections": 0,
         "totalBytesIn": 0,
@@ -292,9 +294,7 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0,
-        "lastThroughputIn": 0,
-        "lastThroughputOut": 0        
+        "maxThroughputOut": 0       
     }
 }
 ```

--- a/docs/rest-api/v1/statistics/current.md
+++ b/docs/rest-api/v1/statistics/current.md
@@ -66,7 +66,9 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0
+        "maxThroughputOut": 0,
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0
     }
 }
 ```
@@ -177,7 +179,9 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0    
+        "maxThroughputOut": 0,
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0      
     }
 }
 ```
@@ -288,7 +292,9 @@ Content-Type: application/json
         "avgThroughputIn": 0,
         "avgThroughputOut": 0,        
         "maxThroughputIn": 0,
-        "maxThroughputOut": 0        
+        "maxThroughputOut": 0,
+        "lastThroughputIn": 0,
+        "lastThroughputOut": 0        
     }
 }
 ```

--- a/src/projects/modules/json_serdes/metrics.cpp
+++ b/src/projects/modules/json_serdes/metrics.cpp
@@ -27,6 +27,8 @@ namespace serdes
 		SetInt64(value, "avgThroughputOut", metrics->GetAvgThroughputOut());		
 		SetInt64(value, "maxThroughputIn", metrics->GetMaxThroughputIn());
 		SetInt64(value, "maxThroughputOut", metrics->GetMaxThroughputOut());
+		SetInt64(value, "lastThroughputIn", metrics->GetLastThroughputIn());
+		SetInt64(value, "lastThroughputOut", metrics->GetLastThroughputOut());
 		SetTimestamp(value, "lastRecvTime", metrics->GetLastRecvTime());
 		SetTimestamp(value, "lastSentTime", metrics->GetLastSentTime());
 		SetInt(value, "totalConnections", metrics->GetTotalConnections());

--- a/src/projects/monitoring/common_metrics.cpp
+++ b/src/projects/monitoring/common_metrics.cpp
@@ -16,11 +16,13 @@ namespace mon
 		_max_total_connections = 0;
 
 		_avg_throughtput_in = 0;
-		_max_throughtput_in = 0;		
+		_max_throughtput_in = 0;	
+		_last_throughtput_in = 0;	
 		_last_total_bytes_out = 0;
 
 		_avg_throughtput_out = 0;
 		_max_throughtput_out = 0;
+		_last_throughtput_out = 0;
 		_last_total_bytes_out = 0;
 
 		_last_throughput_measure_time = std::chrono::system_clock::now();
@@ -110,6 +112,16 @@ namespace mon
 	uint64_t CommonMetrics::GetMaxThroughputOut() const
 	{
 		return _max_throughtput_out;
+	}
+
+	uint64_t CommonMetrics::GetLastThroughputIn() const
+	{
+		return _last_throughtput_in;
+	}
+
+	uint64_t CommonMetrics::GetLastThroughputOut() const
+	{
+		return _last_throughtput_out;
 	}
 
 	uint32_t CommonMetrics::GetTotalConnections() const
@@ -221,6 +233,9 @@ namespace mon
 			}
 			_last_total_bytes_in.store(_total_bytes_in);
 
+			// Calculate last second throughput of provider
+			_last_throughtput_in = (_total_bytes_in.load() - _last_total_bytes_in.load());
+
 			// Calculate average throughput of publisher
 			_avg_throughtput_out =  (_total_bytes_out.load() - _last_total_bytes_out.load()) * 8 / THROUGHPUT_MEASURE_INTERVAL;
 			if(_avg_throughtput_out.load() > _max_throughtput_out.load())
@@ -228,6 +243,9 @@ namespace mon
 				_max_throughtput_out.store(_avg_throughtput_out);
 			}
 			_last_total_bytes_out.store(_total_bytes_out);
+
+			// Calculate last second throughput of publisher
+			_last_throughtput_out = (_total_bytes_out.load() - _last_total_bytes_out.load());
 		}
 	}	
 }

--- a/src/projects/monitoring/common_metrics.cpp
+++ b/src/projects/monitoring/common_metrics.cpp
@@ -225,6 +225,9 @@ namespace mon
 		{
 			_last_throughput_measure_time = throughput_measure_time;
 
+			// Calculate last second throughput of provider
+			_last_throughtput_in = (_total_bytes_in.load() - _last_total_bytes_in.load());
+
 			// Calculate average throughput of provider
 			_avg_throughtput_in = (_total_bytes_in.load() - _last_total_bytes_in.load()) * 8 / THROUGHPUT_MEASURE_INTERVAL;
 			if (_avg_throughtput_in.load() > _max_throughtput_in.load())
@@ -233,8 +236,8 @@ namespace mon
 			}
 			_last_total_bytes_in.store(_total_bytes_in);
 
-			// Calculate last second throughput of provider
-			_last_throughtput_in = (_total_bytes_in.load() - _last_total_bytes_in.load());
+			// Calculate last second throughput of publisher
+			_last_throughtput_out = (_total_bytes_out.load() - _last_total_bytes_out.load());
 
 			// Calculate average throughput of publisher
 			_avg_throughtput_out =  (_total_bytes_out.load() - _last_total_bytes_out.load()) * 8 / THROUGHPUT_MEASURE_INTERVAL;
@@ -244,8 +247,6 @@ namespace mon
 			}
 			_last_total_bytes_out.store(_total_bytes_out);
 
-			// Calculate last second throughput of publisher
-			_last_throughtput_out = (_total_bytes_out.load() - _last_total_bytes_out.load());
 		}
 	}	
 }

--- a/src/projects/monitoring/common_metrics.h
+++ b/src/projects/monitoring/common_metrics.h
@@ -26,6 +26,8 @@ namespace mon
 		virtual uint64_t GetAvgThroughputOut() const;
 		virtual uint64_t GetMaxThroughputIn() const;
 		virtual uint64_t GetMaxThroughputOut() const;		
+		virtual uint64_t GetLastThroughputIn() const;	
+		virtual uint64_t GetLastThroughputOut() const;	
 		virtual uint32_t GetTotalConnections() const;
 		virtual uint32_t GetMaxTotalConnections() const;
 		virtual std::chrono::system_clock::time_point GetMaxTotalConnectionsTime() const;
@@ -68,11 +70,14 @@ namespace mon
 		// Throughput from Provider
 		std::atomic<uint64_t> _avg_throughtput_in;
 		std::atomic<uint64_t> _max_throughtput_in;
+		std::atomic<uint64_t> _last_throughtput_in;
 		std::atomic<uint64_t> _last_total_bytes_in;
+		
 
 		// Throughput from Publishers
 		std::atomic<uint64_t> _avg_throughtput_out;
 		std::atomic<uint64_t> _max_throughtput_out;
+		std::atomic<uint64_t> _last_throughtput_out;
 		std::atomic<uint64_t> _last_total_bytes_out;
 
 		std::chrono::system_clock::time_point	_last_throughput_measure_time;


### PR DESCRIPTION
Hi guys! I noticed the Stream Stats API only returns the _average_ incoming video bitrate. So if you are streaming 4Mb/s for a long time then switch to 1Mb/s, it will take some time for the users to see this.

Please accept this pull request which tested OK on my end. It reveals "lastThroughputIn" and "lastThroughputOut" to show the bitrate in or out for the last second.