### PR TITLE
fix: Correct VP8 case label indentation in rtspc_stream.cpp

### DIFF
--- a/src/projects/providers/rtspc/rtspc_stream.cpp
+++ b/src/projects/providers/rtspc/rtspc_stream.cpp
@@ -548,7 +548,7 @@ namespace pvd
 					depacketizer_type = RtpDepacketizingManager::SupportedDepacketizerType::H265;
 					break;
 
-					case PayloadAttr::SupportCodec::VP8:
+				case PayloadAttr::SupportCodec::VP8:
 					track->SetMediaType(cmn::MediaType::Video);
 					track->SetCodecId(cmn::MediaCodecId::Vp8);
 					track->SetOriginBitstream(cmn::BitstreamFormat::VP8_RTP_RFC_7741);


### PR DESCRIPTION
## Summary

Fixes incorrect indentation of the `VP8` case label in the codec switch statement in `rtspc_stream.cpp`.

## What this does

The `case PayloadAttr::SupportCodec::VP8:` label had an extra tab, placing it at the same indentation level as the code inside the case block rather than aligned with the other case labels (`H264`, `H265`, `MPEG4_GENERIC`, etc.).

One-line whitespace fix, no functional change.