### PR TITLE
fix: Add libgomp1 dependency to Dockerfile.local

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@ FROM    ubuntu:22.04 AS base
 
 ## Install libraries by package
 ENV     DEBIAN_FRONTEND=noninteractive
-RUN     apt-get update && apt-get install -y tzdata sudo curl git
+RUN     apt-get update && apt-get install -y tzdata sudo curl git libgomp1
 
 FROM    base AS build
 


### PR DESCRIPTION
## Summary

Adds `libgomp1` to the package install list in `Dockerfile.local`.

## Why it's needed

The local Docker build fails at runtime when OpenMP (libgomp) is not installed. This is a transitive dependency that isn't pulled in automatically by the other packages in the base image.