### PR TITLE
fix: Call UninitCodec() in CodecThread to prevent TSAN data race (FF_THREAD_FRAME)

### DIFF
--- a/src/projects/transcoder/codec/decoder/decoder_avc.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_avc.cpp
@@ -247,4 +247,8 @@ void DecoderAVC::CodecThread()
 			}
 		}
 	}
+
+	// Must be called here to ensure FF_THREAD_FRAME workers are joined
+	// before this thread exits, avoiding a race with the destructor.
+	UninitCodec();
 }

--- a/src/projects/transcoder/codec/decoder/decoder_hevc.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_hevc.cpp
@@ -241,4 +241,8 @@ void DecoderHEVC::CodecThread()
 			}
 		}
 	}
+
+	// Must be called here to ensure FF_THREAD_FRAME workers are joined
+	// before this thread exits, avoiding a race with the destructor.
+	UninitCodec();
 }

--- a/src/projects/transcoder/codec/decoder/decoder_vp8.cpp
+++ b/src/projects/transcoder/codec/decoder/decoder_vp8.cpp
@@ -238,4 +238,8 @@ void DecoderVP8::CodecThread()
 			}
 		}
 	}
+
+	// Must be called here to ensure FF_THREAD_FRAME workers are joined
+	// before this thread exits, avoiding a race with the destructor.
+	UninitCodec();
 }


### PR DESCRIPTION
## Problem

When `avcodec_open2()` is called with `FF_THREAD_FRAME`, FFmpeg internally spawns worker threads. These threads are lifecycle-managed by FFmpeg itself.

Previously, `avcodec_free_context()` was called from `~TranscodeDecoder()` (running in the socket/stream teardown thread) after `_codec_thread.join()` returned. However, FFmpeg's internal frame-threading workers could still be running at that point, causing the following TSAN data race:

```
Write of size 8 by thread T59:
  #1 avcodec_free_context        (libavcodec.so.59)
  #2 DecoderAVC::~DecoderAVC()
  #10 TranscoderStream::RemoveDecoders()

Previous write of size 8 by thread T133:
  #2 (libavcodec.so.59)          <- FFmpeg internal frame worker
  #2 DecoderAVC::CodecThread()   <- created via avcodec_open2 + FF_THREAD_FRAME
```

## Fix

Call `UninitCodec()` at the end of `CodecThread()`, so that `avcodec_free_context()` is invoked from within the codec thread itself. This causes FFmpeg to properly stop and join its internal frame workers before the thread exits. By the time `_codec_thread.join()` returns in `Stop()`, `_codec_context` is already `nullptr`, and the destructor's null-check guard prevents any double-free.

## Affected Files

| File | Reason |
|---|---|
| `decoder_avc.cpp` | Uses `FF_THREAD_FRAME` (software H.264 decoder) |
| `decoder_hevc.cpp` | Uses `FF_THREAD_FRAME` (software H.265 decoder) |
| `decoder_vp8.cpp`  | Uses `FF_THREAD_FRAME` (software VP8 decoder) |

HW decoders (NV/QSV/XMA/NILOGAN) and all encoders are **not affected** — they do not use `FF_THREAD_FRAME`.