### PR TITLE
Update Dockerfile base image to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:20.04 AS base
+FROM    ubuntu:22.04 AS base
 
 ## Install libraries by package
 ENV     DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM    ubuntu:20.04 AS base
+FROM    ubuntu:22.04 AS base
 
 ## Install libraries by package
 ENV     DEBIAN_FRONTEND=noninteractive

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -435,7 +435,7 @@ fail_exit()
 
 check_version()
 {
-    if [[ "${OSNAME}" == "Ubuntu" && "${OSVERSION}" != "18" && "${OSVERSION}.${OSMINORVERSION}" != "20.04" ]]; then
+    if [[ "${OSNAME}" == "Ubuntu" && "${OSVERSION}" != "18" && "${OSVERSION}.${OSMINORVERSION}" != "20.04" && "${OSVERSION}.${OSMINORVERSION}" != "22.04" ]]; then
         proceed_yn
     fi
 
@@ -458,7 +458,7 @@ check_version()
 
 proceed_yn()
 {
-    read -p "This program [$0] is tested on [Ubuntu 18/20.04, CentOS 7/8 q, Fedora 28, Amazon Linux 2]
+    read -p "This program [$0] is tested on [Ubuntu 18/20.04/22.04, CentOS 7/8 q, Fedora 28, Amazon Linux 2]
 Do you want to continue [y/N] ? " ANS
     if [[ "${ANS}" != "y" && "$ANS" != "yes" ]]; then
         cd ${CURRENT}


### PR DESCRIPTION
The OME Dockerfiles currently are based on Ubuntu 20.04. This is becoming a security issue because of Ubuntu 20.04 not getting properly supplied with security updates any more. Anything that is not core Ubuntu or Linux kernel is not covered by the LTS promise and package maintainers have largely started dropping the upkeep work for the 20.04 package repository in the past year.

Thus I suggest updating the docker image to 22.04. 
This also requires some changes to the misc/prerequisites.sh (especially the check_version + proceed_yn functions) and the scripts for installing the GPU acceleration stuff, as well as testing OME.

I started testing with Dockerfile updated to 22.04 and compiling works, starting as origin works, starting as edge works, rtmp provider works, srt provider works, OVT publisher works, ovt provider works, WebRTC provider works over udp and over tcp, LLHLS provider works, HLS provider works, x264 transcoding works and AAC -> OPUS transcoding works. So far I didn't find any new issues after changing the docker base image to 22.04 and rebuilding the docker images.

However, I don't have any hardware that I could use for testing the GPU acceleration stuff, thus I did not update the `Dockerfile.cuda` and the `Dockerfile.cuda.local`.

This would probably also be a good opportunity to remove any mentions of Ubuntu 18, which is not really usable nowadays anymore anyways, especially once OME also upgrades to ffmpeg 6.1 (which might be needed for the support of Enhanced RTMP for being able to ingest+forward HEVC/AV1 over RTMP). However I decided to exclude that change from this pull request in order to not slow down merging of this change because of fear of breaking any old automated setups.