### PR TITLE
fix: regression in OnlyKeyframes option (decode keyframes only)

### DIFF
--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -288,12 +288,12 @@ namespace cmn
 		{
 			OV_CASE_RETURN(cmn::MediaCodecId::None, false);
 
-			OV_CASE_RETURN(cmn::MediaCodecId::H264, true);
-			OV_CASE_RETURN(cmn::MediaCodecId::H265, true);
-			OV_CASE_RETURN(cmn::MediaCodecId::Vp8, true);
-			OV_CASE_RETURN(cmn::MediaCodecId::Vp9, true);
-			OV_CASE_RETURN(cmn::MediaCodecId::Av1, true);
-			OV_CASE_RETURN(cmn::MediaCodecId::Flv, true);
+			OV_CASE_RETURN(cmn::MediaCodecId::H264, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::H265, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Vp8, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Vp9, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Av1, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Flv, false);
 
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, false);


### PR DESCRIPTION

## SUMMARY
There was a bug where the function that checks if a codec is an image returned image type even for video codecs
Related Comimt: (https://github.com/OvenMediaLabs/OvenMediaEngine/commit/2b8a57678a3d5447dcf506a7b6622d9201d056e3)