### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OvenMediaLabs/ome-core-devs


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically assign a member of the @OvenMediaLabs/ome-core-devs team as a reviewer for new pull requests.