### PR TITLE
fix: intermittent crash on simultaneous start/stop recording API requests

### DIFF
--- a/src/projects/base/info/record.cpp
+++ b/src/projects/base/info/record.cpp
@@ -11,8 +11,6 @@ namespace info
 {
 	Record::Record()
 	{
-		// _stream = nullptr;
-
 		_created_time = std::chrono::system_clock::now();
 		_id = "";
 		_is_config = false;
@@ -30,6 +28,8 @@ namespace info
 		_file_path_by_user = false;
 		_info_path = "";
 		_info_path_by_user = false;
+		_output_file_path = "";
+		_output_info_path = "";
 
 		_record_bytes = 0;
 		_record_time = 0;
@@ -40,9 +40,13 @@ namespace info
 		_interval = 0;
 		_schedule = "";
 		_segmentation_rule = "";
+		_schedule_next = std::chrono::system_clock::time_point{};
+		_record_start_time = std::chrono::system_clock::time_point{};
+		_record_stop_time = std::chrono::system_clock::time_point{};
 
 		_session_id = 0;
-
+		_enable = false;
+		_remove = false;
 		_state = RecordState::Ready;
 	}
 
@@ -86,11 +90,11 @@ namespace info
 
 	void Record::SetEnable(bool eanble)
 	{
-		_enable = eanble;
+		_enable.store(eanble);
 	}
 	bool Record::GetEnable()
 	{
-		return _enable;
+		return _enable.load();
 	}
 
 	void Record::SetVhost(ov::String value)
@@ -133,34 +137,32 @@ namespace info
 
 	void Record::SetTrackIds(const std::vector<uint32_t>& ids)
 	{
-		_selected_track_ids.clear();
-		_selected_track_ids.assign( ids.begin(), ids.end() ); 
+		_selected_track_ids = ids;
 	}
 
 	void Record::SetVariantNames(const std::vector<ov::String>& names)
 	{
-		_selected_variant_names.clear();
-		_selected_variant_names.assign( names.begin(), names.end() ); 
+		_selected_variant_names = names;
 	}
 
-	const std::vector<uint32_t>& Record::GetTrackIds() 
+	std::vector<uint32_t> Record::GetTrackIds()
 	{
 		return _selected_track_ids;
 	}
 
-	const std::vector<ov::String>& Record::GetVariantNames()
+	std::vector<ov::String> Record::GetVariantNames()
 	{
 		return _selected_variant_names;
 	}
 
 	void Record::SetRemove(bool value)
 	{
-		_remove = value;
+		_remove.store(value);
 	}
 
 	bool Record::GetRemove()
 	{
-		return _remove;
+		return _remove.load();
 	}
 
 	void Record::SetSessionId(session_id_t id)
@@ -173,7 +175,7 @@ namespace info
 		return _session_id;
 	}
 
-	const std::chrono::system_clock::time_point &Record::GetCreatedTime() const
+	std::chrono::system_clock::time_point Record::GetCreatedTime() const
 	{
 		return _created_time;
 	}
@@ -206,7 +208,7 @@ namespace info
 		return _segmentation_rule;
 	}
 
-	const std::chrono::system_clock::time_point &Record::GetNextScheduleTime() const
+	std::chrono::system_clock::time_point Record::GetNextScheduleTime() const
 	{
 		return _schedule_next;
 	}
@@ -216,7 +218,7 @@ namespace info
 		return (_schedule_next.time_since_epoch().count() == 0) ? true : false;
 	}
 
-	void Record::SetNextScheduleTime(std::chrono::system_clock::time_point &next)
+	void Record::SetNextScheduleTime(const std::chrono::system_clock::time_point &next)
 	{
 		_schedule_next = next;
 	}
@@ -303,23 +305,11 @@ namespace info
 	}
 	void Record::SetRecordTotalTime(uint64_t time)
 	{
-		_record_total_bytes = time;
+		_record_total_time = time;
 	}
 	void Record::SetSequence(uint64_t sequence)
 	{
 		_sequence = sequence;
-	}
-	void Record::SetCreatedTime(std::chrono::system_clock::time_point tp)
-	{
-		_created_time = tp;
-	}
-	void Record::SetRecordStartTime(std::chrono::system_clock::time_point tp)
-	{
-		_record_start_time = tp;
-	}
-	void Record::SetRecordStopTime(std::chrono::system_clock::time_point tp)
-	{
-		_record_stop_time = tp;
 	}
 	bool Record::IsInfoPathSetByUser()
 	{
@@ -383,11 +373,11 @@ namespace info
 	{
 		return _sequence;
 	}
-	const std::chrono::system_clock::time_point Record::GetRecordStartTime() const
+	std::chrono::system_clock::time_point Record::GetRecordStartTime() const
 	{
 		return _record_start_time;
 	}
-	const std::chrono::system_clock::time_point Record::GetRecordStopTime() const
+	std::chrono::system_clock::time_point Record::GetRecordStopTime() const
 	{
 		return _record_stop_time;
 	}
@@ -418,8 +408,45 @@ namespace info
 		return "Unknown";
 	}
 
-	void Record::Clone(std::shared_ptr<info::Record> &record)
+	void Record::CloneTo(const std::shared_ptr<info::Record> &record)
 	{
+		if (record == nullptr || record.get() == this)
+		{
+			return;
+		}
+
+		record->_transaction_id			= _transaction_id;
+		record->_id						= _id;
+		record->_is_config				= _is_config;
+		record->_metadata				= _metadata;
+		record->_enable.store(_enable.load());
+		record->_remove.store(_remove.load());
+		record->_vhost_name				= _vhost_name;
+		record->_application_name		= _application_name;
+		record->_stream_name			= _stream_name;
+		record->_selected_track_ids		= _selected_track_ids;
+		record->_selected_variant_names = _selected_variant_names;
+		record->_file_path				= _file_path;
+		record->_file_path_by_user		= _file_path_by_user;
+		record->_info_path				= _info_path;
+		record->_info_path_by_user		= _info_path_by_user;
+		record->_output_file_path		= _output_file_path;
+		record->_output_info_path		= _output_info_path;
+		record->_tmp_path				= _tmp_path;
+		record->_interval				= _interval;
+		record->_schedule				= _schedule;
+		record->_schedule_next			= _schedule_next;
+		record->_record_bytes			= _record_bytes;
+		record->_record_total_bytes		= _record_total_bytes;
+		record->_record_time			= _record_time;
+		record->_record_total_time		= _record_total_time;
+		record->_segmentation_rule		= _segmentation_rule;
+		record->_sequence				= _sequence;
+		record->_created_time			= _created_time;
+		record->_record_start_time		= _record_start_time;
+		record->_record_stop_time		= _record_stop_time;
+		record->_state					= _state;
+		record->_session_id				= _session_id;
 	}
 
 	const ov::String Record::GetInfoString()

--- a/src/projects/base/info/record.h
+++ b/src/projects/base/info/record.h
@@ -55,8 +55,8 @@ namespace info
 		void SetTrackIds(const std::vector<uint32_t>& ids);
 		void SetVariantNames(const std::vector<ov::String>& names);
 
-		const std::vector<uint32_t>& GetTrackIds();
-		const std::vector<ov::String>& GetVariantNames();
+		std::vector<uint32_t> GetTrackIds();
+		std::vector<ov::String> GetVariantNames();
 
 		void SetRemove(bool value);
 		bool GetRemove();
@@ -71,8 +71,8 @@ namespace info
 		// set by user
 		void SetSchedule(ov::String schedule);
 		ov::String GetSchedule();
-		const std::chrono::system_clock::time_point &GetNextScheduleTime() const;
-		void SetNextScheduleTime(std::chrono::system_clock::time_point &next);
+		std::chrono::system_clock::time_point GetNextScheduleTime() const;
+		void SetNextScheduleTime(const std::chrono::system_clock::time_point &next);
 		bool IsNextScheduleTimeEmpty();
 		bool UpdateNextScheduleTime();
 
@@ -82,12 +82,10 @@ namespace info
 
 		// set by user
 		void SetFilePath(ov::String file_path);
-		void SetFilePathTemplate(ov::String file_path);
 		ov::String GetFilePath();
 
 		// set by user
 		void SetInfoPath(ov::String info_path);
-		void SetInfoPathTemplate(ov::String file_path);
 		ov::String GetInfoPath();
 
 		void SetFilePathSetByUser(bool by_user);
@@ -125,12 +123,9 @@ namespace info
 		uint64_t GetSequence();
 		void SetSequence(uint64_t sequence);
 
-		const std::chrono::system_clock::time_point &GetCreatedTime() const;
-		const std::chrono::system_clock::time_point GetRecordStartTime() const;
-		const std::chrono::system_clock::time_point GetRecordStopTime() const;
-		void SetCreatedTime(std::chrono::system_clock::time_point tp);
-		void SetRecordStartTime(std::chrono::system_clock::time_point tp);
-		void SetRecordStopTime(std::chrono::system_clock::time_point tp);
+		std::chrono::system_clock::time_point GetCreatedTime() const;
+		std::chrono::system_clock::time_point GetRecordStartTime() const;
+		std::chrono::system_clock::time_point GetRecordStopTime() const;
 
 		enum class RecordState : int8_t
 		{
@@ -145,7 +140,7 @@ namespace info
 		void SetState(RecordState state);
 		ov::String GetStateString();
 
-		void Clone(std::shared_ptr<info::Record> &record);
+		void CloneTo(const std::shared_ptr<info::Record> &record);
 
 		const ov::String GetInfoString();
 
@@ -164,10 +159,10 @@ namespace info
 		ov::String _metadata;
 
 		// Enabled/Disabled Flag
-		bool _enable;
+		std::atomic<bool> _enable;
 
 		// Remove Flag
-		bool _remove;
+		std::atomic<bool> _remove;
 
 		// Virtual Host
 		ov::String _vhost_name;

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -166,6 +166,12 @@ namespace ffmpeg
 
 	bool Writer::AddMediaTrack(const std::shared_ptr<MediaTrack> &media_track, const std::shared_ptr<AVStream> &av_stream)
 	{
+		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
+		{
+			SetErrorMessage("Could not add track. MediaTrack or AVStream is null");
+			return false;
+		}
+
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_av_track_map[media_track->GetId()] = std::make_pair(av_stream, media_track);
 
@@ -180,6 +186,12 @@ namespace ffmpeg
 
 	bool Writer::AddEventTrack(const std::shared_ptr<MediaTrack> &media_track, const std::shared_ptr<AVStream> &av_stream, cmn::BitstreamFormat format)
 	{
+		if (media_track == nullptr || av_stream == nullptr || av_stream->codecpar == nullptr)
+		{
+			SetErrorMessage("Could not add event track. MediaTrack or AVStream is null");
+			return false;
+		}
+
 		std::lock_guard<std::shared_mutex> mlock(_track_map_lock);
 		_event_track_map[std::make_pair(media_track->GetId(), format)] = std::make_pair(av_stream, media_track);
 
@@ -215,6 +227,7 @@ namespace ffmpeg
 
 			if (!AddMediaTrack(media_track, av_stream))
 			{
+				// TODO(Keukhan): AVStream has been added to the AVFormat, a logic to remove the AVStream is needed in case of failure.
 				return false;
 			}
 		}

--- a/src/projects/publishers/file/file_application.cpp
+++ b/src/projects/publishers/file/file_application.cpp
@@ -48,7 +48,7 @@ namespace pub
 			auto records_info = GetRecordInfoFromFile(stream_map_config.GetPath(), info);
 			for (auto record : records_info)
 			{
-				auto result = RecordStart(record);
+				auto result = RecordStartInternal(record);
 				if (result->GetCode() != FilePublisher::FilePublisherStatusCode::Success)
 				{
 					logtw("FileStream(%s/%s) - Failed to start record. id(%s) status(%d) description(%s)", GetVHostAppName().CStr(), info->GetName().CStr(), record->GetId().CStr(), result->GetCode(), result->GetMessage().CStr());
@@ -59,6 +59,7 @@ namespace pub
 		return FileStream::Create(GetSharedPtrAs<pub::Application>(), *info);
 	}
 
+	// Called by StreamWorkekr when the stream is deleted.
 	bool FileApplication::DeleteStream(const std::shared_ptr<info::Stream> &info)
 	{
 		auto stream = std::static_pointer_cast<FileStream>(GetStream(info->GetId()));
@@ -72,17 +73,21 @@ namespace pub
 		auto record_info_list = _record_info_list.GetByStreamName(info->GetName());
 		for (auto record_info : record_info_list)
 		{
+			// If the record is requested by the user. it is not deleted even if the stream is deleted.
+			// It will be maintained until the user requests Record Stop API.
 			if (record_info->IsByConfig() == false)
 			{
 				continue;
 			}
 
-			auto result = RecordStop(record_info);
+			auto result = RecordStopInternal(record_info);
 			if (result->GetCode() != FilePublisher::FilePublisherStatusCode::Success)
 			{
 				logtw("FileStream(%s/%s) - Failed to stop record. id(%s) status(%d) description(%s)", GetVHostAppName().CStr(), info->GetName().CStr(), record_info->GetId().CStr(), result->GetCode(), result->GetMessage().CStr());
+				continue;
 			}
 		}
+		SessionUpdateInternal();
 
 		logti("File Application %s/%s stream has been deleted", GetVHostAppName().CStr(), stream->GetName().CStr());
 
@@ -145,7 +150,7 @@ namespace pub
 		}
 	}
 
-	void FileApplication::SessionUpdate(std::shared_ptr<FileStream> stream, std::shared_ptr<info::Record> userdata)
+	void FileApplication::SessionControllInternal(std::shared_ptr<FileStream> stream, std::shared_ptr<info::Record> userdata)
 	{
 		// If there is no session, create a new file(record) session.
 		auto session = std::static_pointer_cast<FileSession>(stream->GetSession(userdata->GetSessionId()));
@@ -179,45 +184,47 @@ namespace pub
 			return;
 		}
 
-		for (uint32_t i = 0; i < _record_info_list.GetCount(); i++)
+		auto record_info_list = _record_info_list.GetByStreamName(stream->GetName());
+		for (auto &userdata : record_info_list)
 		{
-			auto userdata = _record_info_list.GetAt(i);
-			if (userdata == nullptr)
-				continue;
-
-			if (userdata->GetStreamName() != stream->GetName())
-				continue;
-
 			if (stopped == true)
 			{
 				userdata->SetState(info::Record::RecordState::Ready);
 			}
 			else
 			{
-				SessionUpdate(stream, userdata);
+				SessionControllInternal(stream, userdata);
 			}
 		}
 	}
 
-	void FileApplication::SessionUpdateByUser()
+	void FileApplication::SessionUpdateInternal()
 	{
-		for (uint32_t i = 0; i < _record_info_list.GetCount(); i++)
+		auto record_info_list = _record_info_list.GetAll();
+		for (auto &userdata : record_info_list)
 		{
-			auto userdata = _record_info_list.GetAt(i);
 			if (userdata == nullptr)
 				continue;
 
-			// Find a stream related to Userdata.
+			auto record_info = _record_info_list.GetByKey(userdata->GetId());
+			if (record_info == nullptr)
+			{
+				continue;
+			}
+
 			auto stream = std::static_pointer_cast<FileStream>(GetStream(userdata->GetStreamName()));
 			if (stream != nullptr && stream->GetState() == pub::Stream::State::STARTED)
 			{
-				SessionUpdate(stream, userdata);
+				// If the stream is already exist, the session is controlled according to the user request.
+				SessionControllInternal(stream, userdata);
 			}
 			else
 			{
+				// If the stream is not exist, the record state is set to ready until the stream is created.
 				userdata->SetState(info::Record::RecordState::Ready);
 			}
 
+			// GC
 			if (userdata->GetRemove() == true)
 			{
 				if (stream != nullptr && userdata->GetSessionId() != 0)
@@ -230,7 +237,13 @@ namespace pub
 		}
 	}
 
+	// Called By API
 	std::shared_ptr<ov::Error> FileApplication::RecordStart(const std::shared_ptr<info::Record> record)
+	{
+		return RecordStartInternal(record);
+	}
+
+	std::shared_ptr<ov::Error> FileApplication::RecordStartInternal(const std::shared_ptr<info::Record> &record)
 	{
 		// Checking for the required parameters
 		if (record->GetId().IsEmpty() == true || record->GetStreamName().IsEmpty() == true)
@@ -282,14 +295,6 @@ namespace pub
 			}
 		}
 
-		// Checking for the duplicate id
-		if (_record_info_list.GetByKey(record->GetId()) != nullptr)
-		{
-			ov::String error_message = "Duplicate ID already exists";
-
-			return ov::Error::CreateError(FILE_PUBLISHER_ERROR_DOMAIN, FilePublisher::FilePublisherStatusCode::FailureDuplicateKey, error_message);
-		}
-
 		record->SetTransactionId(ov::Random::GenerateString(16));
 		record->SetEnable(true);
 		record->SetRemove(false);
@@ -299,14 +304,30 @@ namespace pub
 		record->SetFilePathSetByUser((record->GetFilePath().IsEmpty() != true) ? true : false);
 		record->SetInfoPathSetByUser((record->GetInfoPath().IsEmpty() != true) ? true : false);
 
-		_record_info_list.Set(record->GetId(), record);
+		if (_record_info_list.Set(record->GetId(), record) == false)
+		{
+			ov::String error_message = "Duplicate ID already exists";
 
-		SessionUpdateByUser();
+			return ov::Error::CreateError(FILE_PUBLISHER_ERROR_DOMAIN, FilePublisher::FilePublisherStatusCode::FailureDuplicateKey, error_message);
+		}
 
 		return ov::Error::CreateError(FILE_PUBLISHER_ERROR_DOMAIN, FilePublisher::FilePublisherStatusCode::Success, "Success");
 	}
 
+	// Call by API
 	std::shared_ptr<ov::Error> FileApplication::RecordStop(const std::shared_ptr<info::Record> record)
+	{
+		std::shared_ptr<ov::Error> result = RecordStopInternal(record);
+		if (result->GetCode() == FilePublisher::FilePublisherStatusCode::Success)
+		{
+			SessionUpdateInternal();
+		}
+
+		return result;
+	}
+
+
+	std::shared_ptr<ov::Error> FileApplication::RecordStopInternal(const std::shared_ptr<info::Record> &record)
 	{
 		if (record->GetId().IsEmpty() == true)
 		{
@@ -333,39 +354,17 @@ namespace pub
 		record_info->SetEnable(false);
 		record_info->SetRemove(true);
 
-		// Copy current recording information to the requested parameters.
-		//
+		record_info->CloneTo(record);
 		record->SetState(info::Record::RecordState::Stopping);
-		record->SetMetadata(record_info->GetMetadata());
-		record->SetStreamName(record_info->GetStreamName());
-		record->SetTrackIds(record_info->GetTrackIds());
-		record->SetVariantNames(record_info->GetVariantNames());
-		record->SetSessionId(record_info->GetSessionId());
-		record->SetInterval(record_info->GetInterval());
-		record->SetSchedule(record_info->GetSchedule());
-		record->SetSegmentationRule(record_info->GetSegmentationRule());
-		record->SetFilePath(record_info->GetFilePath());
-		record->SetInfoPath(record_info->GetInfoPath());
-		record->SetTmpPath(record_info->GetTmpPath());
-		record->SetRecordBytes(record_info->GetRecordBytes());
-		record->SetRecordTotalBytes(record_info->GetRecordTotalBytes());
-		record->SetRecordTime(record_info->GetRecordTime());
-		record->SetRecordTotalTime(record_info->GetRecordTotalTime());
-		record->SetSequence(record_info->GetSequence());
-		record->SetCreatedTime(record_info->GetCreatedTime());
-		record->SetRecordStartTime(record_info->GetRecordStartTime());
-		record->SetRecordStopTime(record_info->GetRecordStopTime());
-
-		SessionUpdateByUser();
 
 		return ov::Error::CreateError(FILE_PUBLISHER_ERROR_DOMAIN, FilePublisher::FilePublisherStatusCode::Success, "Success");
 	}
 
 	std::shared_ptr<ov::Error> FileApplication::GetRecords(const std::shared_ptr<info::Record> record_query, std::vector<std::shared_ptr<info::Record>> &results)
 	{
-		for (uint32_t i = 0; i < _record_info_list.GetCount(); i++)
+		auto record_info_list = _record_info_list.GetAll();
+		for (auto &record_info : record_info_list)
 		{
-			auto record_info = _record_info_list.GetAt(i);
 			if (record_info == nullptr)
 				continue;
 

--- a/src/projects/publishers/file/file_application.h
+++ b/src/projects/publishers/file/file_application.h
@@ -28,9 +28,7 @@ namespace pub
 		std::vector<std::shared_ptr<info::Record>> GetRecordInfoFromFile(const ov::String &file_path, const std::shared_ptr<info::Stream> &info);
 
 	public:
-		void SessionUpdateByUser();
 		void SessionUpdateByStream(std::shared_ptr<FileStream> stream, bool stopped);
-		void SessionUpdate(std::shared_ptr<FileStream> stream, std::shared_ptr<info::Record> userdata);
 		void SessionStart(std::shared_ptr<FileSession> session);
 		void SessionStop(std::shared_ptr<FileSession> session);
 
@@ -38,6 +36,12 @@ namespace pub
 		std::shared_ptr<ov::Error> RecordStart(const std::shared_ptr<info::Record> record);
 		std::shared_ptr<ov::Error> RecordStop(const std::shared_ptr<info::Record> record);
 		std::shared_ptr<ov::Error> GetRecords(const std::shared_ptr<info::Record> record_query, std::vector<std::shared_ptr<info::Record>> &results);
+
+	private:
+		void SessionUpdateInternal();	
+		void SessionControllInternal(std::shared_ptr<FileStream> stream, std::shared_ptr<info::Record> userdata);		
+		std::shared_ptr<ov::Error> RecordStartInternal(const std::shared_ptr<info::Record> &record);
+		std::shared_ptr<ov::Error> RecordStopInternal(const std::shared_ptr<info::Record> &record);
 
 	private:
 		FileUserdataSets _record_info_list;

--- a/src/projects/publishers/file/file_session.cpp
+++ b/src/projects/publishers/file/file_session.cpp
@@ -50,7 +50,8 @@ namespace pub
 		if (StartRecord() == false)
 		{
 			logte("Failed to start recording. id(%d)", GetId());
-
+			SetState(SessionState::Error);
+			GetRecord()->SetState(info::Record::RecordState::Error);
 			return false;
 		}
 
@@ -64,7 +65,8 @@ namespace pub
 		if (StopRecord() == false)
 		{
 			logte("Failed to stop recording. id(%d)", GetId());
-
+			SetState(SessionState::Error);
+			GetRecord()->SetState(info::Record::RecordState::Error);
 			return false;
 		}
 
@@ -78,12 +80,16 @@ namespace pub
 		if (StopRecord() == false)
 		{
 			logte("Failed to stop recording. id(%d)", GetId());
+			SetState(SessionState::Error);
+			GetRecord()->SetState(info::Record::RecordState::Error);
 			return false;
 		}
 
 		if (StartRecord() == false)
 		{
 			logte("Failed to start recording. id(%d)", GetId());
+			SetState(SessionState::Error);
+			GetRecord()->SetState(info::Record::RecordState::Error);
 			return false;
 		}
 
@@ -444,7 +450,7 @@ namespace pub
 		_record = record;
 	}
 
-	std::shared_ptr<info::Record> &FileSession::GetRecord()
+	std::shared_ptr<info::Record> FileSession::GetRecord()
 	{
 		std::shared_lock<std::shared_mutex> mlock(_record_mutex);
 		return _record;
@@ -636,7 +642,7 @@ namespace pub
 		{
 			logtw("Could not supported codec. trackId: %u, container: %s codec: %s, variantName: %s",
 				  track->GetId(), output_format.CStr(), GetCodecIdString(track->GetCodecId()), track->GetVariantName().CStr());
-			return false;
+			return true;
 		}
 
 		logtd("Adding track to writer. trackId: %d, variantName: %s", track->GetId(), track->GetVariantName().CStr());

--- a/src/projects/publishers/file/file_session.h
+++ b/src/projects/publishers/file/file_session.h
@@ -30,7 +30,7 @@ namespace pub
 		void SendOutgoingData(const std::any &packet) override;
 
 		void SetRecord(std::shared_ptr<info::Record> &record);
-		std::shared_ptr<info::Record> &GetRecord();
+		std::shared_ptr<info::Record> GetRecord();
 		
 		bool AddTrack(const ov::String output_format, const std::shared_ptr<MediaTrack> &track);
 		

--- a/src/projects/publishers/file/file_userdata.cpp
+++ b/src/projects/publishers/file/file_userdata.cpp
@@ -16,18 +16,32 @@ namespace pub
 		_sets.clear();
 	}
 
-	bool FileUserdataSets::Set(ov::String record_id, std::shared_ptr<info::Record> record_info)
+	bool FileUserdataSets::Set(ov::String record_id, const std::shared_ptr<info::Record> &record_info)
 	{
 		std::lock_guard<std::shared_mutex> lock(_mutex);
 
-		_sets[record_id] = record_info;
+		auto [it, inserted] = _sets.emplace(record_id, record_info);
+		return inserted;
+	}
 
-		return true;
+	
+	std::vector<std::shared_ptr<info::Record>> FileUserdataSets::GetAll()
+	{
+		std::vector<std::shared_ptr<info::Record>> results;
+
+		std::shared_lock<std::shared_mutex> lock(_mutex);
+
+		for (auto &item : _sets)
+		{
+			results.push_back(item.second);
+		}
+
+		return results;
 	}
 
 	std::shared_ptr<info::Record> FileUserdataSets::GetByKey(ov::String record_id)
 	{
-		std::lock_guard<std::shared_mutex> lock(_mutex);
+		std::shared_lock<std::shared_mutex> lock(_mutex);
 
 		auto iter = _sets.find(record_id);
 		if (iter == _sets.end())
@@ -42,7 +56,7 @@ namespace pub
 	{
 		std::vector<std::shared_ptr<info::Record>> results;
 
-		std::lock_guard<std::shared_mutex> lock(_mutex);
+		std::shared_lock<std::shared_mutex> lock(_mutex);
 
 		for (auto& [record_id, record_info] : _sets)
 		{
@@ -57,7 +71,7 @@ namespace pub
 
 	std::shared_ptr<info::Record> FileUserdataSets::GetBySessionId(session_id_t session_id)
 	{
-		std::lock_guard<std::shared_mutex> lock(_mutex);
+		std::shared_lock<std::shared_mutex> lock(_mutex);
 
 		for (auto& item : _sets)
 		{
@@ -72,14 +86,16 @@ namespace pub
 
 	std::shared_ptr<info::Record> FileUserdataSets::GetAt(uint32_t index)
 	{
-		std::lock_guard<std::shared_mutex> lock(_mutex);
+		std::shared_lock<std::shared_mutex> lock(_mutex);
 
 		auto iter = _sets.begin();
 
 		std::advance(iter, index);
 
 		if (iter == _sets.end())
+		{
 			return nullptr;
+		}
 
 		return iter->second;
 	}
@@ -93,7 +109,7 @@ namespace pub
 
 	uint32_t FileUserdataSets::GetCount()
 	{
-		std::lock_guard<std::shared_mutex> lock(_mutex);
+		std::shared_lock<std::shared_mutex> lock(_mutex);
 
 		return _sets.size();
 	}

--- a/src/projects/publishers/file/file_userdata.h
+++ b/src/projects/publishers/file/file_userdata.h
@@ -11,10 +11,11 @@ namespace pub
 		FileUserdataSets();
 		~FileUserdataSets();
 
-		bool Set(ov::String record_id, std::shared_ptr<info::Record> record_info);
+		bool Set(ov::String record_id, const std::shared_ptr<info::Record> &record_info);
 
 		uint32_t GetCount();
 
+		std::vector<std::shared_ptr<info::Record>> GetAll();
 		std::shared_ptr<info::Record> GetAt(uint32_t index);
 		std::shared_ptr<info::Record> GetByKey(ov::String record_id);
 		std::vector<std::shared_ptr<info::Record>> GetByStreamName(ov::String stream_name);


### PR DESCRIPTION
## SUMMARY
This PR fixes an intermittent crash that occurred when Start/Stop Recording API requests were sent concurrently, and improves the safety of recording state transitions.
Related issue: (#2016)

## Changes
- Added synchronization to FileUserDataSets for recording metadata handling
- Updated state codes on recording start/stop failures
- Minor refactoring for better readability and structure