### PR TITLE
Patch, schedulerChannel reading .ts file format, crash.

### DIFF
--- a/src/projects/modules/ffmpeg/ffmpeg_conv.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_conv.h
@@ -382,46 +382,56 @@ namespace ffmpeg
 			{
 				case cmn::MediaCodecId::H264:
 				{
-					// AVCC format
-					auto avc_config = std::make_shared<AVCDecoderConfigurationRecord>();
-					auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
-
-					if (avc_config->Parse(extra_data) == false)
+					if (stream->codecpar->extradata_size > 0)
 					{
-						return false;
+						// AVCC format
+						auto avc_config = std::make_shared<AVCDecoderConfigurationRecord>();
+						auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
+
+						if (avc_config->Parse(extra_data) == false)
+						{
+							return false;
+						}
+
+						media_track->SetDecoderConfigurationRecord(avc_config);
 					}
 
-					media_track->SetDecoderConfigurationRecord(avc_config);
 					
 					break;
 				}
 				case cmn::MediaCodecId::H265:
 				{
-					// HVCC format
-					auto hevc_config = std::make_shared<HEVCDecoderConfigurationRecord>();
-					auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
-
-					if (hevc_config->Parse(extra_data) == false)
+					if (stream->codecpar->extradata_size > 0)
 					{
-						return false;
-					}
+						// HVCC format
+						auto hevc_config = std::make_shared<HEVCDecoderConfigurationRecord>();
+						auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
 
-					media_track->SetDecoderConfigurationRecord(hevc_config);
+						if (hevc_config->Parse(extra_data) == false)
+						{
+							return false;
+						}
+
+						media_track->SetDecoderConfigurationRecord(hevc_config);
+					}
 
 					break;
 				}
 				case cmn::MediaCodecId::Aac:
 				{
-					// ASC format
-					auto asc = std::make_shared<AudioSpecificConfig>();
-					auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
-
-					if (asc->Parse(extra_data) == false)
+					if (stream->codecpar->extradata_size > 0)
 					{
-						return false;
+						// ASC format
+						auto asc = std::make_shared<AudioSpecificConfig>();
+						auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
+
+						if (asc->Parse(extra_data) == false)
+						{
+							return false;
+						}
+
+						media_track->SetDecoderConfigurationRecord(asc);
 					}
-					
-					media_track->SetDecoderConfigurationRecord(asc);
 
 					break;
 				}

--- a/src/projects/providers/scheduled/scheduled_stream.cpp
+++ b/src/projects/providers/scheduled/scheduled_stream.cpp
@@ -400,6 +400,8 @@ namespace pvd
         std::map<int, int64_t> track_single_file_dts_offset_map;
         std::map<int, bool> end_of_track_map;
 
+        bool use_annexb { std::strncmp(context->iformat->name, "mpegts", 6) == 0 };
+
         while (_worker_thread_running)
         {
             if (CheckCurrentProgramChanged() == true)
@@ -477,13 +479,13 @@ namespace pvd
 			switch (track->GetCodecId())
 			{
 				case cmn::MediaCodecId::H264:
-					bitstream_format = cmn::BitstreamFormat::H264_AVCC;
+					bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H264_ANNEXB : cmn::BitstreamFormat::H264_AVCC;
 					packet_type = cmn::PacketType::NALU;
 					break;
-                case cmn::MediaCodecId::H265:
-                    bitstream_format = cmn::BitstreamFormat::HVCC;
-                    packet_type = cmn::PacketType::NALU;
-                    break;
+				case cmn::MediaCodecId::H265:
+					bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H265_ANNEXB : cmn::BitstreamFormat::HVCC;
+					packet_type = cmn::PacketType::NALU;
+					break;
 				case cmn::MediaCodecId::Aac:
 					bitstream_format = cmn::BitstreamFormat::AAC_RAW;
 					packet_type = cmn::PacketType::RAW;


### PR DESCRIPTION
ScheduledChannel, when it reads a file, ts format, previously saved with startRecord, CRASH.
This P.R. solves the problem, simply by changing the bitstream type.

`bool use_annexb { std::strncmp(context->iformat->name, "mpegts", 6) == 0 };`

```
case cmn::MediaCodecId::H264:
	bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H264_ANNEXB : cmn::BitstreamFormat::H264_AVCC;
	packet_type = cmn::PacketType::NALU;
	break;
case cmn::MediaCodecId::H265:
	bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H265_ANNEXB : cmn::BitstreamFormat::HVCC;
	packet_type = cmn::PacketType::NALU;
	break;
```

Mpegts use annexb.
Many thanks in advance.
