### PR TITLE
src/core/main.mk: improve install procedure

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -3,7 +3,7 @@
 OvenMediaEngine has an XML configuration file. If you start OvenMediaEngine with `systemctl start ovenmediaengine`, the config file is loaded from the following path.
 
 ```bash
-/usr/share/ovenmediaengine/conf/Server.xml
+/etc/ovenmediaengine/Server.xml
 ```
 
 If you run it directly from the command line, it loads the configuration file from:
@@ -110,9 +110,9 @@ The `Bind` is the configuration for the server port that will be used. Bind cons
 
             <IceCandidates>
                 <IceCandidate>*:10000/udp</IceCandidate>
-                <!-- 
+                <!--
                     If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
+                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
                     For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
                 -->
                 <TcpRelay>*:3478</TcpRelay>
@@ -129,9 +129,9 @@ The `Bind` is the configuration for the server port that will be used. Bind cons
             <WorkerCount>1</WorkerCount>
         </OVT>
         <LLHLS>
-            <!-- 
-            OME only supports h2, so LLHLS works over HTTP/1.1 on non-TLS ports. 
-            LLHLS works with higher performance over HTTP/2, 
+            <!--
+            OME only supports h2, so LLHLS works over HTTP/1.1 on non-TLS ports.
+            LLHLS works with higher performance over HTTP/2,
             so it is recommended to use a TLS port.
             -->
             <Port>3333</Port>
@@ -147,9 +147,9 @@ The `Bind` is the configuration for the server port that will be used. Bind cons
             </Signalling>
             <IceCandidates>
                 <IceCandidate>*:10000-10005/udp</IceCandidate>
-                <!-- 
+                <!--
                     If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
+                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
                     For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
                 -->
                 <TcpRelay>*:3478</TcpRelay>
@@ -331,14 +331,14 @@ To run the Edge server, Origin creates application and stream if there isn't tho
                         <Samplerate>48000</Samplerate>
                         <Channel>2</Channel>
                     </Audio>
-                    <!--                             
+                    <!--
                     <Video>
                         <Codec>vp8</Codec>
                         <Bitrate>1024000</Bitrate>
                         <Framerate>30</Framerate>
                         <Width>1280</Width>
                         <Height>720</Height>
-                    </Video>                                
+                    </Video>
                     -->
                 </Encodes>
             </OutputProfile>
@@ -410,16 +410,16 @@ Finally, `Server.xml` is configured as follows:
     <IP>*</IP>
     <PrivacyProtection>false</PrivacyProtection>
 
-    <!-- 
-    To get the public IP address(mapped address of stun) of the local server. 
-    This is useful when OME cannot obtain a public IP from an interface, such as AWS or docker environment. 
+    <!--
+    To get the public IP address(mapped address of stun) of the local server.
+    This is useful when OME cannot obtain a public IP from an interface, such as AWS or docker environment.
     If this is successful, you can use ${PublicIP} in your settings.
     -->
     <StunServer>stun.l.google.com:19302</StunServer>
 
     <Modules>
-        <!-- 
-        Currently OME only supports h2 like all browsers do. Therefore, HTTP/2 only works on TLS ports.			
+        <!--
+        Currently OME only supports h2 like all browsers do. Therefore, HTTP/2 only works on TLS ports.
         -->
         <HTTP2>
             <Enable>true</Enable>
@@ -483,9 +483,9 @@ Finally, `Server.xml` is configured as follows:
 
             <IceCandidates>
                 <IceCandidate>*:10000/udp</IceCandidate>
-                <!-- 
+                <!--
                     If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
+                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
                     For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
                 -->
                 <TcpRelay>*:3478</TcpRelay>
@@ -502,9 +502,9 @@ Finally, `Server.xml` is configured as follows:
             <WorkerCount>1</WorkerCount>
         </OVT>
         <LLHLS>
-            <!-- 
-            OME only supports h2, so LLHLS works over HTTP/1.1 on non-TLS ports. 
-            LLHLS works with higher performance over HTTP/2, 
+            <!--
+            OME only supports h2, so LLHLS works over HTTP/1.1 on non-TLS ports.
+            LLHLS works with higher performance over HTTP/2,
             so it is recommended to use a TLS port.
             -->
             <Port>3333</Port>
@@ -520,9 +520,9 @@ Finally, `Server.xml` is configured as follows:
             </Signalling>
             <IceCandidates>
                 <IceCandidate>*:10000-10005/udp</IceCandidate>
-                <!-- 
+                <!--
                     If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
+                    This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
                     For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
                 -->
                 <TcpRelay>*:3478</TcpRelay>
@@ -536,7 +536,7 @@ Finally, `Server.xml` is configured as follows:
 
     <!--
         Enable this configuration if you want to use API Server
-        
+
         <AccessToken> is a token for authentication, and when you invoke the API, you must put "Basic base64encode(<AccessToken>)" in the "Authorization" header of HTTP request.
         For example, if you set <AccessToken> to "ome-access-token", you must set "Basic b21lLWFjY2Vzcy10b2tlbg==" in the "Authorization" header.
     -->
@@ -592,7 +592,7 @@ Finally, `Server.xml` is configured as follows:
                 -->
             </Host>
 
-            <!-- 	
+            <!--
             Refer https://airensoft.gitbook.io/ovenmediaengine/signedpolicy
             <SignedPolicy>
                 <PolicyQueryKeyName>policy</PolicyQueryKeyName>
@@ -646,7 +646,7 @@ Finally, `Server.xml` is configured as follows:
                     </Pass>
                 </Origin>
             </Origins> -->
-            
+
             <!-- Settings for applications -->
             <Applications>
                 <Application>
@@ -672,7 +672,7 @@ Finally, `Server.xml` is configured as follows:
                                     <Samplerate>48000</Samplerate>
                                     <Channel>2</Channel>
                                 </Audio>
-                                <!-- 							
+                                <!--
                                 <Video>
                                     <Codec>vp8</Codec>
                                     <Bitrate>1024000</Bitrate>

--- a/misc/ovenmediaengine.service
+++ b/misc/ovenmediaengine.service
@@ -5,8 +5,7 @@ After=network-online.target
 [Service]
 Type=forking
 PIDFile=/var/run/ovenmediaengine.pid
-WorkingDirectory=/usr/share/ovenmediaengine
-ExecStart=/usr/bin/OvenMediaEngine -d
+ExecStart=/usr/bin/OvenMediaEngine -d -c /etc/ovenmediaengine
 Restart=always
 RestartSec=2
 RestartPreventExitStatus=1

--- a/src/core/main.mk
+++ b/src/core/main.mk
@@ -6,11 +6,11 @@ BUILD_ROOT := .
 BUILD_SYSTEM_DIRECTORY := core
 OME := OvenMediaEngine
 OME_SERVICE := ovenmediaengine.service
-INSTALL_DIRECTORY := /usr/share/ovenmediaengine
-INSTALL_CONF_DIRECTORY := $(INSTALL_DIRECTORY)/conf
-LINK_BIN_DIRECTORY := /usr/bin
-INSTALL_SERVICE_DIRECTORY := /lib/systemd/system
-LINK_SERVICE_DIRECTORY := /etc/systemd/system
+DESTDIR := /
+PREFIX := /usr
+BINDIR := /bin
+SYSCONFDIR := /etc
+SYSTEMDUNITDIR := $(shell pkg-config systemd --variable=systemdsystemunitdir)
 
 #===============================================================================
 # Include makefiles
@@ -116,34 +116,28 @@ install:
 	    exit 1; \
 	fi
 
-	@echo "$(ANSI_GREEN)Installing directory$(ANSI_RESET) $(INSTALL_DIRECTORY)"
-	@mkdir -p $(INSTALL_CONF_DIRECTORY)
-	@install -m 755 -s bin/$(BUILD_METHOD)/$(OME) $(INSTALL_DIRECTORY)
+	@echo "$(ANSI_GREEN)Installing binary$(ANSI_RESET) $(DESTDIR)$(PREFIX)$(BINDIR)/$(OME)"
+	@mkdir -p $(DESTDIR)$(PREFIX)$(BINDIR)
+	@install -m 755 -s bin/$(BUILD_METHOD)/$(OME) $(DESTDIR)$(PREFIX)$(BINDIR)
 
-	@if test ! -f $(INSTALL_CONF_DIRECTORY)/Server.xml; then \
-	    install -m 644 ../misc/conf_examples/Server.xml $(INSTALL_CONF_DIRECTORY); \
+	@mkdir -p $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/
+	@if test ! -f $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/Server.xml; then \
+			echo "$(ANSI_GREEN)Installing config file$(ANSI_RESET) $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/Server.xml"; \
+	    install -m 644 ../misc/conf_examples/Server.xml $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/; \
 	fi
 
-	@if test ! -f $(INSTALL_CONF_DIRECTORY)/Logger.xml; then \
-	    install -m 644 ../misc/conf_examples/Logger.xml $(INSTALL_CONF_DIRECTORY); \
+	@if test ! -f $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/Logger.xml; then \
+			echo "$(ANSI_GREEN)Installing config file$(ANSI_RESET) $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/Logger.xml"; \
+	    install -m 644 ../misc/conf_examples/Logger.xml $(DESTDIR)$(SYSCONFDIR)/ovenmediaengine/; \
 	fi
 
-	@echo "$(ANSI_GREEN)Creating link file$(ANSI_RESET) $(LINK_BIN_DIRECTORY)/$(OME) => \
-	$(ANSI_BLUE)$(INSTALL_DIRECTORY)/$(OME)$(ANSI_RESET)"
-	@ln -sf $(INSTALL_DIRECTORY)/$(OME) $(LINK_BIN_DIRECTORY)/$(OME)
-	@echo "$(ANSI_GREEN)Installing service$(ANSI_RESET) $(INSTALL_SERVICE_DIRECTORY)/$(OME_SERVICE)"
-	@install -m 644 ../misc/$(OME_SERVICE) $(INSTALL_SERVICE_DIRECTORY)
-	@echo "$(ANSI_GREEN)Creating link file$(ANSI_RESET) $(LINK_SERVICE_DIRECTORY)/$(OME_SERVICE) => \
-	$(ANSI_BLUE)$(INSTALL_SERVICE_DIRECTORY)/$(OME_SERVICE)$(ANSI_RESET)"
-	@ln -sf $(INSTALL_SERVICE_DIRECTORY)/$(OME_SERVICE) $(LINK_SERVICE_DIRECTORY)/$(OME_SERVICE)
+	@echo "$(ANSI_GREEN)Installing service$(ANSI_RESET) $(DESTDIR)$(SYSCONFDIR)/systemd/system/$(OME_SERVICE)"
+	@mkdir -p $(DESTDIR)$(SYSTEMDUNITDIR)
+	@install -m 644 ../misc/$(OME_SERVICE) $(DESTDIR)$(SYSTEMDUNITDIR)
 
 .PHONY: uninstall
 uninstall:
-	@echo "$(CONFIG_CLEAN_COLOR)Deleting directory$(ANSI_RESET) $(INSTALL_DIRECTORY)"
-	@rm -rf $(INSTALL_DIRECTORY)
-	@echo "$(CONFIG_CLEAN_COLOR)Deleting link file$(ANSI_RESET) $(LINK_BIN_DIRECTORY)/$(OME)"
-	@rm -rf $(LINK_BIN_DIRECTORY)/$(OME)
-	@echo "$(CONFIG_CLEAN_COLOR)Deleting service file$(ANSI_RESET) $(INSTALL_SERVICE_DIRECTORY)/$(OME_SERVICE)"
-	@rm -rf $(INSTALL_SERVICE_DIRECTORY)/$(OME_SERVICE)
-	@echo "$(CONFIG_CLEAN_COLOR)Deleting link file$(ANSI_RESET) $(LINK_SERVICE_DIRECTORY)/$(OME_SERVICE)"
-	@rm -rf $(LINK_SERVICE_DIRECTORY)/$(OME_SERVICE)
+	@echo "$(CONFIG_CLEAN_COLOR)Deleting binary$(ANSI_RESET) $(DESTDIR)$(PREFIX)$(BINDIR)/$(OME)"
+	@rm -f $(DESTDIR)$(PREFIX)$(BINDIR)/$(OME)
+	@echo "$(CONFIG_CLEAN_COLOR)Deleting service file$(ANSI_RESET) $(DESTDIR)$(PREFIX)/lib/systemd/system/$(OME_SERVICE)"
+	@rm -f $(DESTDIR)$(SYSTEMDUNITDIR)/$(OME_SERVICE)


### PR DESCRIPTION
Hello,

A small PR to improve the Makefile code that installs stuff into a given system to fit more with:
- The Filesystem Hierarchy Standard
  - see https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html
- Packaging practices

Changes: Use extra "PREFIX", "DESTDIR", "SYSCONFDIR", "BINDIR" and "SYSTEMDUNITDIR" variables
- "SYSTEMDUNITDIR" is where systemd services and unit files should be installed, by default we query this path using pkg-config
- Files are installed into the folder '$DESTDIR'. Along with the other variables, they help packagers tweak where binaries and config files are installed.
  - Install the binary directly into the bin directory instead of: '/usr/share/ovenmediaengine/' + symlink to '/usr/bin'
  - Put config files in '/etc/ovenmediaengine' instead of '/usr/share/ovenmediaengine/conf'
    - Update the service file accordingly

I tested it:
- Locally by installing directly into my own system and running the systemd service.
- By installing into a temporary folder (packagers will use this path)
- Note: I do not know if this change affects your Dockerized approach

A further improvement is to install documentation and license into the proper folders.

As a final suggestion: it's probably best for you guys to move to a proper build system, like [meson](https://mesonbuild.com/) :D 