### PR TITLE
fix(gcc_version build): gcc_version is always empty

### DIFF
--- a/src/core/global_config.mk
+++ b/src/core/global_config.mk
@@ -1,5 +1,5 @@
 GCC_VERSION := $(shell gcc -v 2>&1 | tail -1 | awk ' { print $3 } ')
-GCC_VERSION := $(word 3, $(GCC_VERSION))
+# GCC_VERSION := $(word 3, $(GCC_VERSION))
 GCC_VERSION := $(subst ., ,$(GCC_VERSION))
 
 GCC_VERSION_MAJOR := $(word 1, $(GCC_VERSION))


### PR DESCRIPTION
shell:gcc -v 2>&1 | tail -1 | awk ' { print $3 } ' 
output: x.x.x
GCC_VERSION := $(word 3, $(GCC_VERSION))
GCC_VERSION is always '' ,then it always goes to the else 