### PR TITLE
refactor: improve pull stream error handling in Orchestrator

### DIFF
--- a/src/projects/api_server/controllers/v1/vhosts/apps/app_actions_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/app_actions_controller.cpp
@@ -334,7 +334,15 @@ namespace api
 				auto url		 = ov::Url::Parse(client->GetRequest()->GetUri());
 				auto app_name	 = app->GetVHostAppName();
 				auto stream_name = push->GetStreamName();
-				ocst::Orchestrator::GetInstance()->RequestPullStreamWithOriginMap(url, app_name, stream_name);
+				auto error		 = ocst::Orchestrator::GetInstance()->RequestPullStreamWithOriginMap(url, app_name, stream_name);
+
+				if (error != nullptr)
+				{
+					logte("Could not pull stream from origin map [%s/%s]: %s",
+						  app_name.CStr(),
+						  stream_name.CStr(),
+						  error->What());
+				}
 			}
 
 			response = ::serdes::JsonFromPush(push);

--- a/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
@@ -117,22 +117,32 @@ namespace api
 						logti(" - %s", url.CStr());
 					}
 
-					auto result = orchestrator->RequestPullStreamWithUrls(source_url, app->GetVHostAppName(), stream_name, request_urls, 0, properties);
+					auto error = orchestrator->RequestPullStreamWithUrls(source_url, app->GetVHostAppName(), stream_name, request_urls, 0, properties);
 
-					if (result)
+					if (error == nullptr)
 					{
 						std::vector<std::shared_ptr<mon::StreamMetrics>> output_streams;
 						stream = GetStream(app, stream_name, &output_streams);
 						if (stream == nullptr)
 						{
-							throw http::HttpError(http::StatusCode::BadGateway, ov::String::FormatString("Could not pull the stream : %s", source_url->ToUrlString(true).CStr()));
+							throw http::HttpError(http::StatusCode::BadGateway, "Could not pull the stream : %s", source_url->ToUrlString(true).CStr());
 						}
 
 						return {http::StatusCode::Created};
 					}
 					else
 					{
-						throw http::HttpError(http::StatusCode::BadGateway, ov::String::FormatString("Could not pull the stream : %s", source_url->ToUrlString(true).CStr()));
+						logte("Could not pull stream [%s/%s]: %s",
+							  app->GetVHostAppName().CStr(),
+							  stream_name.CStr(),
+							  error->What());
+
+						if (error->GetCommonErrorCode() == CommonErrorCode::INVALID_REQUEST)
+						{
+							throw http::HttpError(http::StatusCode::BadRequest, error->GetMessage().CStr());
+						}
+
+						throw http::HttpError(http::StatusCode::BadGateway, "Could not pull the stream : %s", source_url->ToUrlString(true).CStr());
 					}
 				}
 				else

--- a/src/projects/base/publisher/publisher.cpp
+++ b/src/projects/base/publisher/publisher.cpp
@@ -177,8 +177,14 @@ namespace pub
 
 		// Pull stream with the local origin map
 		logti("Try to pull stream from local origin map: [%s/%s]", vapp_name.CStr(), stream_name.CStr());
-		if (orchestrator->RequestPullStreamWithOriginMap(request_from, vhost_app_name, stream_name) == false)
+		auto origin_map_error = orchestrator->RequestPullStreamWithOriginMap(request_from, vhost_app_name, stream_name);
+		if (origin_map_error != nullptr)
 		{
+			logtw("Could not pull stream from local origin map [%s/%s]: %s",
+				  vapp_name.CStr(),
+				  stream_name.CStr(),
+				  origin_map_error->What());
+
 			// Pull stream with the origin map store
 			logti("Try to pull stream from origin map store: [%s/%s]", vapp_name.CStr(), stream_name.CStr());
 			auto origin_url = orchestrator->GetOriginUrlFromOriginMapStore(vhost_app_name, stream_name);
@@ -194,8 +200,14 @@ namespace pub
 				properties->EnableRelay(true);
 			}
 
-			if (orchestrator->RequestPullStreamWithUrls(request_from, vhost_app_name, stream_name, {origin_url->ToUrlString()}, 0, properties) == false)
+			auto origin_store_error = orchestrator->RequestPullStreamWithUrls(request_from, vhost_app_name, stream_name, {origin_url->ToUrlString()}, 0, properties);
+			if (origin_store_error != nullptr)
 			{
+				logte("Could not pull stream from origin map store [%s/%s]: %s",
+					  vapp_name.CStr(),
+					  stream_name.CStr(),
+					  origin_store_error->What());
+
 				return nullptr;
 			}
 		}

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -20,6 +20,49 @@
 
 namespace ocst
 {
+	namespace
+	{
+		std::shared_ptr<Error> ValidatePullStreamUrlList(const std::vector<ov::String> &url_list, ov::String *scheme)
+		{
+			if (url_list.empty())
+			{
+				return Error::CreateError(CommonErrorCode::INVALID_REQUEST, "RequestPullStream must have at least one URL");
+			}
+
+			ov::String validated_scheme;
+			for (const auto &url : url_list)
+			{
+				auto parsed_url = ov::Url::Parse(url);
+				if (parsed_url == nullptr)
+				{
+					return Error::CreateError(CommonErrorCode::INVALID_REQUEST, "Invalid URL: %s", url.CStr());
+				}
+
+				auto current_scheme = parsed_url->Scheme().LowerCaseString();
+				if (validated_scheme.IsEmpty())
+				{
+					validated_scheme = current_scheme;
+				}
+				else if (validated_scheme != current_scheme)
+				{
+					return Error::CreateError(CommonErrorCode::INVALID_REQUEST, "Only urls with the same scheme can be sent as a group.");
+				}
+			}
+
+			// A single pull request is still dispatched to one provider module. Before this
+			// refactoring we implicitly used the first URL's scheme (`url_list[0]`) for that
+			// dispatch, so mixed-scheme URL lists were never handled correctly. Keep that
+			// behavior explicit by validating that all URLs share the same scheme and then
+			// returning the validated scheme to the caller.
+			if (scheme != nullptr)
+			{
+				*scheme = validated_scheme;
+			}
+
+			return nullptr;
+		}
+	}  // namespace
+
 	bool Orchestrator::StartServer(const std::shared_ptr<const cfg::Server> &server_config)
 	{
 		_server_config = server_config;
@@ -427,30 +470,22 @@ namespace ocst
 		return resolved;
 	}
 
-	bool Orchestrator::RequestPullStreamWithUrls(
+	std::shared_ptr<Error> Orchestrator::RequestPullStreamWithUrls(
 		const std::shared_ptr<const ov::Url> &request_from,
 		const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 		const std::vector<ov::String> &url_list, off_t offset, const std::shared_ptr<pvd::PullStreamProperties> &properties)
 	{
-		if (url_list.empty() == true)
+		ov::String scheme;
+
+		auto validation_error = ValidatePullStreamUrlList(url_list, &scheme);
+		if (validation_error != nullptr)
 		{
-			logtw("RequestPullStream must have at least one URL");
-			return false;
+			return validation_error;
 		}
 
-		auto url = url_list[0];
-		auto parsed_url = ov::Url::Parse(url);
-
-		if (parsed_url == nullptr)
-		{
-			// Invalid URL
-			logte("Pull stream is requested for invalid URL: %s", url.CStr());
-			return false;
-		}
-		
 		auto app_info = info::Application::GetInvalidApplication();
 		// Check if the application does exists
-		app_info = GetApplicationInfo(vhost_app_name);
+		app_info	  = GetApplicationInfo(vhost_app_name);
 		if (app_info.IsValid() == false)
 		{
 			// Create a new application using application template if exists
@@ -459,16 +494,14 @@ namespace ocst
 			auto vhost = GetVirtualHost(vhost_app_name.GetVHostName());
 			if (vhost == nullptr)
 			{
-				logte("Could not find VirtualHost for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find virtual host");
 			}
 
 			// Copy application template configuration
 			auto app_cfg = vhost->GetDynamicApplicationConfigTemplate();
 			if (app_cfg.IsParsed() == false)
 			{
-				logte("Could not find application template for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find application template");
 			}
 
 			// Set the application name
@@ -477,48 +510,43 @@ namespace ocst
 			logti("Trying to create dynamic application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
 			if (CreateApplication(vhost->GetHostInfo(), app_cfg, true) != Result::Succeeded)
 			{
-				logte("Could not create application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::ERROR, "Could not create application");
 			}
 
 			app_info = GetApplicationInfo(vhost_app_name);
 			if (app_info.IsValid() == false)
 			{
 				// MUST NOT HAPPEN
-				logte("Could not find created application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::ERROR, "Could not find created application");
 			}
 		}
 
-		auto provider_module = GetProviderModuleForScheme(parsed_url->Scheme());
+		auto provider_module = GetProviderModuleForScheme(scheme);
 		if (provider_module == nullptr)
 		{
-			logte("Could not find provider for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-			return false;
+			return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find provider for scheme: %s", scheme.CStr());
 		}
-		
+
 		logti("Trying to pull stream [%s/%s] from provider using URL: %s",
-				vhost_app_name.CStr(), stream_name.CStr(),
-				GetModuleTypeName(provider_module->GetModuleType()).CStr());
+			  vhost_app_name.CStr(), stream_name.CStr(),
+			  GetModuleTypeName(provider_module->GetModuleType()).CStr());
 
 		auto stream = provider_module->PullStream(request_from, app_info, stream_name, url_list, offset, properties);
 		if (stream != nullptr)
 		{
 			logti("The stream was pulled successfully: [%s/%s] (%u)",
-					vhost_app_name.CStr(), stream_name.CStr(), stream->GetId());
+				  vhost_app_name.CStr(), stream_name.CStr(), stream->GetId());
 
-			return true;
+			return nullptr;
 		}
 
-		logte("Could not pull stream [%s/%s] from provider: %s",
-				vhost_app_name.CStr(), stream_name.CStr(),
-				GetModuleTypeName(provider_module->GetModuleType()).CStr());
-
-		return true;
+		return Error::CreateError(CommonErrorCode::ERROR,
+								  "Could not pull stream from provider: %s",
+								  GetModuleTypeName(provider_module->GetModuleType()).CStr());
 	}
 
 	// Pull a stream using Origin map
-	bool Orchestrator::RequestPullStreamWithOriginMap(
+	std::shared_ptr<Error> Orchestrator::RequestPullStreamWithOriginMap(
 		const std::shared_ptr<const ov::Url> &request_from,
 		const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 		off_t offset)
@@ -528,27 +556,24 @@ namespace ocst
 		std::vector<ov::String> url_list;
 		Origin matched_origin;
 		auto &host_name = request_from->Host();
-		
+
 		std::vector<ov::String> url_list_in_map;
 		if (GetUrlListForLocation(vhost_app_name, host_name, stream_name, matched_origin, url_list_in_map) == false)
 		{
-			logte("Could not find Origin for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-			return false;
+			return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find origin");
 		}
 
 		if (matched_origin.IsValid() == false)
 		{
 			// Origin/Domain can never be nullptr if origin is found
 			OV_ASSERT2(matched_origin.IsValid() == true);
-			logte("Could not find URL list for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-			return false;
+			return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find URL list");
 		}
 
 		provider_module = GetProviderModuleForScheme(matched_origin.GetScheme());
 		if (provider_module == nullptr)
 		{
-			logte("Could not find provider for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-			return false;
+			return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find provider for scheme: %s", matched_origin.GetScheme().CStr());
 		}
 
 		// Check if the application does exists
@@ -558,14 +583,18 @@ namespace ocst
 			// Create a new application using application template if exists
 
 			// Get vhost info
-			auto vhost = GetVirtualHost(vhost_app_name.GetVHostName());
+			auto vhost	 = GetVirtualHost(vhost_app_name.GetVHostName());
+
+			if (vhost == nullptr)
+			{
+				return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find virtual host");
+			}
 
 			// Copy application template configuration
 			auto app_cfg = vhost->GetDynamicApplicationConfigTemplate();
 			if (app_cfg.IsParsed() == false)
 			{
-				logte("Could not find application template for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::NOT_FOUND, "Could not find application template");
 			}
 
 			app_cfg.SetName(vhost_app_name.GetAppName());
@@ -573,16 +602,14 @@ namespace ocst
 			logti("Trying to create dynamic application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
 			if (CreateApplication(vhost->GetHostInfo(), app_cfg, true) != Result::Succeeded)
 			{
-				logte("Could not create application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::ERROR, "Could not create application");
 			}
 
 			app_info = GetApplicationInfo(vhost_app_name);
 			if (app_info.IsValid() == false)
 			{
 				// MUST NOT HAPPEN
-				logte("Could not find created application for the stream: [%s/%s]", vhost_app_name.CStr(), stream_name.CStr());
-				return false;
+				return Error::CreateError(CommonErrorCode::ERROR, "Could not find created application");
 			}
 		}
 
@@ -624,14 +651,12 @@ namespace ocst
 		auto stream = provider_module->PullStream(request_from, app_info, stream_name, url_list, offset, properties);
 		if (stream != nullptr)
 		{
-			return true;
+			return nullptr;
 		}
 
-		logte("Could not pull stream [%s/%s] from provider: %s",
-			  vhost_app_name.CStr(), stream_name.CStr(),
-			  GetModuleTypeName(provider_module->GetModuleType()).CStr());
-
-		return false;
+		return Error::CreateError(CommonErrorCode::ERROR,
+								  "Could not pull stream from provider: %s",
+								  GetModuleTypeName(provider_module->GetModuleType()).CStr());
 	}
 
 	/// Delete PullStream

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -11,12 +11,51 @@
 #include <base/mediarouter/mediarouter_interface.h>
 #include <base/provider/provider.h>
 #include <base/publisher/publisher.h>
+#include <modules/http/http_error.h>
 
 #include "virtual_host.h"
 #include "module.h"
 
 namespace ocst
 {
+	class Error : public ov::Error
+	{
+	public:
+		Error(CommonErrorCode code, const char *message)
+			: ov::Error("Orchestrator", ov::ToUnderlyingType(code), message)
+		{
+		}
+
+		template <typename... Targs>
+		Error(CommonErrorCode code, const char *format, Targs... args)
+			: ov::Error("Orchestrator", ov::ToUnderlyingType(code), ov::String::FormatString(format, args...))
+		{
+		}
+
+		static std::shared_ptr<Error> CreateError(CommonErrorCode code, const char *message)
+		{
+			return std::make_shared<Error>(code, message);
+		}
+
+		template <typename... Targs>
+		static std::shared_ptr<Error> CreateError(CommonErrorCode code, const char *format, Targs... args)
+		{
+			return std::make_shared<Error>(code, format, args...);
+		}
+
+		CommonErrorCode GetCommonErrorCode() const
+		{
+			return static_cast<CommonErrorCode>(GetCode());
+		}
+
+		std::shared_ptr<http::HttpError> ToHttpError() const
+		{
+			return http::HttpError::CreateError(
+				http::StatusCodeFromCommonError(GetCommonErrorCode()),
+				GetMessage().CStr());
+		}
+	};
+
 	class Orchestrator : public ov::Singleton<Orchestrator>, 
 							public Application::CallbackInterface
 	{
@@ -94,7 +133,18 @@ namespace ocst
 		const info::Application &GetApplicationInfo(const ov::String &vhost_name, const ov::String &app_name) const;
 		const info::Application &GetApplicationInfo(const info::VHostAppName &vhost_app_name) const;
 
-		bool RequestPullStreamWithUrls(
+		/// Pull a stream using specified URLs with offset
+		///
+		/// @param request_from Source from which `RequestPullStream()` invoked (Mainly provided when requested by Publisher)
+		/// @param vhost_app_name When the URL is pulled, its stream is created in this `vhost_name` and `app_name`
+		/// @param stream_name When the URL is pulled, its stream is created in this `stream_name`
+		/// @param url_list URLs to pull. All URLs in the list must use the same scheme,
+		/// because one pull request is dispatched to a single provider module
+		/// @param offset Parameters to be used when you want to pull from a certain point (available only when the provider supports that)
+		/// @param properties Additional pull stream properties
+		///
+		/// @return `nullptr` if the pull request succeeds, otherwise an error describing the failure
+		std::shared_ptr<Error> RequestPullStreamWithUrls(
 			const std::shared_ptr<const ov::Url> &request_from,
 			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 			const std::vector<ov::String> &url_list, off_t offset,
@@ -102,12 +152,14 @@ namespace ocst
 
 		/// Pull a stream using specified URL with offset
 		///
-		/// @param request_from Source from which RequestPullStream() invoked (Mainly provided when requested by Publisher)
-		/// @param vhost_app_name When the URL is pulled, its stream is created in this vhost_name and app_name
-		/// @param stream_name When the URL is pulled, its stream is created in this stream_name
+		/// @param request_from Source from which `RequestPullStream()` invoked (Mainly provided when requested by Publisher)
+		/// @param vhost_app_name When the URL is pulled, its stream is created in this `vhost_name` and `app_name`
+		/// @param stream_name When the URL is pulled, its stream is created in this `stream_name`
 		/// @param url URL to pull
 		/// @param offset Parameters to be used when you want to pull from a certain point (available only when the provider supports that)
-		bool RequestPullStreamWithUrl(
+		///
+		/// @return `nullptr` if the pull request succeeds, otherwise an error describing the failure
+		std::shared_ptr<Error> RequestPullStreamWithUrl(
 			const std::shared_ptr<const ov::Url> &request_from,
 			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 			const ov::String &url, off_t offset)
@@ -117,11 +169,13 @@ namespace ocst
 
 		/// Pull a stream using specified URL
 		///
-		/// @param request_from Source from which RequestPullStream() invoked (Mainly provided when requested by Publisher)
-		/// @param vhost_app_name When the URL is pulled, its stream is created in this vhost_name and app_name
-		/// @param stream_name When the URL is pulled, its stream is created in this stream_name
+		/// @param request_from Source from which `RequestPullStream()` invoked (Mainly provided when requested by Publisher)
+		/// @param vhost_app_name When the URL is pulled, its stream is created in this `vhost_name` and `app_name`
+		/// @param stream_name When the URL is pulled, its stream is created in this `stream_name`
 		/// @param url URL to pull
-		bool RequestPullStreamWithUrl(
+		///
+		/// @return `nullptr` if the pull request succeeds, otherwise an error describing the failure
+		std::shared_ptr<Error> RequestPullStreamWithUrl(
 			const std::shared_ptr<const ov::Url> &request_from,
 			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 			const ov::String &url)
@@ -131,21 +185,25 @@ namespace ocst
 
 		/// Pull a stream using Origin map with offset
 		///
-		/// @param request_from Source from which RequestPullStream() invoked (Mainly provided when requested by Publisher)
-		/// @param vhost_app_name When the URL is pulled, its stream is created in this vhost_name and app_name
-		/// @param stream_name When the URL is pulled, its stream is created in this stream_name
+		/// @param request_from Source from which `RequestPullStream()` invoked (Mainly provided when requested by Publisher)
+		/// @param vhost_app_name When the URL is pulled, its stream is created in this `vhost_name` and `app_name`
+		/// @param stream_name When the URL is pulled, its stream is created in this `stream_name`
 		/// @param offset Parameters to be used when you want to pull from a certain point (available only when the provider supports that)
-		bool RequestPullStreamWithOriginMap(
+		///
+		/// @return `nullptr` if the pull request succeeds, otherwise an error describing the failure
+		std::shared_ptr<Error> RequestPullStreamWithOriginMap(
 			const std::shared_ptr<const ov::Url> &request_from,
 			const info::VHostAppName &vhost_app_name, const ov::String &stream_name,
 			off_t offset);
 
 		/// Pull a stream using Origin map with offset
 		///
-		/// @param request_from Source from which RequestPullStream() invoked (Mainly provided when requested by Publisher)
-		/// @param vhost_app_name When the URL is pulled, its stream is created in this vhost_name and app_name
-		/// @param stream_name When the URL is pulled, its stream is created in this stream_name
-		bool RequestPullStreamWithOriginMap(
+		/// @param request_from Source from which `RequestPullStream()` invoked (Mainly provided when requested by Publisher)
+		/// @param vhost_app_name When the URL is pulled, its stream is created in this `vhost_name` and `app_name`
+		/// @param stream_name When the URL is pulled, its stream is created in this `stream_name`
+		///
+		/// @return `nullptr` if the pull request succeeds, otherwise an error describing the failure
+		std::shared_ptr<Error> RequestPullStreamWithOriginMap(
 			const std::shared_ptr<const ov::Url> &request_from,
 			const info::VHostAppName &vhost_app_name, const ov::String &stream_name)
 		{

--- a/src/projects/publishers/ovt/ovt_publisher.cpp
+++ b/src/projects/publishers/ovt/ovt_publisher.cpp
@@ -295,8 +295,14 @@ void OvtPublisher::HandleDescribeRequest(const std::shared_ptr<ov::Socket> &remo
 	if (stream == nullptr)
 	{
 		// If the stream does not exists, request to the provider
-		if (orchestrator->RequestPullStreamWithOriginMap(url, vhost_app_name, stream_name) == false)
+		auto error = orchestrator->RequestPullStreamWithOriginMap(url, vhost_app_name, stream_name);
+		if (error != nullptr)
 		{
+			logte("Could not pull stream from origin map [%s/%s]: %s",
+				  vhost_app_name.CStr(),
+				  stream_name.CStr(),
+				  error->What());
+
 			msg.Format("There is no such stream (%s/%s)", vhost_app_name.CStr(), url->Stream().CStr());
 			ResponseResult(remote, 0, "describe", request_id, 404, msg);
 			return;


### PR DESCRIPTION
- Change `RequestPullStream()` return type from `bool` to `std::shared_ptr<ocst::Error>` to provide detailed failure reasons.
- Add URL scheme validation to ensure all URLs in a pull request share the same scheme.
- Update API controllers and publishers to handle the new Error object and provide better error responses/logging.
- Fix a bug where `RequestPullStreamWithUrls()` would return success even on failure.