### PR TITLE
Add x264 to enable 10-bit high422 WebRTC and HLS to Chrome

### DIFF
--- a/docs/transcoding/README.md
+++ b/docs/transcoding/README.md
@@ -20,8 +20,8 @@ OvenMediaEngine has a built-in live transcoder. The live transcoder can decode t
 |       |       | h264\_openh264                                                       |
 |       |       | h264\_nvenc                                                          |
 |       |       | h264\_qsv                                                            |
+|       |       | h264\_x264 _<mark style="color:blue;">(10-bit high422)</mark>_       |
 |       |       | h264\_beamr _<mark style="color:blue;">(Enterprise Only)</mark>_     |
-|       |       | h264\_x264 _<mark style="color:blue;">(Louper specific)</mark>_      |
 | Audio | AAC   | aac                                                                  |
 |       | Opus  | opus                                                                 |
 | Image | JPEG  | jpeg                                                                 |

--- a/docs/transcoding/README.md
+++ b/docs/transcoding/README.md
@@ -21,6 +21,7 @@ OvenMediaEngine has a built-in live transcoder. The live transcoder can decode t
 |       |       | h264\_nvenc                                                          |
 |       |       | h264\_qsv                                                            |
 |       |       | h264\_beamr _<mark style="color:blue;">(Enterprise Only)</mark>_     |
+|       |       | h264\_x264 _<mark style="color:blue;">(Louper specific)</mark>_      |
 | Audio | AAC   | aac                                                                  |
 |       | Opus  | opus                                                                 |
 | Image | JPEG  | jpeg                                                                 |

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -309,144 +309,30 @@
 					<!-- Application type (live/vod) -->
 					<Type>live</Type>
 					<OutputProfiles>
-						<!-- Enable this configuration if you want to hardware acceleration using GPU -->
-						<HardwareAcceleration>false</HardwareAcceleration>
 						<OutputProfile>
 							<Name>bypass_stream</Name>
-							<OutputStreamName>${OriginStreamName}</OutputStreamName>
-
-							<!-- 
-							You can provide ABR with Playlist. Currently, ABR is supported in LLHLS and WebRTC.
-							
-							<Playlist>
-								<Name>Paid</Name>
-								You can play this playlist with 
-								LLHLS : http[s]://<domain>[:port]/<app>/<stream>/<FileName>.m3u8 
-								WebRTC : ws[s]://<domain>[:port]/<app>/<stream>/<FileName>
-								Note that the keywords "playlist" and "chunklist" MUST NOT be included in FileName.
-								<FileName>premium</FileName>
-
-								Options is optional. 
-								<Options>
-									WebRtcAutoAbr : Default value is true
-									<WebRtcAutoAbr>true</WebRtcAutoAbr> 
-								</Options>
-								
-								<Rendition>
-									<Name>bypass</Name>
-									<Video>bypass_video</Video>
-									<Audio>bypass_audio</Audio>
-								</Rendition>
-								<Rendition>
-									<Name>480p</Name>
-									<Video>480p</Video>
-									<Audio>bypass_audio</Audio>
-								</Rendition>
-								<Rendition>
-									<Name>720p</Name>
-									<Video>720p</Video>
-									<Audio>bypass_audio</Audio>
-								</Rendition>
-							</Playlist>
-							<Playlist>
-								<Name>free</Name>
-								<FileName>free</FileName>
-								<Rendition>
-									<Name>720p</Name>
-									<Video>720p</Video>
-									<Audio>bypass_audio</Audio>
-								</Rendition>
-							</Playlist>
-							-->
-
+							<OutputStreamName>x_${OriginStreamName}</OutputStreamName>
 							<Encodes>
-								<Video>
-									<Name>bypass_video</Name>
+								<Audio>
 									<Bypass>true</Bypass>
+								</Audio>
+								<!-- <Video>
+									<Bypass>true</Bypass>
+								</Video> -->
+								<Video>
+									<!-- vp8, h264 -->
+									<Codec>h264_x264</Codec>
+									<Width>640</Width>
+									<Height>480</Height>
+									<Bitrate>1000000</Bitrate>
+									<Framerate>30.0</Framerate>
 								</Video>
 								<Audio>
-									<Name>aac_audio</Name>
-									<Codec>aac</Codec>
-									<Bitrate>128000</Bitrate>
-									<Samplerate>48000</Samplerate>
-									<Channel>2</Channel>
-									<BypassIfMatch>
-										<Codec>eq</Codec>
-									</BypassIfMatch>
-								</Audio>
-								<Audio>
-									<Name>opus_audio</Name>
 									<Codec>opus</Codec>
 									<Bitrate>128000</Bitrate>
 									<Samplerate>48000</Samplerate>
 									<Channel>2</Channel>
-									<BypassIfMatch>
-										<Codec>eq</Codec>
-									</BypassIfMatch>
 								</Audio>
-								<!--
-								<Video>
-									<Name>video_1280</Name>
-									<Codec>h264</Codec>
-									<Bitrate>5024000</Bitrate>
-									<Width>1920</Width>
-									<Height>1280</Height>
-									<Framerate>30</Framerate>
-									<KeyFrameInterval>30</KeyFrameInterval>
-									<BFrames>0</BFrames>
-									<Preset>faster</Preset>
-								</Video>
-								<Video>
-									<Name>video_720</Name>
-									<Codec>h264</Codec>
-									<Bitrate>2024000</Bitrate>
-									<Width>1280</Width>
-									<Height>720</Height>
-									<Framerate>30</Framerate>
-									<KeyFrameInterval>30</KeyFrameInterval>
-									<BFrames>0</BFrames>									
-									<Preset>faster</Preset>
-								</Video>	
-								<Audio>
-									<Name>bypass_audio</Name>
-									<Bypass>true</Bypass>
-								</Audio>																
-								-->
-								<!-- 
-									 If all conditions of BypassIfMatch are matched, bypass is used without encoding.
-									 [Options] 
-									   eq: euqal to
-									   lte: less than or equal to
-									   gte: greater than or equal to
-
-								<Video>
-									<Name>conditional_video_encoding</Name>
-									<Codec>h264</Codec>
-									<Bitrate>2024000</Bitrate>
-									<Width>1280</Width>
-									<Height>720</Height>
-									<Framerate>30</Framerate>
-									<BypassIfMatch>
-										<Codec>eq</Codec>
-										<Framerate>lte</Framerate>
-										<Width>lte</Width>
-										<Height>lte</Height>
-										<SAR>eq</SAR>
-									</BypassIfMatch>									
-								</Video>
-								<Audio>
-									<Name>conditional_audio_encoding</Name>
-									<Codec>aac</Codec>
-									<Bitrate>128000</Bitrate>
-									<Samplerate>48000</Samplerate>
-									<Channel>2</Channel>
-									<BypassIfMatch>
-										<Codec>eq</Codec>
-										<Samplerate>lte</Samplerate>
-										<Channel>eq</Channel>
-									</BypassIfMatch>
-								</Audio>																			
-								-->
 							</Encodes>
 						</OutputProfile>
 					</OutputProfiles>

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -15,7 +15,7 @@
 	This is useful when OME cannot obtain a public IP from an interface, such as AWS or docker environment. 
 	If this is successful, you can use ${PublicIP} in your settings.
 	-->
-	<StunServer>stun.ovenmediaengine.com:13478</StunServer>
+	<StunServer>stun.l.google.com:19302</StunServer>
 
 	<Modules>
 		<!-- 

--- a/misc/conf_examples/Server.xml
+++ b/misc/conf_examples/Server.xml
@@ -86,7 +86,7 @@
 				<IceCandidates>
 					<!-- Uncomment the line below to use IPv6 ICE Candidate -->
 					<!-- <IceCandidate>[::]:10000-10004/udp</IceCandidate> -->
-					<IceCandidate>*:10000-10004/udp</IceCandidate>
+					<IceCandidate>*:10000-10200/udp</IceCandidate>
 
 					<!-- Uncomment the line below to use a link local address when specifying an address with IPv6 wildcard (::) -->
 					<!-- <EnableLinkLocalAddress>true</EnableLinkLocalAddress> -->
@@ -128,7 +128,7 @@
 				<IceCandidates>
 					<!-- Uncomment the line below to use IPv6 ICE Candidate -->
 					<!-- <IceCandidate>[::]:10000-10004/udp</IceCandidate> -->
-					<IceCandidate>*:10000-10004/udp</IceCandidate>
+					<IceCandidate>*:10000-10200/udp</IceCandidate>
 					
 					<!-- Uncomment the line below to use a link local address when specifying an address with IPv6 wildcard (::) -->
 					<!-- <EnableLinkLocalAddress>true</EnableLinkLocalAddress> -->

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -8,6 +8,7 @@ OPENSSL_VERSION=3.0.7
 SRTP_VERSION=2.4.2
 SRT_VERSION=1.5.2
 OPUS_VERSION=1.3.1
+X264_VERSION=20190513-2245-stable
 VPX_VERSION=1.11.0
 FDKAAC_VERSION=2.0.2
 NASM_VERSION=2.15.05
@@ -94,6 +95,19 @@ install_libopus()
     sudo rm -rf ${PREFIX}/share && \
     rm -rf ${DIR}) || fail_exit "opus"
 }
+
+install_libx264()
+{
+    (DIR=${TEMP_PATH}/x264 && \
+    mkdir -p ${DIR} && \
+    cd ${DIR} && \
+    curl -sLf https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | tar -jx --strip-components=1 && \
+    ./configure --prefix="${PREFIX}" --enable-shared --enable-pic --disable-cli && \
+    make -j$(nproc) && \
+    sudo make install && \
+    rm -rf ${DIR}) || fail_exit "x264"
+}
+
 
 install_libopenh264()
 {
@@ -281,14 +295,16 @@ install_ffmpeg()
     # Build & Install
     (cd ${DIR} && PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${PREFIX}/lib64/pkgconfig:${PREFIX}/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH} ./configure \
     --prefix="${PREFIX}" \
+    --enable-gpl \
+    --enable-nonfree \
     --extra-cflags="-I${PREFIX}/include ${ADDI_CFLAGS}"  \
     --extra-ldflags="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib ${ADDI_LDFLAGS}" \
     --extra-libs=-ldl ${ADDI_EXTRA_LIBS} \
     ${ADDI_LICENSE} \
     --disable-everything --disable-programs --disable-avdevice --disable-dct --disable-dwt --disable-lsp --disable-lzo --disable-rdft --disable-faan --disable-pixelutils \
-    --enable-shared --enable-zlib --enable-libopus --enable-libvpx --enable-libfdk_aac --enable-libopenh264 --enable-openssl --enable-network --enable-libsrt ${ADDI_LIBS} \
+    --enable-shared --enable-zlib --enable-libopus --enable-libvpx --enable-libfdk_aac --enable-libx264 --enable-libopenh264 --enable-openssl --enable-network --enable-libsrt ${ADDI_LIBS} \
     ${ADDI_HWACCEL} \
-    --enable-encoder=libvpx_vp8,libopus,libfdk_aac,libopenh264,mjpeg,png${ADDI_ENCODER} \
+    --enable-encoder=libx266,libvpx_vp8,libopus,libfdk_aac,libopenh264,mjpeg,png${ADDI_ENCODER} \
     --enable-decoder=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8${ADDI_DECODER} \
     --enable-parser=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8 \
     --enable-protocol=tcp,udp,rtp,file,rtmp,tls,rtmps,libsrt \
@@ -492,6 +508,7 @@ install_openssl
 install_libsrtp
 install_libsrt
 install_libopus
+install_libx264
 install_libopenh264
 install_libvpx
 install_fdk_aac

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -304,7 +304,7 @@ install_ffmpeg()
     --disable-everything --disable-programs --disable-avdevice --disable-dct --disable-dwt --disable-lsp --disable-lzo --disable-rdft --disable-faan --disable-pixelutils \
     --enable-shared --enable-zlib --enable-libopus --enable-libvpx --enable-libfdk_aac --enable-libx264 --enable-libopenh264 --enable-openssl --enable-network --enable-libsrt ${ADDI_LIBS} \
     ${ADDI_HWACCEL} \
-    --enable-encoder=libx266,libvpx_vp8,libopus,libfdk_aac,libopenh264,mjpeg,png${ADDI_ENCODER} \
+    --enable-encoder=libvpx_vp8,libopus,libfdk_aac,libopenh264,libx264,mjpeg,png${ADDI_ENCODER} \
     --enable-decoder=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8${ADDI_DECODER} \
     --enable-parser=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8 \
     --enable-protocol=tcp,udp,rtp,file,rtmp,tls,rtmps,libsrt \

--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -98,6 +98,7 @@ namespace cmn
 		DEFAULT,
 		OPENH264,
 		BEAMR,
+		X264,
 		NVENC,
 		QSV,
 		XMA,
@@ -234,6 +235,10 @@ namespace cmn
 		{
 			return cmn::MediaCodecLibraryId::BEAMR;
 		}
+		else if (name.HasSuffix("_X264"))
+		{
+			return cmn::MediaCodecLibraryId::X264;
+		}
 		else if (name.HasSuffix("_NVENC"))
 		{
 			return cmn::MediaCodecLibraryId::NVENC;
@@ -268,6 +273,8 @@ namespace cmn
 				return "OpenH264";
 			case cmn::MediaCodecLibraryId::BEAMR:
 				return "Beamr";
+			case cmn::MediaCodecLibraryId::X264:
+				return "x264";
 			case cmn::MediaCodecLibraryId::NVENC:
 				return "nvenc";
 			case cmn::MediaCodecLibraryId::QSV:
@@ -323,6 +330,7 @@ namespace cmn
 		if (name == "H264" ||
 			name == "H264_OPENH264" ||
 			name == "H264_BEAMR" ||
+			name == "H264_X264" ||
 			name == "H264_NVENC" ||
 			name == "H264_QSV" ||
 			name == "H264_XMA")

--- a/src/projects/modules/sdp/media_description.h
+++ b/src/projects/modules/sdp/media_description.h
@@ -96,7 +96,7 @@ public:
 	bool EnableRtcpFb(uint8_t id, const ov::String &type, bool on);
 	void EnableRtcpFb(uint8_t id, const PayloadAttr::RtcpFbType &type, bool on);
 
-	// a=fmtp:96 packetization-mode=1;profile-level-id=42e01f;level-asymmetry-allowed=1
+	// a=fmtp:96 packetization-mode=1;profile-level-id=f4001f;level-asymmetry-allowed=1
 	// a=fmtp:96 profile-level-id=1;moe=AAC-hbr;sizelength=13
 	void SetFmtp(uint8_t id, const ov::String &fmtp);
 

--- a/src/projects/providers/webrtc/webrtc_application.cpp
+++ b/src/projects/providers/webrtc/webrtc_application.cpp
@@ -101,7 +101,7 @@ namespace pvd
 		// H264
 		payload = std::make_shared<PayloadAttr>();
 		payload->SetRtpmap(payload_type_num++, "H264", 90000);
-		payload->SetFmtp(ov::String::FormatString("packetization-mode=1;profile-level-id=%x;level-asymmetry-allowed=1",	0x42e01f));
+		payload->SetFmtp(ov::String::FormatString("packetization-mode=1;profile-level-id=%x;level-asymmetry-allowed=1",	0xf4001f));
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::CcmFir, true);
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::NackPli, true);
 		payload->EnableRtcpFb(PayloadAttr::RtcpFbType::TransportCc, true);

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -560,7 +560,7 @@ std::shared_ptr<PayloadAttr> RtcStream::MakePayloadAttr(const std::shared_ptr<co
 				//(Getroot's Note) The software decoder of Firefox or Chrome cannot play when 64001f (High, 3.1) stream is input. 
 				// However, when I put the fake information of 42e01f in FMTP, I confirmed that both Firefox and Chrome play well (high profile, but stream without B-Frame). 
 				// I thought it would be better to put 42e01f in fmtp than put the correct value, so I decided to put fake information.
-				profile_string = "42e01f";
+				profile_string = "f4001f";
 
 				payload->SetFmtp(ov::String::FormatString(
 						// NonInterleaved => packetization-mode=1

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
@@ -21,6 +21,8 @@ bool EncoderAVC::SetCodecParams()
 {
 	_codec_context->framerate = ::av_d2q((GetRefTrack()->GetFrameRate() > 0) ? GetRefTrack()->GetFrameRate() : GetRefTrack()->GetEstimateFrameRate(), AV_TIME_BASE);
 	_codec_context->bit_rate = _codec_context->rc_min_rate = _codec_context->rc_max_rate = GetRefTrack()->GetBitrate();
+	// testing line
+	// cam _codec_context->bit_rate = _codec_context->rc_min_rate = _codec_context->rc_max_rate = 100000;
 	_codec_context->rc_buffer_size = static_cast<int>(_codec_context->bit_rate / 2);
 	_codec_context->sample_aspect_ratio = ::av_make_q(1, 1);
 

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
@@ -83,7 +83,8 @@ bool EncoderAVC::SetCodecParams()
 	}
 
 	// Profile
-	::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	//::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+	::av_opt_set(_codec_context->priv_data, "profile", "high422", 0);
 
 	// Tune
 	::av_opt_set(_codec_context->priv_data, "tune", "zerolatency", 0);

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
@@ -1,0 +1,363 @@
+//==============================================================================
+//
+//  Transcode
+//
+//  Created by Kwon Keuk Han
+//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include "encoder_avc_x264.h"
+
+#include <unistd.h>
+
+#include "../../transcoder_private.h"
+
+// EncoderAVC::~EncoderAVC()
+// {
+// 	Stop();
+// }
+
+bool EncoderAVC::SetCodecParams()
+{
+	_codec_context->framerate = ::av_d2q((GetRefTrack()->GetFrameRate() > 0) ? GetRefTrack()->GetFrameRate() : GetRefTrack()->GetEstimateFrameRate(), AV_TIME_BASE);
+	_codec_context->bit_rate = _codec_context->rc_min_rate = _codec_context->rc_max_rate = GetRefTrack()->GetBitrate();
+	_codec_context->rc_buffer_size = static_cast<int>(_codec_context->bit_rate / 2);
+	_codec_context->sample_aspect_ratio = ::av_make_q(1, 1);
+
+	// From avcodec.h:
+	// For some codecs, the time base is closer to the field rate than the frame rate.
+	// Most notably, H.264 and MPEG-2 specify time_base as half of frame duration
+	// if no telecine is used ...
+	// Set to time_base ticks per frame. Default 1, e.g., H.264/MPEG-2 set it to 2.
+	_codec_context->ticks_per_frame = 2;
+
+	// From avcodec.h:
+	// For fixed-fps content, timebase should be 1/framerate and timestamp increments should be identically 1.
+	// This often, but not always is the inverse of the frame rate or field rate for video. 1/time_base is not the average frame rate if the frame rate is not constant.
+	_codec_context->time_base = ::av_inv_q(::av_mul_q(_codec_context->framerate, (AVRational){_codec_context->ticks_per_frame, 1}));
+
+	_codec_context->max_b_frames = 0;
+	_codec_context->pix_fmt = (AVPixelFormat)GetSupportedFormat();
+	_codec_context->width = GetRefTrack()->GetWidth();
+	_codec_context->height = GetRefTrack()->GetHeight();
+	
+	// Set KeyFrame Interval
+	_codec_context->gop_size = (GetRefTrack()->GetKeyFrameInterval() == 0) ? (_codec_context->framerate.num / _codec_context->framerate.den) : GetRefTrack()->GetKeyFrameInterval();
+	
+	// -1(Default) => FFMIN(FFMAX(4, av_cpu_count() / 3), 8) 
+	// 0 => Auto
+	// >1 => Set
+	_codec_context->thread_count = GetRefTrack()->GetThreadCount() < 0 ? FFMIN(FFMAX(4, av_cpu_count() / 3), 8) : GetRefTrack()->GetThreadCount();
+	_codec_context->slices = _codec_context->thread_count; //openh264
+	
+	//_codec_context->thread_count = FFMAX(4, av_cpu_count() / 3);
+
+	// Preset
+	auto preset = GetRefTrack()->GetPreset().LowerCaseString();
+	if (preset == "slower")
+	{
+		::av_opt_set(_codec_context->priv_data, "preset", "slower", 0);
+	}
+	else if (preset == "slow")
+	{
+		::av_opt_set(_codec_context->priv_data, "preset", "slow", 0);
+	}
+	else if (preset == "medium")
+	{
+		::av_opt_set(_codec_context->priv_data, "preset", "medium", 0);
+	}
+	else if (preset == "fast")
+	{
+		::av_opt_set(_codec_context->priv_data, "preset", "fast", 0);
+	}
+	else if (preset == "faster")
+	{
+		::av_opt_set(_codec_context->priv_data, "preset", "faster", 0);
+	}
+	else
+	{
+		// Default
+		::av_opt_set(_codec_context->priv_data, "preset", "faster", 0);
+	}
+
+	// Profile
+	::av_opt_set(_codec_context->priv_data, "profile", "baseline", 0);
+
+	// Tune
+	::av_opt_set(_codec_context->priv_data, "tune", "zerolatency", 0);
+
+	// Remove the sliced-thread option from encoding delay. Browser compatibility in MAC environment
+	::av_opt_set(_codec_context->priv_data, "x264opts", "bframes=0:sliced-threads=0:b-adapt=1:no-scenecut:keyint=30:min-keyint=30", 0);
+
+	return true;
+}
+
+// Notes.
+//
+// - B-frame must be disabled. because, WEBRTC does not support B-Frame.
+//
+bool EncoderAVC::Configure(std::shared_ptr<MediaTrack> context)
+{
+	if (TranscodeEncoder::Configure(context) == false)
+	{
+		return false;
+	}
+
+	auto codec_id = GetCodecID();
+
+	//const AVCodec *codec = ::avcodec_find_encoder(codec_id);
+	AVCodec *codec = ::avcodec_find_encoder_by_name("libx264");
+	if (codec == nullptr)
+	{
+		logte("Could not find encoder: %d (%s)", codec_id, ::avcodec_get_name(codec_id));
+		return false;
+	}
+
+	_codec_context = ::avcodec_alloc_context3(codec);
+	if (_codec_context == nullptr)
+	{
+		logte("Could not allocate codec context for %s (%d)", ::avcodec_get_name(codec_id), codec_id);
+		return false;
+	}
+
+	if (SetCodecParams() == false)
+	{
+		logte("Could not set codec parameters for %s (%d)", ::avcodec_get_name(codec_id), codec_id);
+		return false;
+	}
+
+	if (::avcodec_open2(_codec_context, codec, nullptr) < 0)
+	{
+		logte("Could not open codec: %s (%d)", ::avcodec_get_name(codec_id), codec_id);
+		return false;
+	}
+
+	// Generates a thread that reads and encodes frames in the input_buffer queue and places them in the output queue.
+	try
+	{
+		_kill_flag = false;
+
+		_codec_thread = std::thread(&TranscodeEncoder::CodecThread, this);
+		pthread_setname_np(_codec_thread.native_handle(), ov::String::FormatString("Enc%s", avcodec_get_name(GetCodecID())).CStr());
+	}
+	catch (const std::system_error &e)
+	{
+		logte("Failed to start encoder thread.");
+		_kill_flag = true;
+
+		return false;
+	}
+
+	return true;
+}
+
+// void EncoderAVC::Stop()
+// {
+// 	_kill_flag = true;
+
+// 	_input_buffer.Stop();
+// 	_output_buffer.Stop();
+
+// 	if (_thread_work.joinable())
+// 	{
+// 		_thread_work.join();
+// 		logtd("AVC encoder thread has ended.");
+// 	}
+// }
+
+//old 2021 model -cam
+#if 0
+void EncoderAVC::ThreadEncode()
+{
+	while (!_kill_flag)
+	{
+		auto obj = _input_buffer.Dequeue();
+		if (obj.has_value() == false)
+			continue;
+
+		auto frame = std::move(obj.value());
+
+		///////////////////////////////////////////////////
+		// Request frame encoding to codec
+		///////////////////////////////////////////////////
+
+		_frame->format = frame->GetFormat();
+		_frame->nb_samples = 1;
+		_frame->pts = frame->GetPts();
+		// The encoder will not pass this duration
+		_frame->pkt_duration = frame->GetDuration();
+
+		_frame->width = frame->GetWidth();
+		_frame->height = frame->GetHeight();
+		_frame->linesize[0] = frame->GetStride(0);
+		_frame->linesize[1] = frame->GetStride(1);
+		_frame->linesize[2] = frame->GetStride(2);
+
+		if (::av_frame_get_buffer(_frame, 32) < 0)
+		{
+			logte("Could not allocate the video frame data");
+			break;
+		}
+
+		if (::av_frame_make_writable(_frame) < 0)
+		{
+			logte("Could not make sure the frame data is writable");
+			break;
+		}
+
+		::memcpy(_frame->data[0], frame->GetBuffer(0), frame->GetBufferSize(0));
+		::memcpy(_frame->data[1], frame->GetBuffer(1), frame->GetBufferSize(1));
+		::memcpy(_frame->data[2], frame->GetBuffer(2), frame->GetBufferSize(2));
+
+		int ret = ::avcodec_send_frame(_codec_context, _frame);
+		::av_frame_unref(_frame);
+
+		if (ret < 0)
+		{
+			logte("Error sending a frame for encoding : %d", ret);
+		}
+
+		///////////////////////////////////////////////////
+		// The encoded packet is taken from the codec.
+		///////////////////////////////////////////////////
+		while (true)
+		{
+			// Check frame is availble
+			int ret = ::avcodec_receive_packet(_codec_context, _packet);
+
+			if (ret == AVERROR(EAGAIN))
+			{
+				// More packets are needed for encoding.
+				break;
+			}
+			else if (ret == AVERROR_EOF)
+			{
+				logte("Error receiving a packet for decoding : AVERROR_EOF");
+				break;
+			}
+			else if (ret < 0)
+			{
+				logte("Error receiving a packet for decoding : %d", ret);
+				break;
+			}
+			else
+			{
+				// Encoded packet is ready
+				auto packet_buffer = std::make_shared<MediaPacket>(
+					0,
+					cmn::MediaType::Video,
+					0,
+					_packet->data,
+					_packet->size,
+					_packet->pts,
+					_packet->dts,
+					-1L,
+					(_packet->flags & AV_PKT_FLAG_KEY) ? MediaPacketFlag::Key : MediaPacketFlag::NoFlag);
+
+				if (packet_buffer == nullptr)
+				{
+					logte("Could not allocate the media packet");
+					break;
+				}
+
+				packet_buffer->SetBitstreamFormat(cmn::BitstreamFormat::H264_ANNEXB);
+				packet_buffer->SetPacketType(cmn::PacketType::NALU);
+
+				::av_packet_unref(_packet);
+
+				SendOutputBuffer(std::move(packet_buffer));
+			}
+		}
+	}
+}
+#endif
+
+// std::shared_ptr<MediaPacket> EncoderAVC::RecvBuffer(TranscodeResult *result)
+// {
+// 	if (!_output_buffer.IsEmpty())
+// 	{
+// 		*result = TranscodeResult::DataReady;
+
+// 		auto obj = _output_buffer.Dequeue();
+// 		if (obj.has_value())
+// 		{
+// 			return obj.value();
+// 		}
+// 	}
+
+// 	*result = TranscodeResult::NoData;
+
+// 	return nullptr;
+// }
+
+// 8 25 23 Cam
+// this was adopted from the openh264 encoder
+// there was just a single line difference between the CodecThread() func
+// in the qsv,nv,openh264 encoders, as noted below
+//
+
+
+void EncoderAVC::CodecThread()
+{
+	while (!_kill_flag)
+	{
+		auto obj = _input_buffer.Dequeue();
+		if (obj.has_value() == false)
+			continue;
+
+		auto media_frame = std::move(obj.value());
+
+		///////////////////////////////////////////////////
+		// Request frame encoding to codec
+		///////////////////////////////////////////////////
+		auto av_frame = ffmpeg::Conv::ToAVFrame(cmn::MediaType::Video, media_frame);
+		if (!av_frame)
+		{
+			logte("Could not allocate the video frame data");
+			break;
+		}
+
+		// AV_Frame.pict_type must be set to AV_PICTURE_TYPE_NONE. This will ensure that the keyframe interval option is applied correctly.
+		//cam commented out for now, was in openh264, but not nv, qsv encoders
+		//av_frame->pict_type = AV_PICTURE_TYPE_NONE;
+
+		int ret = ::avcodec_send_frame(_codec_context, av_frame);
+		if (ret < 0)
+		{
+			logte("Error sending a frame for encoding : %d", ret);
+		}
+
+		///////////////////////////////////////////////////
+		// The encoded packet is taken from the codec.
+		///////////////////////////////////////////////////
+		while (true)
+		{
+			// Check frame is available
+			int ret = ::avcodec_receive_packet(_codec_context, _packet);
+			if (ret == AVERROR(EAGAIN))
+			{
+				// More packets are needed for encoding.
+				break;
+			}
+			else if (ret == AVERROR_EOF && ret < 0)
+			{
+				logte("Error receiving a packet for decoding : %d", ret);
+				break;
+			}
+			else
+			{
+				auto media_packet = ffmpeg::Conv::ToMediaPacket(_packet, cmn::MediaType::Video, cmn::BitstreamFormat::H264_ANNEXB, cmn::PacketType::NALU);
+				if (media_packet == nullptr)
+				{
+					logte("Could not allocate the media packet");
+					break;
+				}
+
+				::av_packet_unref(_packet);
+
+				SendOutputBuffer(std::move(media_packet));
+			}
+		}
+	}
+}
+

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.cpp
@@ -108,7 +108,7 @@ bool EncoderAVC::Configure(std::shared_ptr<MediaTrack> context)
 	auto codec_id = GetCodecID();
 
 	//const AVCodec *codec = ::avcodec_find_encoder(codec_id);
-	AVCodec *codec = ::avcodec_find_encoder_by_name("libx264");
+	const AVCodec *codec = ::avcodec_find_encoder_by_name("libx264");
 	if (codec == nullptr)
 	{
 		logte("Could not find encoder: %d (%s)", codec_id, ::avcodec_get_name(codec_id));

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.h
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.h
@@ -25,7 +25,7 @@ public:
 
 	int GetSupportedFormat() const noexcept override
 	{
-		return AV_PIX_FMT_YUV420P;
+		return AV_PIX_FMT_YUV422P10LE;
 	}
 
 	cmn::BitstreamFormat GetBitstreamFormat() const noexcept override

--- a/src/projects/transcoder/codec/encoder/encoder_avc_x264.h
+++ b/src/projects/transcoder/codec/encoder/encoder_avc_x264.h
@@ -1,0 +1,42 @@
+//==============================================================================
+//
+//  Transcode
+//
+//  Created by Kwon Keuk Han
+//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "../../transcoder_encoder.h"
+
+class EncoderAVC : public TranscodeEncoder
+{
+public:
+	EncoderAVC(const info::Stream &stream_info)
+		: TranscodeEncoder(stream_info)
+	{
+	}
+
+	AVCodecID GetCodecID() const noexcept override
+	{
+		return AV_CODEC_ID_H264;
+	}
+
+	int GetSupportedFormat() const noexcept override
+	{
+		return AV_PIX_FMT_YUV420P;
+	}
+
+	cmn::BitstreamFormat GetBitstreamFormat() const noexcept override
+	{
+		return cmn::BitstreamFormat::H264_ANNEXB;
+	}
+
+	bool Configure(std::shared_ptr<MediaTrack> context) override;
+
+	void CodecThread() override;
+
+private:
+	bool SetCodecParams() override;
+};

--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -15,6 +15,7 @@
 #include "codec/encoder/encoder_avc_openh264.h"
 #include "codec/encoder/encoder_avc_qsv.h"
 #include "codec/encoder/encoder_avc_xma.h"
+#include "codec/encoder/encoder_avc_x264.h"
 #include "codec/encoder/encoder_ffopus.h"
 #include "codec/encoder/encoder_hevc_nv.h"
 #include "codec/encoder/encoder_hevc_qsv.h"
@@ -106,6 +107,7 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Create(int32_t encoder_id, c
 						goto done;
 					}
 				}				
+				
 			}
 
 			if (library_id == cmn::MediaCodecLibraryId::AUTO || library_id == cmn::MediaCodecLibraryId::OPENH264)
@@ -115,6 +117,17 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Create(int32_t encoder_id, c
 				{
 
 					output_track->SetCodecLibraryId(cmn::MediaCodecLibraryId::OPENH264);
+					goto done;
+				}
+			}
+
+			if (library_id == cmn::MediaCodecLibraryId::X264)
+			{
+				encoder = std::make_shared<EncoderAVC>(info);
+				if (encoder != nullptr && encoder->Configure(output_track) == true)
+				{
+
+					output_track->SetCodecLibraryId(cmn::MediaCodecLibraryId::X264);
 					goto done;
 				}
 			}


### PR DESCRIPTION
The Chrome browser has support for 10-bit high422 H.264 WebRTC playback.
[libwebrtc-commit][h264]

10-bit video support is valued in the film and video industry, and also the
gaming industry.

This PR enables OME to send 10-bit high422 H.264 over WebRTC to Chrome.

This enables piplines like this: OBStudio -> 10bit/422/HEVC/SRT-or-WHIP -> OME
-> 10bit/422/H264/WebRTC -> Chrome

This enables real-time low latency 10-bit broadcasting enabled by OME!

This may be the first pipeline enabling 10-bit low latency broadcasting to the
Chrome browser using OBS. OME can make this possible.

We don't believe the GPLv2 license of x264 presents a conflict with licensed
used in OME:

1. OME is licensed under the AGPLv3
1. The [x264 GPLv2 allows redistribution under the terms of the GPLv3][1]
1. The [AGPLv3 and GPLv3 are compatible][agplgpl]
1. OME does not redistribute x264 in source form
1. OME/Airensoft does redistribute x264 in binary form in Docker images

If, in spite of these arguments, the OME maintainers are worried about
redistributing Docker images containing x264 object code, then the x264 features
could be left out of the default Docker images. Only to be built and included
using special build flags.

Although not the focus of my efforts, this may also enable 10-bit/422 H.264
LLHLS and other streaming methods also.

PLEASE let me know if these PR's benefits are of interest, and I will proceed
with editing this PR to the maintainers standards in the interest of merging
when acceptable.

Thank you

[1]: https://github.com/mirror/x264/blob/master/COPYING#L296
[agplgpl]: https://www.gnu.org/licenses/gpl-faq.html#AGPLGPL
[h264]: https://webrtc-review.googlesource.com/c/src/+/256964

