### PR TITLE
Add <InternalQueueCongestion> feature to Alert

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -43,7 +43,7 @@ Alert can be set up on \<Server>, as shown below.
 
 ### Rules
 
-| Type    | Key                  | Description                                                                        |
+| Key     |                      | Description                                                                        |
 | ------- | -------------------- | ---------------------------------------------------------------------------------- |
 | Ingress | MinBitrate           | Detects when the input stream's bitrate is lower than the set value.               |
 |         | MaxBitrate           | Detects when the input stream's bitrate is greater than the set value.             |
@@ -120,34 +120,36 @@ X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
 				"type":"Data"
 			}
 		]
-	}
+	},
+	"type":"INGRESS"
 }
 ```
 
-Here is a detailed explanation of each element of Json payload:
+Here is a detailed explanation of each element of JSON payload:
 
-| Element    | Description                                                                                                                                                         |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sourceUri  | <p>URI information of the detected source.</p><p>It consists of #&#x3C;vhost>#&#x3C;application>/&#x3C;stream>.</p>                                                 |
-| messages   | List of messages detected by the Rules.                                                                                                                             |
-| sourceInfo | Detailed information about the source at the time of detection. It is identical to the response of the REST API's source information query for the detected source. |
+| Element        | Description                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| sourceUri      | <p>URI information of the detected source.</p><p>It consists of #&#x3C;vhost>#&#x3C;application>/&#x3C;stream>.</p>      |
+| messages       | List of messages detected by the Rules.                                                                                  |
+| sourceInfo     | Detailed information about the source at the time of detection. It is identical to the response of the REST API's source information query for the detected source. |
+| type           | <p>It represents the format of the JSON payload. The information of the JSON elements can vary depending on the value of the type.</p><p>Currently, the value is fixed as `INGRESS`.</p> |
 
 #### Messages
 
-| Code                                 | Description                                                                                                                       |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| INGRESS\_BITRATE\_LOW                | The ingress stream's current bitrate (`%d` bps) is lower than the configured bitrate (`%d` bps)                                   |
-| INGRESS\_BITRATE\_HIGH               | The ingress stream's current bitrate (`%d` bps) is higher than the configured bitrate (`%d` bps)                                  |
-| INGRESS\_FRAMERATE\_LOW              | The ingress stream's current framerate (`%.2f` fps) is lower than the configured framerate (`%.2f` fps)                           |
-| INGRESS\_FRAMERATE\_HIGH             | The ingress stream's current framerate (`%f` fps) is higher than the configured framerate (`%f` fps)                              |
-| INGRESS\_WIDTH\_SMALL                | The ingress stream's width (`%d`) is smaller than the configured width (`%d`)                                                     |
-| INGRESS\_WIDTH\_LARGE                | The ingress stream's width (`%d`) is larger than the configured width (`%d`)                                                      |
-| INGRESS\_HEIGHT\_SMALL               | The ingress stream's height (`%d`) is smaller than the configured height (`%d`)                                                   |
-| INGRESS\_HEIGHT\_LARGE               | The ingress stream's height (`%d`) is larger than the configured height (`%d`)                                                    |
-| INGRESS\_SAMPLERATE\_LOW             | The ingress stream's current samplerate (`%d`) is lower than the configured samplerate (`%d`)                                     |
-| INGRESS\_SAMPLERATE\_HIGH            | The ingress stream's current samplerate (`%d`) is higher than the configured samplerate (`%d`)                                    |
-| INGRESS\_LONG\_KEY\_FRAME\_INTERVAL  | The ingress stream's current keyframe interval (`%.1f` seconds) is too long. Please use a keyframe interval of 4 seconds or less. |
-| INGRESS\_HAS\_BFRAME                 | There are B-Frames in the ingress stream.                                                                                         |
+| Code                                 | Description                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| INGRESS\_BITRATE\_LOW                | The ingress stream's current bitrate (`%d` bps) is lower than the configured bitrate (`%d` bps)          |
+| INGRESS\_BITRATE\_HIGH               | The ingress stream's current bitrate (`%d` bps) is higher than the configured bitrate (`%d` bps)         |
+| INGRESS\_FRAMERATE\_LOW              | The ingress stream's current framerate (`%.2f` fps) is lower than the configured framerate (`%.2f` fps)  |
+| INGRESS\_FRAMERATE\_HIGH             | The ingress stream's current framerate (`%f` fps) is higher than the configured framerate (`%f` fps)     |
+| INGRESS\_WIDTH\_SMALL                | The ingress stream's width (`%d`) is smaller than the configured width (`%d`)                            |
+| INGRESS\_WIDTH\_LARGE                | The ingress stream's width (`%d`) is larger than the configured width (`%d`)                             |
+| INGRESS\_HEIGHT\_SMALL               | The ingress stream's height (`%d`) is smaller than the configured height (`%d`)                          |
+| INGRESS\_HEIGHT\_LARGE               | The ingress stream's height (`%d`) is larger than the configured height (`%d`)                           |
+| INGRESS\_SAMPLERATE\_LOW             | The ingress stream's current samplerate (`%d`) is lower than the configured samplerate (`%d`)            |
+| INGRESS\_SAMPLERATE\_HIGH            | The ingress stream's current samplerate (`%d`) is higher than the configured samplerate (`%d`)           |
+| INGRESS\_LONG\_KEY\_FRAME\_INTERVAL  | The ingress stream's current keyframe interval (`%.1f` seconds) is too long. Please use a keyframe interval of 4 seconds or less |
+| INGRESS\_HAS\_BFRAME                 | There are B-Frames in the ingress stream                                                                 |
 
 #### Security
 
@@ -155,7 +157,7 @@ The control server may need to validate incoming http requests for security reas
 
 ### Response
 
-The engine in the closing state does not need any parameter in response. To the query just answer with empty json object.
+The engine in the closing state does not need any parameter in response. To the query just answer with empty JSON object.
 
 ```http
 HTTP/1.1 200 OK

--- a/src/projects/monitoring/alert/alert.h
+++ b/src/projects/monitoring/alert/alert.h
@@ -8,10 +8,12 @@
 //==============================================================================
 #pragma once
 
+#include "../queue_metrics.h"
 #include "../stream_metrics.h"
 #include "base/ovlibrary/ovlibrary.h"
 #include "config/config.h"
 #include "message.h"
+#include "notification_data.h"
 
 namespace mon
 {
@@ -28,21 +30,24 @@ namespace mon
 		private:
 			void DispatchThreadProc();
 
-			void VerifyIngressRules(const ov::String &source_uri, cfg::alrt::rule::Rules rules, const std::shared_ptr<StreamMetrics> &stream_metric, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list);
-			void VerifyVideoIngressRules(const ov::String &source_uri, cfg::alrt::rule::Ingress ingress, const std::shared_ptr<MediaTrack> &video_track, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list);
-			void VerifyAudioIngressRules(const ov::String &source_uri, cfg::alrt::rule::Ingress ingress, const std::shared_ptr<MediaTrack> &audio_track, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list);
+			bool VerifyQueueCongestionRules(const cfg::alrt::rule::Rules &rules, const std::shared_ptr<QueueMetrics> &queue_metric, std::vector<std::shared_ptr<Message>> &message_list);
+			void VerifyIngressRules(const cfg::alrt::rule::Rules &rules, const std::shared_ptr<StreamMetrics> &stream_metric, std::vector<std::shared_ptr<Message>> &message_list);
+			void VerifyVideoIngressRules(const cfg::alrt::rule::Ingress &ingress, const std::shared_ptr<MediaTrack> &video_track, std::vector<std::shared_ptr<Message>> &message_list);
+			void VerifyAudioIngressRules(const cfg::alrt::rule::Ingress &ingress, const std::shared_ptr<MediaTrack> &audio_track, std::vector<std::shared_ptr<Message>> &message_list);
 
-			bool IsAlertNeeded(const ov::String &source_uri, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list);
+			bool IsAlertNeeded(const ov::String &messages_key, const std::vector<std::shared_ptr<Message>> &message_list);
+			void SendNotification(const NotificationData &notificationData);
+			void SendNotification(const NotificationData::Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const ov::String &source_uri, const std::shared_ptr<StreamMetrics> &stream_metric);
+			void SendNotification(const NotificationData::Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const std::map<uint32_t, std::shared_ptr<QueueMetrics>> &queue_metric_list);
 
-			void CleanupDeletedSources(const std::vector<ov::String> *exist_source_uri_list);
-			bool PutSourceUriMessages(const ov::String &source_uri, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list);
-			bool RemoveSourceUriMessages(const ov::String &source_uri);
-			std::shared_ptr<std::vector<std::shared_ptr<Message>>> GetSourceUriMessages(const ov::String &source_uri);
+			void CleanupReleasedMessages(const std::vector<ov::String> &new_messages_keys);
+			bool PutVerifiedMessages(const ov::String &messages_key, std::vector<std::shared_ptr<Message>> &message_list);
+			bool RemoveVerifiedMessages(const ov::String &messages_key);
+			std::vector<std::shared_ptr<Message>> GetVerifiedMessages(const ov::String &messages_key);
 
 			std::shared_ptr<const cfg::Server> _server_config = nullptr;
 
-			std::map<ov::String, std::shared_ptr<std::vector<std::shared_ptr<Message>>>> _source_uri_messages_map;
-			std::map<ov::String, bool> _changed_map;
+			std::map<ov::String, std::vector<std::shared_ptr<Message>>> _last_verified_messages_map;
 
 			ov::DelayQueue _timer{"MonAlert"};
 		};

--- a/src/projects/monitoring/alert/message.h
+++ b/src/projects/monitoring/alert/message.h
@@ -37,7 +37,10 @@ namespace mon
 				INGRESS_SAMPLERATE_LOW,
 				INGRESS_SAMPLERATE_HIGH,
 				INGRESS_LONG_KEY_FRAME_INTERVAL,
-				INGRESS_HAS_BFRAME
+				INGRESS_HAS_BFRAME,
+
+				// Internal Codes
+				INTERNAL_QUEUE_CONGESTION
 			};
 
 			static std::shared_ptr<Message> CreateMessage(Code code, const ov::String &description)
@@ -78,6 +81,8 @@ namespace mon
 					MESSAGE_CASE_RETURN(Code::INGRESS_SAMPLERATE_HIGH, "INGRESS_SAMPLERATE_HIGH");
 					MESSAGE_CASE_RETURN(Code::INGRESS_LONG_KEY_FRAME_INTERVAL, "INGRESS_LONG_KEY_FRAME_INTERVAL");
 					MESSAGE_CASE_RETURN(Code::INGRESS_HAS_BFRAME, "INGRESS_HAS_BFRAME");
+
+					MESSAGE_CASE_RETURN(Code::INTERNAL_QUEUE_CONGESTION, "INTERNAL_QUEUE_CONGESTION");
 				}
 
 				return "OK";
@@ -114,9 +119,11 @@ namespace mon
 					MESSAGE_CASE_RETURN(Code::INGRESS_SAMPLERATE_HIGH,
 										ov::String::FormatString("The ingress stream's current samplerate (%d) is higher than the configured samplerate (%d)", measured, config));
 					MESSAGE_CASE_RETURN(Code::INGRESS_LONG_KEY_FRAME_INTERVAL,
-										ov::String::FormatString("The ingress stream's current keyframe interval (%.1f seconds) is too long. Please use a keyframe interval of %.1f seconds or less.", measured, config));
+										ov::String::FormatString("The ingress stream's current keyframe interval (%.1f seconds) is too long. Please use a keyframe interval of %.1f seconds or less", measured, config));
 					MESSAGE_CASE_RETURN(Code::INGRESS_HAS_BFRAME,
-										ov::String::FormatString("There are B-Frames in the ingress stream."));
+										ov::String::FormatString("There are B-Frames in the ingress stream"));
+					MESSAGE_CASE_RETURN(Code::INTERNAL_QUEUE_CONGESTION,
+										ov::String::FormatString("Internal queue(s) is currently congested"));
 				}
 
 				return "The current status is good";

--- a/src/projects/monitoring/alert/notification.h
+++ b/src/projects/monitoring/alert/notification.h
@@ -12,6 +12,7 @@
 #include <base/ovlibrary/ovlibrary.h>
 #include <base/ovsocket/socket_address.h>
 
+#include "../queue_metrics.h"
 #include "../stream_metrics.h"
 #include "message.h"
 
@@ -33,9 +34,7 @@ namespace mon
 				INTERNAL_ERROR,
 			};
 
-			static std::shared_ptr<Notification> Query(const std::shared_ptr<ov::Url> &notification_server_url, uint32_t timeout_msec, const ov::String secret_key,
-													   const ov::String &source_uri, const std::shared_ptr<std::vector<std::shared_ptr<Message>>> &message_list,
-													   const std::shared_ptr<StreamMetrics> &stream_metric);
+			static std::shared_ptr<Notification> Query(const std::shared_ptr<ov::Url> &notification_server_url, uint32_t timeout_msec, const ov::String secret_key, const ov::String message_body);
 
 			StatusCode GetStatusCode() const;
 			ov::String GetErrorReason() const;
@@ -54,9 +53,7 @@ namespace mon
 			std::shared_ptr<ov::Url> _notification_server_url = nullptr;
 			uint64_t _timeout_msec = 0;
 			ov::String _secret_key;
-			ov::String _source_uri;
-			std::shared_ptr<std::vector<std::shared_ptr<Message>>> _message_list = nullptr;
-			std::shared_ptr<StreamMetrics> _stream_metric = nullptr;
+			ov::String _message_body;
 
 			// Response
 			StatusCode _status_code = StatusCode::OK;

--- a/src/projects/monitoring/alert/notification_data.cpp
+++ b/src/projects/monitoring/alert/notification_data.cpp
@@ -1,0 +1,98 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "notification_data.h"
+
+#include <modules/json_serdes/converters.h>
+
+namespace mon
+{
+	namespace alrt
+	{
+		NotificationData::NotificationData(const Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const ov::String source_uri, const std::shared_ptr<StreamMetrics> &stream_metric)
+		{
+			_type = type;
+			_message_list = message_list;
+			_source_uri = source_uri;
+			_stream_metric = stream_metric;
+		}
+
+		NotificationData::NotificationData(const Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const std::map<uint32_t, std::shared_ptr<QueueMetrics>> &queue_metric_list)
+		{
+			_type = type;
+			_message_list = message_list;
+			_queue_metric_list = queue_metric_list;
+		}
+
+		ov::String NotificationData::ToJsonString() const
+		{
+			// Make request message
+			Json::Value jv_root;
+
+			// Type
+			jv_root["type"] = StringFromType(_type).CStr();
+
+			// Messages
+			Json::Value jv_messages;
+			if (_message_list.size() <= 0)
+			{
+				// If the message_list is empty, it means that the status of the stream has become normal, so send an OK message.
+
+				Json::Value jv_message;
+
+				jv_message["code"] = Message::StringFromMessageCode(Message::Code::OK).CStr();
+				jv_message["description"] = Message::DescriptionFromMessageCode<bool>(Message::Code::OK, true, true).CStr();
+
+				jv_messages.append(jv_message);
+			}
+			else
+			{
+				for (auto &message : _message_list)
+				{
+					Json::Value jv_message;
+
+					jv_message["code"] = Message::StringFromMessageCode(message->GetCode()).CStr();
+					jv_message["description"] = message->GetDescription().CStr();
+
+					jv_messages.append(jv_message);
+				}
+			}
+			jv_root["messages"] = jv_messages;
+
+			// Source uri
+			if (!_source_uri.IsEmpty())
+			{
+				jv_root["sourceUri"] = _source_uri.CStr();
+			}
+
+			// Metric infos
+			if (_stream_metric != nullptr)
+			{
+				Json::Value jv_source_info = ::serdes::JsonFromStream(_stream_metric);
+				jv_root["sourceInfo"] = jv_source_info;
+
+			}
+
+			if (_queue_metric_list.size() > 0)
+			{
+				Json::Value jv_queues;
+
+				for (const auto &[queue_key, queue_metric] : _queue_metric_list)
+				{
+					Json::Value jv_queue = ::serdes::JsonFromQueueMetrics(queue_metric);
+
+					jv_queues.append(jv_queue);
+				}
+
+				jv_root["internalQueues"] = jv_queues;
+			}
+
+			return ov::Converter::ToString(jv_root);
+		}
+	}  // namespace alrt
+}  // namespace mon

--- a/src/projects/monitoring/alert/notification_data.h
+++ b/src/projects/monitoring/alert/notification_data.h
@@ -1,0 +1,55 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "../queue_metrics.h"
+#include "../stream_metrics.h"
+#include "message.h"
+
+namespace mon
+{
+	namespace alrt
+	{
+		class NotificationData
+		{
+		public:
+			enum class Type : uint16_t
+			{
+				INGRESS,
+				INTERNAL_QUEUE
+			};
+
+			static ov::String StringFromType(Type type)
+			{
+				switch (type)
+				{
+					case Type::INGRESS:
+						return "INGRESS";
+					case Type::INTERNAL_QUEUE:
+						return "INTERNAL_QUEUE";
+				}
+
+				return "INGRESS";
+			}
+
+			NotificationData(const Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const ov::String source_uri, const std::shared_ptr<StreamMetrics> &stream_metric);
+			NotificationData(const Type &type, const std::vector<std::shared_ptr<Message>> &message_list, const std::map<uint32_t, std::shared_ptr<QueueMetrics>> &queue_metric_list);
+			ov::String ToJsonString() const;
+
+		private:
+			Type _type;
+			std::vector<std::shared_ptr<Message>> _message_list = {};
+
+			ov::String _source_uri;
+			std::shared_ptr<StreamMetrics> _stream_metric = nullptr;
+
+			std::map<uint32_t, std::shared_ptr<QueueMetrics>> _queue_metric_list;
+		};
+	}  // namespace alrt
+}  // namespace mon


### PR DESCRIPTION
The purpose of this P.R. is to add a feature to Alert that detects congestion in the internal queue.
It detects situations where the current size of the internal queue exceeds the threshold.

**Configuration**
```
<Server version="8">
	<Alert>
		<Rules>
			...
			<InternalQueueCongestion />
		</Rules>
	</Alert>
</Server>
```

**Notification**
```
POST /configured/target/url/ HTTP/1.1
Content-Length: 1037
Content-Type: application/json
Accept: application/json
X-OME-Signature: f871jd991jj1929jsjd91pqa0amm1
{
	"sourceUri":"#default#app/stream",
	"messages":[
		{
			"code":"INTERNAL_QUEUE_CONGESTION",
			"description":"Internal queue(s) is currently congested"
		}
	],
	"sourceInfo":{
		"createdTime":"2023-04-07T21:15:24.487+09:00",
		"sourceType":"Rtmp",
		"sourceUrl":"TCP://192.168.0.220:10639",
		...
	},
	"internalQueues":[
		{
			"drop":0,
			"id":262532154,
			"imps":0,
			"omps":0,
			"peak":0,
			"size":0,
			"thld":500,
			"type":"std::shared_ptr<MediaFrame const>",
			"urn":"mngq:v=#default#app:s=stream:p=trs:r=encoder_opus_3",
			"watm":0
		},
		...
	]
}
```