### PR TITLE
Add feature for SRT push publisher

### DIFF
--- a/docs/push-publishing.md
+++ b/docs/push-publishing.md
@@ -1,6 +1,6 @@
 # Push Publishing (Beta)
 
-OvenMediaEngine supports **Push Publishing** function that can retransmit live streams to other systems. The protocol supported for retransmission uses RTMP or MPEGTS. Because, most services and products support this protocol. also, one output stream can be transmitted to multiple destinations at the same time. You can start and stop pushing the output stream through REST API. Note that the only codecs that can be retransmitted in RTMP and MPEGTS protocol are H264 and AAC.
+OvenMediaEngine supports **Push Publishing** function that can retransmit live streams to other systems. The protocol supported for retransmission uses SRT, RTMP or MPEGTS. Because, most services and products support this protocol. also, one output stream can be transmitted to multiple destinations at the same time. You can start and stop pushing the output stream through REST API. Note that the only codecs that can be retransmitted in RTMP and MPEGTS protocol are H264 and AAC.
 
 ## Configuration
 
@@ -25,7 +25,7 @@ To use RTMP Push Publishing, you need to declare the `<RTMPPush>` publisher in t
 
 To use MPEGTS Push Publishing, you need to declare the `<MPEGTSPush>` publisher in the configuration. There are no other detailed options.
 
-```markup
+```xml
 <Applications>
   <Application>
      ...
@@ -42,9 +42,30 @@ To use MPEGTS Push Publishing, you need to declare the `<MPEGTSPush>` publisher 
 Only H264 and AAC are supported codecs.
 {% endhint %}
 
+### SRTPush Publisher
+
+To use SRT Push Publishing, you need to declare the `<SRTPush>` publisher in the configuration. There are no other detailed options.
+
+```xml
+<Applications>
+  <Application>
+     ...
+    <Publishers>
+      ...
+      <SRTPush>
+      </SRTPush>
+    </Publishers>
+  </Application>
+</Applications>
+```
+
+{% hint style="info" %}
+Only H264 and AAC are supported codecs.
+{% endhint %}
+
 ### Start & Stop Push
 
-For control of push, use the REST API. RTMP, MPEGTS push can be requested based on the output stream name (specified in the JSON body), and you can selectively transfer all/some tracks. In addition, you must specify the URL and Stream Key of the external server to be transmitted. It can send multiple Pushes simultaneously for the same stream. If transmission is interrupted due to network or other problems, it automatically reconnects.
+For control of push, use the REST API. SRT, RTMP, MPEGTS push can be requested based on the output stream name (specified in the JSON body), and you can selectively transfer all/some tracks. In addition, you must specify the URL and Stream Key of the external server to be transmitted. It can send multiple Pushes simultaneously for the same stream. If transmission is interrupted due to network or other problems, it automatically reconnects.
 
 For how to use the API, please refer to the link below.
 

--- a/docs/rest-api/v1/virtualhost/application/push.md
+++ b/docs/rest-api/v1/virtualhost/application/push.md
@@ -2,7 +2,7 @@
 
 ## Start Push Publishing
 
-Start  push publishing the stream with RTMP or MPEG2-TS. If the requested stream does not exist on the server, this task is reserved. And when the stream is created, it automatically starts push publishing.
+Start  push publishing the stream with SRT, RTMP or MPEG2-TS. If the requested stream does not exist on the server, this task is reserved. And when the stream is created, it automatically starts push publishing.
 
 > ### Request
 
@@ -18,6 +18,48 @@ Authorization: Basic {credentials}
 # Authorization
     Credentials for HTTP Basic Authentication created with <AccessToken>
 ```
+
+#### Body : SRT
+
+```json
+{
+  "id": "{unique_push_id}",
+  "stream": {
+    "name": "{output_stream_name}",
+    "variantNames": []
+  },
+  "protocol": "srt",
+  "url": "srt://{host}[:port]?mode=caller&latency=120000&timeout=500000",
+  "streamKey": ""
+}
+
+# id (required)
+    unique ID to identify the task
+    
+# stream (required)
+    ## name (required)
+        output stream name
+        
+    ## variantNames (optional)
+        Array of track names to publsh. 
+        This value is Encodes.[Video|Audio|Data].Name in the OutputProfile
+        setting.
+        
+        If empty, all tracks will be sent.
+
+# protocol (required)
+    srt
+    
+# url (required) 
+    address of destination.
+    options can be set in query-string format.
+    
+# streamKey (optional)
+    not used with mpegts
+```
+{% hint style="info" %}
+In SRT Push Publisher, only the `caller` connection mode is supported.
+{% endhint %}
 
 #### Body : RTMP
 

--- a/src/projects/api_server/controllers/v1/vhosts/apps/app_actions_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/app_actions_controller.cpp
@@ -288,7 +288,9 @@ namespace api
 			}
 
 			auto push_protocol{push->GetProtocol().LowerCaseString()};
-			auto publisher_type{(push_protocol == "rtmp") ? PublisherType::RtmpPush : (push_protocol == "mpegts") ? PublisherType::MpegtsPush : PublisherType::Unknown};
+			auto publisher_type{(push_protocol == "rtmp") ? PublisherType::RtmpPush
+														: (push_protocol == "mpegts") ? PublisherType::MpegtsPush
+														: (push_protocol == "srt") ? PublisherType::SrtPush : PublisherType::Unknown};
 
 			if (publisher_type == PublisherType::Unknown)
 			{
@@ -357,7 +359,7 @@ namespace api
 			push->SetVhost(vhost->GetName().CStr());
 			push->SetApplication(app->GetName().GetAppName());
 
-			std::vector<PublisherType> publisher_types{PublisherType::RtmpPush, PublisherType::MpegtsPush};
+			std::vector<PublisherType> publisher_types{PublisherType::RtmpPush, PublisherType::MpegtsPush, PublisherType::SrtPush};
 			for (auto publisher_type : publisher_types)
 			{
 				auto publisher{

--- a/src/projects/base/common_types.h
+++ b/src/projects/base/common_types.h
@@ -86,6 +86,7 @@ enum class PublisherType : int8_t
 	Webrtc,
 	MpegtsPush,
 	RtmpPush,
+	SrtPush,
 	Hls,
 	Dash,
 	LLDash,
@@ -359,6 +360,8 @@ static ov::String StringFromPublisherType(const PublisherType &type)
 			return "MPEGTSPush";
 		case PublisherType::RtmpPush:
 			return "RTMPPush";
+		case PublisherType::SrtPush:
+			return "SRTPush";
 		case PublisherType::Hls:
 			return "HLS";
 		case PublisherType::Dash:

--- a/src/projects/config/items/virtual_hosts/applications/publishers/publishers.h
+++ b/src/projects/config/items/virtual_hosts/applications/publishers/publishers.h
@@ -15,6 +15,7 @@
 #include "ovt_publisher.h"
 #include "mpegtspush_publisher.h"
 #include "rtmppush_publisher.h"
+#include "srtpush_publisher.h"
 #include "thumbnail_publisher.h"
 #include "webrtc_publisher.h"
 #include "ll_hls_publisher.h"
@@ -42,7 +43,8 @@ namespace cfg
 							&_ovt_publisher,
 							&_file_publisher,
 							&_rtmppush_publisher,
-							&_thumbnail_publisher
+							&_thumbnail_publisher,
+							&_srtpush_publisher,
 						};
 					}
 
@@ -58,6 +60,7 @@ namespace cfg
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetFilePublisher, _file_publisher)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetRtmpPushPublisher, _rtmppush_publisher)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetThumbnailPublisher, _thumbnail_publisher)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetSrtPushPublisher, _srtpush_publisher)
 
 				protected:
 					void MakeList() override
@@ -75,6 +78,7 @@ namespace cfg
 						Register<Optional>({"FILE", "file"}, &_file_publisher);
 						Register<Optional>({"RTMPPush", "rtmpPush"}, &_rtmppush_publisher);
 						Register<Optional>({"Thumbnail", "thumbnail"}, &_thumbnail_publisher);
+						Register<Optional>({"SRTPush", "srtPush"}, &_srtpush_publisher);
 					}
 
 					int _app_worker_count = 1;
@@ -90,6 +94,7 @@ namespace cfg
 					OvtPublisher _ovt_publisher;
 					FilePublisher _file_publisher;
 					ThumbnailPublisher _thumbnail_publisher;
+					SrtPushPublisher _srtpush_publisher;
 				};
 			}  // namespace pub
 		}	   // namespace app

--- a/src/projects/config/items/virtual_hosts/applications/publishers/srtpush_publisher.h
+++ b/src/projects/config/items/virtual_hosts/applications/publishers/srtpush_publisher.h
@@ -1,0 +1,39 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "../../../common/cross_domain_support.h"
+#include "publisher.h"
+
+namespace cfg
+{
+	namespace vhost
+	{
+		namespace app
+		{
+			namespace pub
+			{
+				struct SrtPushPublisher : public Publisher
+				{
+				public:
+					PublisherType GetType() const override
+					{
+						return PublisherType::SrtPush;
+					}
+
+				protected:
+					void MakeList() override
+					{
+						Publisher::MakeList();
+					}
+				};
+			}  // namespace pub
+		}	   // namespace app
+	}		   // namespace vhost
+}  // namespace cfg

--- a/src/projects/main/AMS.mk
+++ b/src/projects/main/AMS.mk
@@ -9,6 +9,7 @@ LOCAL_STATIC_LIBRARIES := \
 	file_publisher \
 	mpegtspush_publisher \
 	rtmppush_publisher \
+	srtpush_publisher \
 	thumbnail_publisher \
 	ovt_provider \
 	rtmp_provider \

--- a/src/projects/main/main.cpp
+++ b/src/projects/main/main.cpp
@@ -135,6 +135,7 @@ int main(int argc, char *argv[])
 	INIT_MODULE(file_publisher, "File Publisher", pub::FilePublisher::Create(*server_config, media_router));
 	INIT_MODULE(mpegtspush_publisher, "MpegtsPush Publisher", MpegtsPushPublisher::Create(*server_config, media_router));
 	INIT_MODULE(rtmppush_publisher, "RtmpPush Publisher", RtmpPushPublisher::Create(*server_config, media_router));
+	INIT_MODULE(srtpush_publisher, "SrtPush Publisher", SrtPushPublisher::Create(*server_config, media_router));
 	INIT_MODULE(thumbnail_publisher, "Thumbnail Publisher", ThumbnailPublisher::Create(*server_config, media_router));
 
 	// Initialize Transcoder
@@ -197,6 +198,7 @@ int main(int argc, char *argv[])
 	RELEASE_MODULE(file_publisher, "File Publisher");
 	RELEASE_MODULE(mpegtspush_publisher, "MpegtsPush Publisher");
 	RELEASE_MODULE(rtmppush_publisher, "RtmpPush Publisher");
+	RELEASE_MODULE(srtpush_publisher, "SrtPush Publisher");
 	RELEASE_MODULE(thumbnail_publisher, "Thumbnail Publisher");
 
 	RELEASE_MODULE(media_router, "MediaRouter");

--- a/src/projects/publishers/mpegtspush/mpegtspush_application.h
+++ b/src/projects/publishers/mpegtspush/mpegtspush_application.h
@@ -12,10 +12,10 @@ class MpegtsPushApplication : public pub::PushApplication
 public:
 	static std::shared_ptr<MpegtsPushApplication> Create(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info);
 	MpegtsPushApplication(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info);
-	~MpegtsPushApplication() final;
+	~MpegtsPushApplication();
+	bool Start() override;
 
 private:
-	bool Start() override;
 	bool Stop() override;
 
 	// Application Implementation
@@ -33,6 +33,6 @@ public:
 	virtual std::shared_ptr<ov::Error> PushStop(const std::shared_ptr<info::Push> &push) override;
 	virtual std::shared_ptr<ov::Error> GetPushes(const std::shared_ptr<info::Push> push, std::vector<std::shared_ptr<info::Push>> &results) override;
 
-private:
+protected:
 	MpegtsPushUserdataSets _userdata_sets;
 };

--- a/src/projects/publishers/publishers.h
+++ b/src/projects/publishers/publishers.h
@@ -15,4 +15,5 @@
 #include "./file/file_publisher.h"
 #include "./mpegtspush/mpegtspush_publisher.h"
 #include "./rtmppush/rtmppush_publisher.h"
+#include "./srtpush/srtpush_publisher.h"
 #include "./thumbnail/thumbnail_publisher.h"

--- a/src/projects/publishers/srtpush/AMS.mk
+++ b/src/projects/publishers/srtpush/AMS.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call get_local_path)
+include $(DEFAULT_VARIABLES)
+
+LOCAL_TARGET := srtpush_publisher
+
+$(call add_pkg_config,srt)
+
+include $(BUILD_STATIC_LIBRARY)

--- a/src/projects/publishers/srtpush/srtpush_application.cpp
+++ b/src/projects/publishers/srtpush/srtpush_application.cpp
@@ -1,0 +1,112 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "srtpush_application.h"
+
+#include "srtpush_private.h"
+
+#define SRT_PUSH_PUBLISHER_ERROR_DOMAIN "SRTPushPublisher"
+
+std::shared_ptr<SrtPushApplication> SrtPushApplication::Create(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info)
+{
+	auto application = std::make_shared<SrtPushApplication>(publisher, application_info);
+	application->Start();
+	return application;
+}
+
+SrtPushApplication::SrtPushApplication(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info)
+	: MpegtsPushApplication(publisher, application_info)
+{
+}
+
+SrtPushApplication::~SrtPushApplication()
+{
+}
+
+std::shared_ptr<ov::Error> SrtPushApplication::PushStart(const std::shared_ptr<info::Push> &push)
+{
+	// Validation check for required parameters
+	if (push->GetId().IsEmpty() == true ||
+		push->GetStreamName().IsEmpty() == true ||
+		push->GetUrl().IsEmpty() == true ||
+		push->GetProtocol().IsEmpty() == true)
+	{
+		ov::String error_message = "There is no required parameter [";
+
+		if (push->GetId().IsEmpty() == true)
+		{
+			error_message += " id";
+		}
+
+		if (push->GetStreamName().IsEmpty() == true)
+		{
+			error_message += " stream.name";
+		}
+
+		if (push->GetUrl().IsEmpty() == true)
+		{
+			error_message += " url";
+		}
+
+		if (push->GetProtocol().IsEmpty() == true)
+		{
+			error_message += " protocol";
+		}
+
+		error_message += "]";
+		return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::FailureInvalidParameter, error_message);
+	}
+
+	// Validation check for duplicate id
+	if (_userdata_sets.GetByKey(push->GetId()) != nullptr)
+	{
+		ov::String error_message = "Duplicate ID already exists";
+		return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::FailureDuplicateKey, error_message);
+	}
+
+	// Validation check for protocol scheme
+	if (push->GetUrl().HasPrefix("srt://") == false)
+	{
+		ov::String error_message = "Unsupported protocol";
+
+		return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::FailureInvalidParameter, error_message);
+	}
+
+	// Remove suffix '/" of srt url
+	while (push->GetUrl().HasSuffix("/"))
+	{
+		ov::String tmp_url = push->GetUrl().Substring(0, push->GetUrl().IndexOfRev('/'));
+		push->SetUrl(tmp_url);
+	}
+
+	// Validation check for srt's connection mode.
+	auto srt_url = ov::Url::Parse(push->GetUrl());
+	if (srt_url == nullptr)
+	{
+		logte("Could not parse url: %s", push->GetUrl().CStr());
+		ov::String error_message = "Could not parse url";
+		return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::FailureInvalidParameter, error_message);
+	}
+
+	auto connection_mode = srt_url->GetQueryValue("mode");
+	if (!connection_mode.IsEmpty() &&
+		connection_mode != "caller")
+	{
+		ov::String error_message = "Unsupported connection mode";
+		return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::FailureInvalidParameter, error_message);
+	}
+
+	push->SetEnable(true);
+	push->SetRemove(false);
+
+	_userdata_sets.Set(push);
+
+	SessionUpdateByUser();
+
+	return ov::Error::CreateError(SRT_PUSH_PUBLISHER_ERROR_DOMAIN, ErrorCode::Success, "Success");
+}

--- a/src/projects/publishers/srtpush/srtpush_application.h
+++ b/src/projects/publishers/srtpush/srtpush_application.h
@@ -1,0 +1,22 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "../mpegtspush/mpegtspush_application.h"
+
+class SrtPushApplication : public MpegtsPushApplication
+{
+public:
+	static std::shared_ptr<SrtPushApplication> Create(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info);
+	SrtPushApplication(const std::shared_ptr<pub::Publisher> &publisher, const info::Application &application_info);
+	~SrtPushApplication() override;
+
+public:
+	virtual std::shared_ptr<ov::Error> PushStart(const std::shared_ptr<info::Push> &push) override;
+};

--- a/src/projects/publishers/srtpush/srtpush_private.h
+++ b/src/projects/publishers/srtpush/srtpush_private.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define OV_LOG_TAG                      "SRTPush"

--- a/src/projects/publishers/srtpush/srtpush_publisher.cpp
+++ b/src/projects/publishers/srtpush/srtpush_publisher.cpp
@@ -1,0 +1,86 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "srtpush_publisher.h"
+
+#include "srtpush_application.h"
+#include "srtpush_private.h"
+
+#define UNUSED(expr)  \
+	do                \
+	{                 \
+		(void)(expr); \
+	} while (0)
+
+std::shared_ptr<SrtPushPublisher> SrtPushPublisher::Create(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router)
+{
+	auto obj = std::make_shared<SrtPushPublisher>(server_config, router);
+
+	if (!obj->Start())
+	{
+		logte("An error occurred while creating SrtPushPublisher");
+		return nullptr;
+	}
+
+	return obj;
+}
+
+SrtPushPublisher::SrtPushPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router)
+	: Publisher(server_config, router)
+{
+	logtd("SrtPushPublisher has been create");
+}
+
+SrtPushPublisher::~SrtPushPublisher()
+{
+	logtd("SrtPushPublisher has been terminated finally");
+}
+
+bool SrtPushPublisher::Start()
+{
+	return Publisher::Start();
+}
+
+bool SrtPushPublisher::Stop()
+{
+	return Publisher::Stop();
+}
+
+bool SrtPushPublisher::OnCreateHost(const info::Host &host_info)
+{
+	return true;
+}
+
+bool SrtPushPublisher::OnDeleteHost(const info::Host &host_info)
+{
+	return true;
+}
+
+std::shared_ptr<pub::Application> SrtPushPublisher::OnCreatePublisherApplication(const info::Application &application_info)
+{
+	if (IsModuleAvailable() == false)
+	{
+		return nullptr;
+	}
+
+	return SrtPushApplication::Create(SrtPushPublisher::GetSharedPtrAs<pub::Publisher>(), application_info);
+}
+
+bool SrtPushPublisher::OnDeletePublisherApplication(const std::shared_ptr<pub::Application> &application)
+{
+	auto srtpush_application = std::static_pointer_cast<SrtPushApplication>(application);
+	if (srtpush_application == nullptr)
+	{
+		logte("Could not found file application. app:%s", srtpush_application->GetName().CStr());
+		return false;
+	}
+
+	// Applications and child streams must be terminated.
+
+	return true;
+}

--- a/src/projects/publishers/srtpush/srtpush_publisher.h
+++ b/src/projects/publishers/srtpush/srtpush_publisher.h
@@ -1,0 +1,42 @@
+//=============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Gilhoon Choi
+//  Copyright (c) 2023 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "base/info/push.h"
+#include "base/publisher/publisher.h"
+
+class SrtPushPublisher : public pub::Publisher
+{
+public:
+	static std::shared_ptr<SrtPushPublisher> Create(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router);
+
+	SrtPushPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouteInterface> &router);
+	~SrtPushPublisher() override;
+	bool Stop() override;
+
+private:
+	bool Start() override;
+
+	//--------------------------------------------------------------------
+	// Implementation of Publisher
+	//--------------------------------------------------------------------
+	PublisherType GetPublisherType() const override
+	{
+		return PublisherType::SrtPush;
+	}
+	const char *GetPublisherName() const override
+	{
+		return "SRTPushPublisher";
+	}
+
+	bool OnCreateHost(const info::Host &host_info) override;
+	bool OnDeleteHost(const info::Host &host_info) override;
+	std::shared_ptr<pub::Application> OnCreatePublisherApplication(const info::Application &application_info) override;
+	bool OnDeletePublisherApplication(const std::shared_ptr<pub::Application> &application) override;
+};


### PR DESCRIPTION
The purpose of this P.R. is to add the push publisher feature for SRT re-streaming.

In SRT Push Publisher, only the `caller` connection mode is supported.
Options can be set in query-string format in the `url`.

**Configuration**
```
<Applications>
  <Application>
     ...
    <Publishers>
      ...
      <SRTPush>
      </SRTPush>
    </Publishers>
  </Application>
</Applications>
```

**API**
```
/v1/vhosts/{vhost}/apps/{app}:startPush

{
  "id": "{unique_push_id}",
  "stream": {
    "name": "{output_stream_name}",
    "variantNames": []
  },
  "protocol": "srt",
  "url": "srt://{host}[:port]?mode=caller&latency=120000&timeout=500000",
  "streamKey": ""
}
```