### PR TITLE
Add dockerfiles for driver-agnostic CUDA builds

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,53 @@
+FROM    nvidia/cuda:12.2.0-devel-ubuntu20.04 AS build
+
+WORKDIR /tmp
+
+ENV     DEBIAN_FRONTEND=noninteractive
+RUN     apt-get update && apt-get install -y --no-install-recommends tzdata sudo curl git
+
+# Where all libs will be installed
+ENV     PREFIX=/opt/ovenmediaengine
+
+## Download sources
+ARG     OME_REPO=github.com/AirenSoft/OvenMediaEngine
+ARG     OME_VERSION=master
+RUN \
+        mkdir -p /tmp/ome && \
+        cd /tmp/ome && \
+        curl -sLf https://${OME_REPO}/archive/${OME_VERSION}.tar.gz | tar -xz --strip-components=1
+
+## Install dependencies
+RUN     apt-get update && /tmp/ome/misc/prerequisites.sh --enable-nvc
+
+## Build OvenMediaEngine
+ARG 	STRIP=TRUE
+RUN \
+        cd /tmp/ome/src && \
+        make release -j$(nproc) && \
+        if [ "$STRIP" = "TRUE" ] ; then strip /tmp/ome/src/bin/RELEASE/OvenMediaEngine ; fi
+
+## Export release files
+RUN \
+        cd /tmp/ome/src && \
+        mkdir -p ${PREFIX}/bin/origin_conf && \
+        mkdir -p ${PREFIX}/bin/edge_conf && \
+        cp /tmp/ome/src/bin/RELEASE/OvenMediaEngine ${PREFIX}/bin/ && \
+        cp /tmp/ome/misc/conf_examples/Origin.xml ${PREFIX}/bin/origin_conf/Server.xml && \
+        cp /tmp/ome/misc/conf_examples/Logger.xml ${PREFIX}/bin/origin_conf/Logger.xml && \
+        cp /tmp/ome/misc/conf_examples/Edge.xml ${PREFIX}/bin/edge_conf/Server.xml && \
+        cp /tmp/ome/misc/conf_examples/Logger.xml ${PREFIX}/bin/edge_conf/Logger.xml
+
+
+FROM    ubuntu:20.04 AS release
+
+COPY    --from=build /opt/ovenmediaengine /opt/ovenmediaengine
+WORKDIR /opt/ovenmediaengine/bin
+EXPOSE  80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000-10010/udp 9000/tcp
+
+# checked by nvidia container runtime
+ENV     NVIDIA_REQUIRE_CUDA=cuda>=12.2
+# tell nvidia container runtime to mount libnvcuvid into the container
+ENV     NVIDIA_DRIVER_CAPABILITIES=video
+
+# Default run as Origin mode
+CMD     ["/opt/ovenmediaengine/bin/OvenMediaEngine", "-c", "origin_conf"]

--- a/Dockerfile.cuda.local
+++ b/Dockerfile.cuda.local
@@ -1,0 +1,49 @@
+FROM    nvidia/cuda:12.2.0-devel-ubuntu20.04 AS build
+
+WORKDIR /tmp
+
+ENV     DEBIAN_FRONTEND=noninteractive
+RUN     apt-get update && apt-get install -y --no-install-recommends tzdata sudo curl git
+
+# Where all libs will be installed
+ENV     PREFIX=/opt/ovenmediaengine
+
+## Install dependencies
+COPY    ./misc/prerequisites.sh /tmp/ome/misc/prerequisites.sh
+RUN     apt-get update && /tmp/ome/misc/prerequisites.sh --enable-nvc
+
+## Build OvenMediaEngine
+COPY    ./src/ /tmp/ome/src/
+ARG 	STRIP=TRUE
+ARG     OME_VERSION=local
+RUN \
+        cd /tmp/ome/src && \
+        make release -j$(nproc) && \
+        if [ "$STRIP" = "TRUE" ] ; then strip /tmp/ome/src/bin/RELEASE/OvenMediaEngine ; fi
+
+## Export release files
+COPY    ./misc/conf_examples/ /tmp/ome/misc/conf_examples/
+RUN \
+        cd /tmp/ome/src && \
+        mkdir -p ${PREFIX}/bin/origin_conf && \
+        mkdir -p ${PREFIX}/bin/edge_conf && \
+        cp /tmp/ome/src/bin/RELEASE/OvenMediaEngine ${PREFIX}/bin/ && \
+        cp /tmp/ome/misc/conf_examples/Origin.xml ${PREFIX}/bin/origin_conf/Server.xml && \
+        cp /tmp/ome/misc/conf_examples/Logger.xml ${PREFIX}/bin/origin_conf/Logger.xml && \
+        cp /tmp/ome/misc/conf_examples/Edge.xml ${PREFIX}/bin/edge_conf/Server.xml && \
+        cp /tmp/ome/misc/conf_examples/Logger.xml ${PREFIX}/bin/edge_conf/Logger.xml
+
+
+FROM    ubuntu:20.04 AS release
+
+COPY    --from=build /opt/ovenmediaengine /opt/ovenmediaengine
+WORKDIR /opt/ovenmediaengine/bin
+EXPOSE  80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000-10010/udp 9000/tcp
+
+# checked by nvidia container runtime
+ENV     NVIDIA_REQUIRE_CUDA=cuda>=12.2
+# tell nvidia container runtime to mount libnvcuvid into the container
+ENV     NVIDIA_DRIVER_CAPABILITIES=video
+
+# Default run as Origin mode
+CMD     ["/opt/ovenmediaengine/bin/OvenMediaEngine", "-c", "origin_conf"]

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 PREFIX=/opt/ovenmediaengine
 TEMP_PATH=/tmp
 
@@ -50,7 +52,7 @@ install_openssl()
     (DIR=${TEMP_PATH}/openssl && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/openssl/openssl/archive/openssl-${OPENSSL_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/openssl/openssl/archive/openssl-${OPENSSL_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     ./config --prefix="${PREFIX}" --openssldir="${PREFIX}" --libdir=lib -Wl,-rpath,"${PREFIX}/lib" shared no-idea no-mdc2 no-rc5 no-ec2m no-ecdh no-ecdsa no-async && \
     make -j$(nproc) && \
     sudo make install_sw && \
@@ -62,7 +64,7 @@ install_libsrtp()
     (DIR=${TEMP_PATH}/srtp && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/cisco/libsrtp/archive/v${SRTP_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/cisco/libsrtp/archive/v${SRTP_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     ./configure --prefix="${PREFIX}" --enable-openssl --with-openssl-dir="${PREFIX}" && \
     make -j$(nproc) shared_library&& \
     sudo make install && \
@@ -74,7 +76,7 @@ install_libsrt()
     (DIR=${TEMP_PATH}/srt && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/Haivision/srt/archive/v${SRT_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/Haivision/srt/archive/v${SRT_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH} ./configure --prefix="${PREFIX}" --enable-shared --disable-static && \
     make -j$(nproc) && \
     sudo make install && \
@@ -86,7 +88,7 @@ install_libopus()
     (DIR=${TEMP_PATH}/opus && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://archive.mozilla.org/pub/opus/opus-${OPUS_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://archive.mozilla.org/pub/opus/opus-${OPUS_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     autoreconf -fiv && \
     ./configure --prefix="${PREFIX}" --enable-shared --disable-static && \
     make -j$(nproc) && \
@@ -100,7 +102,7 @@ install_libopenh264()
     (DIR=${TEMP_PATH}/openh264 && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/cisco/openh264/archive/refs/tags/v${OPENH264_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/cisco/openh264/archive/refs/tags/v${OPENH264_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     sed -i -e "s|PREFIX=/usr/local|PREFIX=${PREFIX}|" Makefile && \
     make OS=linux && \
     sudo make install && \
@@ -141,7 +143,7 @@ install_libvpx()
     (DIR=${TEMP_PATH}/vpx && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | tar -xz --strip-components=1 && \
+    curl -sSLf https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | tar -xz --strip-components=1 && \
     ./configure --prefix="${PREFIX}" --enable-vp8 --enable-pic --enable-shared --disable-static --disable-vp9 --disable-debug --disable-examples --disable-docs --disable-install-bins ${ADDITIONAL_FLAGS} && \
     make -j$(nproc) && \
     sudo make install && \
@@ -153,7 +155,7 @@ install_fdk_aac()
     (DIR=${TEMP_PATH}/aac && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     autoreconf -fiv && \
     ./configure --prefix="${PREFIX}" --enable-shared --disable-static --datadir=/tmp/aac && \
     make -j$(nproc) && \
@@ -167,7 +169,7 @@ install_nasm()
     (DIR=${TEMP_PATH}/nasm && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-${NASM_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-${NASM_VERSION}.tar.gz | tar -xz --strip-components=1 && \
 	./autogen.sh && \
     ./configure --prefix="${PREFIX}" && \
     make -j$(nproc) && \
@@ -183,7 +185,7 @@ install_nvcc_hdr() {
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         export DESTDIR=${PREFIX} && \
-        curl -sLf https://github.com/FFmpeg/nv-codec-headers/releases/download/n${NVCC_HDR_VERSION}/nv-codec-headers-${NVCC_HDR_VERSION}.tar.gz | tar -xz --strip-components=1 && sed -i 's|PREFIX.*=\(.*\)|PREFIX =|g' Makefile && \
+        curl -sSLf https://github.com/FFmpeg/nv-codec-headers/releases/download/n${NVCC_HDR_VERSION}/nv-codec-headers-${NVCC_HDR_VERSION}.tar.gz | tar -xz --strip-components=1 && sed -i 's|PREFIX.*=\(.*\)|PREFIX =|g' Makefile && \
         sudo make install ) || fail_exit "nvcc_headers"
     fi
 }
@@ -270,7 +272,7 @@ install_ffmpeg()
     # Download
     (rm -rf ${DIR}  && mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf ${FFMPEG_DOWNLOAD_URL} | tar -xz --strip-components=1 ) || fail_exit "ffmpeg"
+    curl -sSLf ${FFMPEG_DOWNLOAD_URL} | tar -xz --strip-components=1 ) || fail_exit "ffmpeg"
 
     # Patch for Enterprise
     if [[ "$(type -t install_patch_ffmpeg)"  == 'function' ]];
@@ -308,7 +310,7 @@ install_jemalloc()
     (DIR=${TEMP_PATH}/jemalloc && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/jemalloc/jemalloc/releases/download/${JEMALLOC_VERSION}/jemalloc-${JEMALLOC_VERSION}.tar.bz2 | tar -jx --strip-components=1 && \
+    curl -sSLf https://github.com/jemalloc/jemalloc/releases/download/${JEMALLOC_VERSION}/jemalloc-${JEMALLOC_VERSION}.tar.bz2 | tar -jx --strip-components=1 && \
     ./configure --prefix="${PREFIX}" && \
     make -j$(nproc) && \
     sudo make install_include install_lib && \
@@ -320,7 +322,7 @@ install_libpcre2()
     (DIR=${TEMP_PATH}/libpcre2 && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PCRE2_VERSION}/pcre2-${PCRE2_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PCRE2_VERSION}/pcre2-${PCRE2_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     ./configure --prefix="${PREFIX}" \
     --disable-static \
         --enable-jit=auto && \
@@ -334,7 +336,7 @@ install_hiredis()
 	(DIR=${TEMP_PATH}/hiredis && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/redis/hiredis/archive/refs/tags/v${HIREDIS_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/redis/hiredis/archive/refs/tags/v${HIREDIS_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     make -j$(nproc) && \
     sudo make install PREFIX="${PREFIX}" && \
     rm -rf ${DIR} ) || fail_exit "hiredis"
@@ -342,7 +344,7 @@ install_hiredis()
 
 install_base_ubuntu()
 {
-    sudo apt install -y build-essential autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc uuid-dev
+    sudo apt-get install -y build-essential autoconf libtool zlib1g-dev tclsh cmake curl pkg-config bc uuid-dev
 }
 
 install_base_fedora()
@@ -388,7 +390,7 @@ install_ovenmediaengine()
     (DIR=${TEMP_PATH}/ome && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sLf https://github.com/AirenSoft/OvenMediaEngine/archive/${OME_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/AirenSoft/OvenMediaEngine/archive/${OME_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     cd src && \
     make release && \
     sudo make install && \


### PR DESCRIPTION
Currently OME requires you to [build a special docker image](https://github.com/AirenSoft/OvenMediaEngine/tree/efa9ea69ff59ccee4d8c6238342e5a002a78a45d/docs/transcoding/gpu-usage#how-to-build-and-run-docker-image) for nvidia transcoding, with driver version matching that on the host.
This is not the intended way of using the nvidia container runtime.

Nvidia doesn't do a great job of spreading the documentation on its forums and github issues but the intended way is to mount host driver files into the container.
You can find the documentation here: https://github.com/NVIDIA/nvidia-container-runtime

In this PR I optimized build process for docker images with CUDA:
- I used a prebuilt CUDA image which saves a lot of time
- Since we are using a separate base image anyway, I separated CUDA Dockerfile from the main one
- I added the `NVIDIA_DRIVER_CAPABILITIES` environment variable which allows you to skip driver installation inside the container
- I rearranged the commands to make a more efficient use of docker build cache for `.local` Dockerfile builds

Resulting image should work with any driver version.

Resulting image is based on `ubuntu:20.04` without any additional tools installed, which makes it 337 MiB uncompressed and 93 MiB compressed (which, I believe, is even smaller than the official images without CUDA).

You can find my image here:
- `docker.io/daniluzlov/k8s-snippets:ome-v0.15.16-cuda`
- https://hub.docker.com/layers/daniluzlov/k8s-snippets/ome-v0.15.16-cuda/images/sha256-da6ee9bb89abed3a7a810840ef07b04007838e2baa3c21080dc753fabf602233?context=repo

This PR will also fix this, and probably some other issues:
- https://github.com/AirenSoft/OvenMediaEngine/discussions/1398

# Notes

- With this image you could publish an official image with NVIDIA/CUDA support that doesn't require users to rebuild the image for each machine.
- Considering that this image is even smaller than the official one, maybe it could become the standard image. I believe there are no issues running cuda-enabled images without cuda hardware.
- While I believe that there should be no issues, because nvidia container runtime is the same everywhere, and I'm able to run the image linked above on my server, I don't have too many servers to test it on. I didn't even test it in docker, because I use containerd+runc+k8s.
- I believe, this dockerfile bumps CUDA version from 10.1 to 12.2. While I don't think this really matters, as I think there are no reasons users would not be able to install modern nvidia drivers with 12.2 support, if you want to, it should be really easy to downgrade the CUDA version: you just change the base image and `NVIDIA_REQUIRE_CUDA`.
- I didn't touch the documentation, or the main dockerfiles, or the install scripts. If you merge this PR, they should probably be updated.