### PR TITLE
fix: dereferenced output_path variable

### DIFF
--- a/src/projects/publishers/hls/hls_stream.cpp
+++ b/src/projects/publishers/hls/hls_stream.cpp
@@ -26,7 +26,7 @@
 [Legacy HLS (Version 3) URLs]
 
 * Master Playlist
-http[s]://<host>:<port>/<application_name>/<stream_name>/ts:playlist.m3u8 
+http[s]://<host>:<port>/<application_name>/<stream_name>/ts:playlist.m3u8
 http[s]://<host>:<port>/<application_name>/<stream_name>/playlist.m3u8?format=ts
 
 * Media Playlist
@@ -387,7 +387,7 @@ void HlsStream::OnEvent(const std::shared_ptr<MediaEvent> &event)
 
 	switch(event->GetCommandType())
 	{
-		case MediaEvent::CommandType::ConcludeLive: 
+		case MediaEvent::CommandType::ConcludeLive:
 		{
 			auto [result, message] = ConcludeLive();
 			if (result == true)
@@ -913,7 +913,7 @@ void HlsStream::InitializeAllDumps()
 
 			auto dump_item = std::make_shared<mdl::Dump>();
 			dump_item->SetId(dump.GetId());
-			dump_item->SetOutputPath(*output_path);
+			dump_item->SetOutputPath(output_path);
 			dump_item->SetPlaylists(dump.GetPlaylists());
 			dump_item->SetEnabled(true);
 
@@ -1025,7 +1025,7 @@ bool HlsStream::DumpSegment(const std::shared_ptr<mdl::Dump> &dump, const ov::St
 	}
 
 	std::shared_ptr<ov::Data> playlist_data;
-	if (segment_number == 0) 
+	if (segment_number == 0)
 	{
 		playlist_data = playlist->ToString(false).ToData(false);
 		if (!playlist_data)

--- a/src/projects/publishers/llhls/llhls_stream.cpp
+++ b/src/projects/publishers/llhls/llhls_stream.cpp
@@ -217,7 +217,7 @@ bool LLHlsStream::Start()
 
 			auto dump_item = std::make_shared<mdl::Dump>();
 			dump_item->SetId(dump.GetId());
-			dump_item->SetOutputPath(*output_path);
+			dump_item->SetOutputPath(output_path);
 			dump_item->SetPlaylists(dump.GetPlaylists());
 			dump_item->SetEnabled(true);
 
@@ -1083,7 +1083,7 @@ void LLHlsStream::SendDataFrame(const std::shared_ptr<MediaPacket> &media_packet
 				auto scte_out_duration_ms = scte35_event->GetDurationMsec();
 				auto scte_in_timestamp_ms = timestamp_ms + scte_out_duration_ms;
 				auto scte_in_data = Scte35Event::Create(mpegts::SpliceCommandType::SPLICE_INSERT, scte35_event->GetID(), false, scte_in_timestamp_ms, scte_out_duration_ms, false)->Serialize();
-				
+
 				// xxx-OUT marker will create one more segment, so we need to shift the sequence number by 1
 				if (InsertMarkerToAllPackagers(media_packet->GetTrackId(), cmn::BitstreamFormat::SCTE35, scte_in_timestamp_ms, scte_in_data) == false)
 				{


### PR DESCRIPTION
In my last PR #1884, I introduced a bug by dereferencing `output_path` when passing it to the setter. The effect was no dumps were being saved, since no path was provided.

