### PR TITLE
feat: Per-track RTCP SR fallback to delta-based PTS calculation

### DIFF
--- a/src/projects/base/provider/stream.h
+++ b/src/projects/base/provider/stream.h
@@ -8,6 +8,7 @@
 //==============================================================================
 #pragma once
 
+#include <set>
 #include <base/common_types.h>
 #include <base/info/stream.h>
 #include <base/ovlibrary/lip_sync_clock.h>
@@ -159,6 +160,10 @@ namespace pvd
 
 		LipSyncClock 						_rtp_lip_sync_clock;
 		ov::StopWatch						_first_rtp_received_time;
+
+		// Per-track fallback to SINGLE_DELTA when SR is never received for a specific track
+		std::set<uint32_t>					_sr_fallback_tracks;
+		std::map<uint32_t, ov::StopWatch>	_per_track_sr_wait;
 
 		int64_t _last_media_timestamp_ms = -1LL;
 		ov::StopWatch _elapsed_from_last_media_timestamp;


### PR DESCRIPTION
## Summary

Adds per-track fallback from RTCP SR-based to delta-based PTS calculation when a specific track never receives Sender Reports.

## What this does

- Starts a per-track timer when `CalcPTS` first fails (no SR received yet)
- After 5 seconds without an SR for a given track, falls back to delta-based PTS calculation for that track only
- Other tracks that do receive SRs continue using lip-sync based calculation
- Logs a warning when falling back
- Clears fallback state on stream reset

## Why it's needed

Some IP cameras (e.g. certain Unifi models) never send RTCP Sender Reports for one or more tracks. Without this fix, those tracks stall indefinitely waiting for an SR that never arrives, making the entire stream unusable.