### PR TITLE
Normalize HLSChunklistPathDepth attribute

### DIFF
--- a/src/projects/providers/multiplex/multiplex_profile.cpp
+++ b/src/projects/providers/multiplex/multiplex_profile.cpp
@@ -418,7 +418,7 @@ namespace pvd
 					playlist->SetWebRtcAutoAbr(webrtc_auto_abr.text().as_bool());
 				}
 
-				auto hls_chunklist_path_depth = options_node.child("HLSChunklistPathDepth");
+				auto hls_chunklist_path_depth = options_node.child("HLSChunklistPathDepth") || options_node.child("HlsChunklistPathDepth");
 				if (hls_chunklist_path_depth)
 				{
 					playlist->SetHlsChunklistPathDepth(hls_chunklist_path_depth.text().as_int());
@@ -618,9 +618,10 @@ namespace pvd
 					options_node.append_child("WebRtcAutoAbr").text().set(playlist->IsWebRtcAutoAbr());
 				}
 
-				if (playlist->GetHlsChunklistPathDepth() != -1)
+				int hls_chunklist_path_depth = playlist->GetHlsChunklistPathDepth();
+				if (hls_chunklist_path_depth != -1)
 				{
-					options_node.append_child("HLSChunklistPathDepth").text().set(playlist->GetHlsChunklistPathDepth());
+					options_node.append_child("HLSChunklistPathDepth").text().set(hls_chunklist_path_depth);
 				}
 
 				if (playlist->IsTsPackagingEnabled())

--- a/src/projects/providers/multiplex/multiplex_profile.cpp
+++ b/src/projects/providers/multiplex/multiplex_profile.cpp
@@ -126,9 +126,9 @@ namespace pvd
 			_last_error = "Failed to find outputStream/name object";
 			return false;
 		}
-		
+
 		_output_stream_name = name_object.asString().c_str();
-		
+
 		return true;
 	}
 
@@ -418,7 +418,7 @@ namespace pvd
 					playlist->SetWebRtcAutoAbr(webrtc_auto_abr.text().as_bool());
 				}
 
-				auto hls_chunklist_path_depth = options_node.child("HlsChunklistPathDepth");
+				auto hls_chunklist_path_depth = options_node.child("HLSChunklistPathDepth");
 				if (hls_chunklist_path_depth)
 				{
 					playlist->SetHlsChunklistPathDepth(hls_chunklist_path_depth.text().as_int());
@@ -511,12 +511,12 @@ namespace pvd
 				_last_error = ov::String::FormatString("Failed to parse url: %s", url_str.CStr());
 				return false;
 			}
-			
+
 			// TrackMap
 			auto track_map_node = source_stream_node.child("TrackMap");
 
 			// Track
-			for (auto track_node = track_map_node.child("Track"); track_node; track_node = track_node.next_sibling("Track"))			
+			for (auto track_node = track_map_node.child("Track"); track_node; track_node = track_node.next_sibling("Track"))
 			{
 				auto source_track_name_node = track_node.child("SourceTrackName");
 				if (!source_track_name_node)
@@ -547,7 +547,7 @@ namespace pvd
 				{
 					framerate_conf = framerate_conf_node.text().as_int();
 				}
-				
+
 				ov::String source_track_name = source_track_name_node.text().as_string();
 				ov::String new_track_name = new_track_name_node.text().as_string();
 				source_stream->AddTrackMap(source_track_name, NewTrackInfo(source_track_name, new_track_name, bitrate_conf, framerate_conf));
@@ -620,7 +620,7 @@ namespace pvd
 
 				if (playlist->GetHlsChunklistPathDepth() != -1)
 				{
-					options_node.append_child("HlsChunklistPathDepth").text().set(playlist->GetHlsChunklistPathDepth());
+					options_node.append_child("HLSChunklistPathDepth").text().set(playlist->GetHlsChunklistPathDepth());
 				}
 
 				if (playlist->IsTsPackagingEnabled())
@@ -781,7 +781,7 @@ namespace pvd
 
 		info_str += ov::String::FormatString("OutputStreamName : %s\n", _output_stream_name.CStr());
 		info_str += ov::String::FormatString("SourceStreams : %d\n", _source_streams.size());
-		
+
 		for (const auto &source : GetSourceStreams())
 		{
 			info_str += ov::String::FormatString("\tSourceStream : %s\n", source->GetName().CStr());

--- a/src/projects/providers/multiplex/multiplex_profile.cpp
+++ b/src/projects/providers/multiplex/multiplex_profile.cpp
@@ -418,11 +418,16 @@ namespace pvd
 					playlist->SetWebRtcAutoAbr(webrtc_auto_abr.text().as_bool());
 				}
 
-				auto hls_chunklist_path_depth = options_node.child("HLSChunklistPathDepth") || options_node.child("HlsChunklistPathDepth");
-				if (hls_chunklist_path_depth)
+				auto hls_chunklist_path_depth = options_node.child("HLSChunklistPathDepth");
+				if (!hls_chunklist_path_depth)
 				{
-					playlist->SetHlsChunklistPathDepth(hls_chunklist_path_depth.text().as_int());
+					hls_chunklist_path_depth = options_node.child("HlsChunklistPathDepth");
 				}
+
+				if (hls_chunklist_path_depth)
+    			{
+        			playlist->SetHlsChunklistPathDepth(hls_chunklist_path_depth.text().as_int());
+    			}
 
 				auto enable_ts_packaging = options_node.child("EnableTsPackaging");
 				if (enable_ts_packaging)
@@ -618,10 +623,9 @@ namespace pvd
 					options_node.append_child("WebRtcAutoAbr").text().set(playlist->IsWebRtcAutoAbr());
 				}
 
-				int hls_chunklist_path_depth = playlist->GetHlsChunklistPathDepth();
-				if (hls_chunklist_path_depth != -1)
+				if (playlist->GetHlsChunklistPathDepth() != -1)
 				{
-					options_node.append_child("HLSChunklistPathDepth").text().set(hls_chunklist_path_depth);
+					options_node.append_child("HLSChunklistPathDepth").text().set(playlist->GetHlsChunklistPathDepth());
 				}
 
 				if (playlist->IsTsPackagingEnabled())


### PR DESCRIPTION
When setting a profile (transcoding) the option to set the depth of the playlist path uses HLSChunklistPathDepth, however, when using multiplexing approach it uses HlsChunklistPathDepth.

It might be a good idea using the same atribute name.