### PR TITLE
fix: Multiplexed stream is not present in OriginMapStore Redis db

### DIFF
--- a/src/projects/publishers/ovt/ovt_stream.cpp
+++ b/src/projects/publishers/ovt/ovt_stream.cpp
@@ -38,7 +38,7 @@ bool OvtStream::Start()
 		return false;
 	}
 
-	if (GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore() == false)
+	if (!IsFromOriginMapStore())
 	{
 		auto result = ocst::Orchestrator::GetInstance()->RegisterStreamToOriginMapStore(GetApplicationInfo().GetVHostAppName(), GetName());
 		if (result == CommonErrorCode::ERROR)
@@ -68,7 +68,7 @@ bool OvtStream::Stop()
 
 	logtd("OvtStream(%u) has been stopped", GetId());
 
-	if (GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore() == false)
+	if (!IsFromOriginMapStore())
 	{
 		// Unegister stream if OriginMapStore is enabled
 		auto result = ocst::Orchestrator::GetInstance()->UnregisterStreamFromOriginMapStore(GetApplicationInfo().GetVHostAppName(), GetName());
@@ -263,4 +263,9 @@ bool OvtStream::RemoveSessionByConnectorId(int connector_id)
 	}
 
 	return false;
+}
+
+bool OvtStream::IsFromOriginMapStore() const
+{
+    return GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore();
 }

--- a/src/projects/publishers/ovt/ovt_stream.h
+++ b/src/projects/publishers/ovt/ovt_stream.h
@@ -34,6 +34,8 @@ private:
 
 	bool GenerateDescription();
 
+	bool IsFromOriginMapStore() const;
+
 	uint32_t							_worker_count = 0;
 
 	Json::Value							_description;


### PR DESCRIPTION
[https://github.com/AirenSoft/OvenMediaEngine/issues/1577](https://github.com/AirenSoft/OvenMediaEngine/issues/1577)

change syntax from
```
GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore() == false
```
| GetLinkedInputStream() | GetLinkedInputStream()->IsFromOriginMapStore() | GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore() == false |
|------------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------|
| nullptr                | N/A                                           | false                                                                                          |
| not nullptr            | false                                         | true                                                                                           |
| not nullptr            | true                                          | false                                                                                          |

to
```
!(GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore())
```

| GetLinkedInputStream() | GetLinkedInputStream()->IsFromOriginMapStore() | GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore() | !(GetLinkedInputStream() != nullptr && GetLinkedInputStream()->IsFromOriginMapStore()) |
|------------------------|-----------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
| nullptr                | N/A                                           | false                                                                               | true                                                                                 |
| not nullptr            | false                                         | false                                                                               | true                                                                                 |
| not nullptr            | true                                          | true                                                                                | false                                                                                |


And for readble, create new private method OvtStream::IsFromOriginMapStore  for reusing in OvtStream::Start() and OvtStream::Stop()