### PR TITLE
ScheduledChannel: patchs for audio, add opus for mpegts and mp4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ src/projects/main/git_info.h
 *.cxxflags
 *.files
 *.includes
+.qtc_clangd
 
 *.o
 *.d

--- a/src/projects/modules/bitstream/opus/opus_specific_config.h
+++ b/src/projects/modules/bitstream/opus/opus_specific_config.h
@@ -1,0 +1,114 @@
+#pragma once
+
+
+// Opus Identification Header.
+// https://datatracker.ietf.org/doc/html/draft-ietf-codec-oggopus#section-5.1
+//
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      'O'      |      'p'      |      'u'      |      's'      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      'H'      |      'e'      |      'a'      |      'd'      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Version = 1  | Channel Count |           Pre-skip            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                     Input Sample Rate (Hz)                    |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |   Output Gain (Q7.8 in dB)    | Mapping Family|               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+               :
+// |                                                               |
+// :               Optional Channel Mapping Table...               :
+// |                                                               |
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+// opus_default_extradata (ffmpeg example)
+// https://github.com/skynav/ffmpeg/blob/master/libavcodec/opus.c
+// https://github.com/skynav/ffmpeg/blob/master/libavcodec/opus.h
+
+// https://patchwork.ffmpeg.org/project/ffmpeg/patch/CAB0OVGqiFSF001jQeuBALTMUN61NO23gjGrza-RNPM9uQdq1gw@mail.gmail.com/#45978
+// https://www.mail-archive.com/libav-user@ffmpeg.org/msg12487.html
+
+
+#include <base/ovlibrary/ovlibrary.h>
+#include <base/info/decoder_configuration_record.h>
+
+// the first 19 bytes are sufficient to bypass the ffmpeg checks
+#define MIN_OPUS_SPECIFIC_CONFIG_SIZE 19
+
+
+class OpusSpecificConfig : public DecoderConfigurationRecord
+{
+public:
+	OpusSpecificConfig()
+	{
+	}
+
+	OpusSpecificConfig(uint8_t channels, uint32_t sample_rate) :
+		_channels(channels),
+		_sample_rate(sample_rate)
+	{
+	}
+
+	bool IsValid() const override
+	{
+		return (_header == _header_const) && (_version == 1) && (_channels > 0) && (_sample_rate == 48000);
+	}
+
+	bool Parse(const std::shared_ptr<ov::Data> &data) override
+	{
+		if (data->GetLength() < MIN_OPUS_SPECIFIC_CONFIG_SIZE)
+		{
+			//logte("The data inputed is too small for parsing (%d must be bigger than %d)", data->GetLength(), MIN_OPUS_SPECIFIC_CONFIG_SIZE);
+			return false;
+		}
+
+		BitReader parser(data->GetDataAs<uint8_t>(), data->GetLength());
+
+		_header = parser.ReadString(8);
+		_version = parser.ReadBytes<uint8_t>(false);
+		_channels = parser.ReadBytes<uint8_t>(false);
+		_pre_skip = parser.ReadBytes<uint16_t>(false);
+		_sample_rate = parser.ReadBytes<uint32_t>(false);
+		_output_gain = parser.ReadBytes<uint16_t>(false);
+		_mapping_family = parser.ReadBytes<uint8_t>(false);
+
+		return true;
+	}
+
+	bool Equals(const std::shared_ptr<DecoderConfigurationRecord> &other) override
+	{
+		return other->GetData()->IsEqual(GetData());
+	}
+
+	std::shared_ptr<ov::Data> Serialize() override
+	{
+		ov::BitWriter bits(MIN_OPUS_SPECIFIC_CONFIG_SIZE);
+
+		bits.Write(_header_const.ToData()->GetDataAs<uint8_t>(), _header.GetLength());
+		bits.Write(8, _version);
+		bits.Write(8, _channels);
+		bits.Write(16, _pre_skip);
+		bits.Write(32, _sample_rate);
+		bits.Write(16, _output_gain);
+		bits.Write(8, _mapping_family);
+
+		return std::make_shared<ov::Data>(bits.GetData(), bits.GetDataSize());
+	}
+
+	// Helpers
+	ov::String GetCodecsParameter() const override
+	{
+		return "mp4a.ad";
+	}
+
+private:
+	const ov::String _header_const { "OpusHead" };
+	ov::String _header { _header_const };
+	uint8_t	_version { 1 };
+	uint8_t _channels { 0 };
+	uint16_t _pre_skip { 0 };
+	uint32_t _sample_rate { 0 };
+	uint16_t _output_gain { 0 };
+	uint8_t _mapping_family { 0 };
+};

--- a/src/projects/modules/ffmpeg/ffmpeg_conv.h
+++ b/src/projects/modules/ffmpeg/ffmpeg_conv.h
@@ -38,6 +38,7 @@ extern "C"
 #include <modules/bitstream/h264/h264_decoder_configuration_record.h>
 #include <modules/bitstream/h265/h265_decoder_configuration_record.h>
 #include <modules/bitstream/aac/audio_specific_config.h>
+#include <modules/bitstream/opus/opus_specific_config.h>
 
 namespace ffmpeg
 {
@@ -435,11 +436,27 @@ namespace ffmpeg
 
 					break;
 				}
-				case cmn::MediaCodecId::Vp8:
+				case cmn::MediaCodecId::Opus:
+				{
+					if (stream->codecpar->extradata_size > 0)
+					{
+						// ASC format
+						auto opus_config = std::make_shared<OpusSpecificConfig>();
+						auto extra_data = std::make_shared<ov::Data>(stream->codecpar->extradata, stream->codecpar->extradata_size, true);
+
+						if (opus_config->Parse(extra_data) == false)
+						{
+							return false;
+						}
+
+						media_track->SetDecoderConfigurationRecord(opus_config);
+					}
+
+					break;
+				}				case cmn::MediaCodecId::Vp8:
 				case cmn::MediaCodecId::Vp9:
 				case cmn::MediaCodecId::Flv:
 				case cmn::MediaCodecId::Mp3:
-				case cmn::MediaCodecId::Opus:
 				case cmn::MediaCodecId::Jpeg:
 				case cmn::MediaCodecId::Png:
 				default:

--- a/src/projects/providers/scheduled/scheduled_stream.cpp
+++ b/src/projects/providers/scheduled/scheduled_stream.cpp
@@ -400,7 +400,7 @@ namespace pvd
         std::map<int, int64_t> track_single_file_dts_offset_map;
         std::map<int, bool> end_of_track_map;
 
-        bool use_annexb { std::strncmp(context->iformat->name, "mpegts", 6) == 0 };
+        bool is_mpegts { std::strncmp(context->iformat->name, "mpegts", 6) == 0 };
 
         while (_worker_thread_running)
         {
@@ -479,15 +479,15 @@ namespace pvd
 			switch (track->GetCodecId())
 			{
 				case cmn::MediaCodecId::H264:
-					bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H264_ANNEXB : cmn::BitstreamFormat::H264_AVCC;
+					bitstream_format = (is_mpegts) ? cmn::BitstreamFormat::H264_ANNEXB : cmn::BitstreamFormat::H264_AVCC;
 					packet_type = cmn::PacketType::NALU;
 					break;
 				case cmn::MediaCodecId::H265:
-					bitstream_format = (use_annexb) ? cmn::BitstreamFormat::H265_ANNEXB : cmn::BitstreamFormat::HVCC;
+					bitstream_format = (is_mpegts) ? cmn::BitstreamFormat::H265_ANNEXB : cmn::BitstreamFormat::HVCC;
 					packet_type = cmn::PacketType::NALU;
 					break;
 				case cmn::MediaCodecId::Aac:
-					bitstream_format = cmn::BitstreamFormat::AAC_RAW;
+					bitstream_format = (is_mpegts) ? cmn::BitstreamFormat::AAC_ADTS : cmn::BitstreamFormat::AAC_RAW;
 					packet_type = cmn::PacketType::RAW;
 					break;
 				case cmn::MediaCodecId::Opus:
@@ -752,7 +752,7 @@ namespace pvd
                 }
 
                 new_track->SetId(kScheduledAudioTrackId);
-                new_track->SetTimeBase(1, kScheduledTimebase); // We fixed time base in scheduled stream
+                new_track->SetTimeBase(1, new_track->GetSampleRate()/*kScheduledTimebase*/); // We fixed time base in scheduled stream
                 _origin_id_track_id_map.emplace(stream->index, kScheduledAudioTrackId);
                 UpdateTrack(new_track);
 

--- a/src/projects/publishers/file/file_session.cpp
+++ b/src/projects/publishers/file/file_session.cpp
@@ -323,14 +323,18 @@ namespace pub
 		// Drop until the first keyframe of the main track is received.
 		if (_found_first_keyframe == false)
 		{
-			if ((_default_track == session_packet->GetTrackId() && session_packet->GetFlag() == MediaPacketFlag::Key) == true)
+			if (_default_track == session_packet->GetTrackId())
 			{
-				_found_first_keyframe = true;
-			}
-			else
-			{
-				GetRecord()->UpdateRecordStartTime();
-				return;
+				if ((session_packet->GetMediaType() == cmn::MediaType::Audio) ||
+					(session_packet->GetMediaType() == cmn::MediaType::Video && session_packet->GetFlag() == MediaPacketFlag::Key))
+				{
+					_found_first_keyframe = true;
+				}
+				else
+				{
+					GetRecord()->UpdateRecordStartTime();
+					return;
+				}
 			}
 		}
 
@@ -338,7 +342,9 @@ namespace pub
 
 		// When setting interval parameter, perform segmentation recording.
 		if (((uint64_t)GetRecord()->GetInterval() > 0) && (GetRecord()->GetRecordTime() > (uint64_t)GetRecord()->GetInterval()) &&
-			(session_packet->GetFlag() == MediaPacketFlag::Key) && (session_packet->GetTrackId() == _default_track))
+			(session_packet->GetTrackId() == _default_track) &&
+			((session_packet->GetMediaType() == cmn::MediaType::Audio) ||
+			(session_packet->GetMediaType() == cmn::MediaType::Video && session_packet->GetFlag() == MediaPacketFlag::Key)) )
 		{
 			need_file_split = true;
 		}


### PR DESCRIPTION
This P.R. solves some audio problems on the scheduled provider.
It also adds the possibility of saving opus audio tracks on mpegts and mp4 containers.

1) Problem. When a file contains only one audio track the stream does not start. Patch to file "src/projects/publishers/file/file_session.cpp" fixes this problem.

2) Problem. When using a mpegts container with aac encoded audio, it doesn't work. Mpegts uses an AAC_ADTS type bitstream. Patch to the "src/projects/providers/scheduled/scheduled_stream.cpp" file resolves this issue.

3) Improvement. Added the ability to save opus audio tracks in mpegts and mp4 containers. This allows you to best use the "bypassTranscoder" parameter of the scheduledChannel API. All other changes add this feature.

4) Added a line to the .gitignore file, for Qt Creator.

Thanks in advance.