### PR TITLE
refactor: add Instantiate() to probe encoder properties before full creation

### DIFF
--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -155,41 +155,57 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 	return candidate_modules;
 }
 
-#define CASE_CREATE_CODEC_IFNEED(MODULE_ID, CLS)                                 \
-	case cmn::MediaCodecModuleId::MODULE_ID:                                     \
-		encoder = std::make_shared<CLS>(*info);                                  \
-		if (encoder == nullptr)                                                  \
-		{                                                                        \
-			break;                                                               \
-		}                                                                        \
-		encoder->SetDeviceID(candidate->GetDeviceId());                          \
-		encoder->SetEncoderId(encoder_id);                                       \
-		encoder->SetCompleteHandler(complete_handler);                           \
-		track->SetCodecModuleId(encoder->GetModuleID());                         \
-		track->SetCodecDeviceId(encoder->GetDeviceID());                         \
-		track->SetOriginBitstream(encoder->GetBitstreamFormat());                \
-		if (encoder->Configure(track) == true)                                   \
-		{                                                                        \
-			if (TranscodeFaultInjector::GetInstance()->IsEnabled())              \
-			{                                                                    \
-				if (TranscodeFaultInjector::GetInstance()->IsTriggered(          \
-						TranscodeFaultInjector::ComponentType::EncoderComponent, \
-						TranscodeFaultInjector::IssueType::InitFailed,           \
-						encoder->GetModuleID(), encoder->GetDeviceID()) == true) \
-				{                                                                \
-					encoder->Stop();                                             \
-					encoder = nullptr;                                           \
-					break;                                                       \
-				}                                                                \
-			}                                                                    \
-			goto done;                                                           \
-		}                                                                        \
-		if (encoder != nullptr)                                                  \
-		{                                                                        \
-			encoder->Stop();                                                     \
-			encoder = nullptr;                                                   \
-		}                                                                        \
-		break;
+std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Instantiate(
+	cmn::MediaCodecId codec_id,
+	cmn::MediaCodecModuleId module_id,
+	const info::Stream &stream_info)
+{
+	if (codec_id == cmn::MediaCodecId::H264)
+	{
+		switch (module_id)
+		{
+			case cmn::MediaCodecModuleId::DEFAULT:
+			case cmn::MediaCodecModuleId::OPENH264: return std::make_shared<EncoderAVCxOpenH264>(stream_info);
+			case cmn::MediaCodecModuleId::X264:     return std::make_shared<EncoderAVCx264>(stream_info);
+			case cmn::MediaCodecModuleId::QSV:      return std::make_shared<EncoderAVCxQSV>(stream_info);
+			case cmn::MediaCodecModuleId::NILOGAN:  return std::make_shared<EncoderAVCxNILOGAN>(stream_info);
+			case cmn::MediaCodecModuleId::XMA:      return std::make_shared<EncoderAVCxXMA>(stream_info);
+			case cmn::MediaCodecModuleId::NVENC:    return std::make_shared<EncoderAVCxNV>(stream_info);
+			default: break;
+		}
+	}
+	else if (codec_id == cmn::MediaCodecId::H265)
+	{
+		switch (module_id)
+		{
+			case cmn::MediaCodecModuleId::QSV:     return std::make_shared<EncoderHEVCxQSV>(stream_info);
+			case cmn::MediaCodecModuleId::NILOGAN: return std::make_shared<EncoderHEVCxNILOGAN>(stream_info);
+			case cmn::MediaCodecModuleId::XMA:     return std::make_shared<EncoderHEVCxXMA>(stream_info);
+			case cmn::MediaCodecModuleId::NVENC:   return std::make_shared<EncoderHEVCxNV>(stream_info);
+			default: break;
+		}
+	}
+	else if (codec_id == cmn::MediaCodecId::Vp8)    return std::make_shared<EncoderVP8>(stream_info);
+	else if (codec_id == cmn::MediaCodecId::Aac)    return std::make_shared<EncoderAAC>(stream_info);
+	else if (codec_id == cmn::MediaCodecId::Opus)
+	{
+#if USE_LEGACY_LIBOPUS
+		return std::make_shared<EncoderOPUS>(stream_info);
+#else
+		return std::make_shared<EncoderFFOPUS>(stream_info);
+#endif
+	}
+	else if (codec_id == cmn::MediaCodecId::Jpeg)    return std::make_shared<EncoderJPEG>(stream_info);
+	else if (codec_id == cmn::MediaCodecId::Png)     return std::make_shared<EncoderPNG>(stream_info);
+	else if (codec_id == cmn::MediaCodecId::Webp)    return std::make_shared<EncoderWEBP>(stream_info);
+	else if (codec_id == cmn::MediaCodecId::Whisper) return std::make_shared<EncoderWhisper>(stream_info);
+	else
+	{
+		OV_ASSERT(false, "Not supported codec: %d", static_cast<int>(codec_id));
+	}
+
+	return nullptr;
+}
 
 
 std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Create(
@@ -200,127 +216,45 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Create(
 	CompleteHandler complete_handler)
 {
 	std::shared_ptr<TranscodeEncoder> encoder = nullptr;
-	std::shared_ptr<info::CodecCandidate> cur_candidate = nullptr;
 
 	for (auto &candidate : *candidates)
 	{
-		cur_candidate = candidate;
+		encoder = Instantiate(candidate->GetCodecId(), candidate->GetModuleId(), *info);
+		if (encoder == nullptr)
+		{
+			continue;
+		}
 
-		if (candidate->GetCodecId() == cmn::MediaCodecId::H264)
-		{
-			switch (candidate->GetModuleId())
-			{
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderAVCxOpenH264);
-				CASE_CREATE_CODEC_IFNEED(OPENH264, EncoderAVCxOpenH264);
-				CASE_CREATE_CODEC_IFNEED(X264, EncoderAVCx264);
-				CASE_CREATE_CODEC_IFNEED(QSV, EncoderAVCxQSV);
-				CASE_CREATE_CODEC_IFNEED(NILOGAN, EncoderAVCxNILOGAN);
-				CASE_CREATE_CODEC_IFNEED(XMA, EncoderAVCxXMA);
-				CASE_CREATE_CODEC_IFNEED(NVENC, EncoderAVCxNV);
-				default:
-					break;
-			}
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::H265)
-		{
-			switch (candidate->GetModuleId())
-			{
-				// No default module for HEVC
-				CASE_CREATE_CODEC_IFNEED(QSV, EncoderHEVCxQSV);
-				CASE_CREATE_CODEC_IFNEED(NILOGAN, EncoderHEVCxNILOGAN);
-				CASE_CREATE_CODEC_IFNEED(XMA, EncoderHEVCxXMA);
-				CASE_CREATE_CODEC_IFNEED(NVENC, EncoderHEVCxNV);
-				default:
-					break;
-			};
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Vp8)
-		{
-			switch (candidate->GetModuleId())
-			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderVP8);
-				CASE_CREATE_CODEC_IFNEED(LIBVPX, EncoderVP8);
+		encoder->SetDeviceID(candidate->GetDeviceId());
+		encoder->SetEncoderId(encoder_id);
+		encoder->SetCompleteHandler(complete_handler);
+		track->SetCodecModuleId(encoder->GetModuleID());
+		track->SetCodecDeviceId(encoder->GetDeviceID());
+		track->SetOriginBitstream(encoder->GetBitstreamFormat());
 
-					break;
-			}
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Aac)
+		if (encoder->Configure(track) == true)
 		{
-			switch (candidate->GetModuleId())
+			if (TranscodeFaultInjector::GetInstance()->IsEnabled())
 			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderAAC);
-				CASE_CREATE_CODEC_IFNEED(FDKAAC, EncoderAAC);
-					break;
-			}
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Opus)
-		{
-			switch (candidate->GetModuleId())
-			{
-#if USE_LEGACY_LIBOPUS
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderOPUS);
-#else
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderFFOPUS);
-				CASE_CREATE_CODEC_IFNEED(LIBOPUS, EncoderFFOPUS);
-#endif
-					break;
-			}
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Jpeg)
-		{
-			switch (candidate->GetModuleId())
-			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderJPEG);
-					break;
+				if (TranscodeFaultInjector::GetInstance()->IsTriggered(
+						TranscodeFaultInjector::ComponentType::EncoderComponent,
+						TranscodeFaultInjector::IssueType::InitFailed,
+						encoder->GetModuleID(), encoder->GetDeviceID()) == true)
+				{
+					encoder->Stop();
+					encoder = nullptr;
+					continue;
+				}
 			}
 			break;
 		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Png)
-		{
-			switch (candidate->GetModuleId())
-			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderPNG);
-					break;
-			}
-			break;
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Webp)
-		{
-			switch (candidate->GetModuleId())
-			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderWEBP);
-					break;
-			}
-			break;
-		}
-		else if (candidate->GetCodecId() == cmn::MediaCodecId::Whisper)
-		{
-			switch (candidate->GetModuleId())
-			{
-				default:
-				CASE_CREATE_CODEC_IFNEED(DEFAULT, EncoderWhisper);
-					break;
-			}
-		}
-		else
-		{
-			OV_ASSERT(false, "Not supported codec: %d", static_cast<int>(track->GetCodecId()));
-		}
 
-		// If the decoder is not created, try the next candidate.
+		encoder->Stop();
 		encoder = nullptr;
 	}
 
-done:
 	if (encoder)
 	{
-
 		logtt("The encoder has been created. track(#%d), codec(%s), module(%s:%d)",
 			  track->GetId(),
 			  cmn::GetCodecIdString(track->GetCodecId()),

--- a/src/projects/transcoder/transcoder_encoder.h
+++ b/src/projects/transcoder/transcoder_encoder.h
@@ -17,6 +17,9 @@ class TranscodeEncoder : public TranscodeBase<MediaFrame, MediaPacket>
 public:
 	typedef std::function<void(TranscodeResult, int32_t, std::shared_ptr<MediaPacket>)> CompleteHandler;
 	static std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> GetCandidates(bool hwaccels_enable, ov::String hwaccles_modules, std::shared_ptr<MediaTrack> track);
+	// Instantiate creates the encoder object for the given codec/module without calling Configure.
+	// Use this to inspect encoder properties (e.g. IsInputOnly()) before committing to full creation.
+	static std::shared_ptr<TranscodeEncoder> Instantiate(cmn::MediaCodecId codec_id, cmn::MediaCodecModuleId module_id, const info::Stream &stream_info);
 	static std::shared_ptr<TranscodeEncoder> Create(int32_t encoder_id, std::shared_ptr<info::Stream> info, std::shared_ptr<MediaTrack> output_track, std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> candidates, CompleteHandler complete_handler);
 
 public:
@@ -32,6 +35,10 @@ public:
 	virtual cmn::AudioSample::Format GetSupportAudioFormat() const noexcept = 0;
 	virtual cmn::VideoPixelFormatId GetSupportVideoFormat() const noexcept = 0;
 	virtual cmn::BitstreamFormat GetBitstreamFormat() const noexcept = 0;
+
+	// Returns true if this encoder consumes input but does not produce output packets
+	// back into the transcoding pipeline (e.g. STT encoders that push data forward directly).
+	virtual bool IsInputOnly() const noexcept { return false; }
 
 	bool InitCodecInteral();
 	virtual bool InitCodec() = 0;


### PR DESCRIPTION
Currently, encoder properties (like IsInputOnly()) can only be read after a successful Create(), which makes it impossible to inspect them when creation fails or before committing to full initialization.

This PR introduces Instantiate(), a lightweight static method that constructs an encoder instance without calling Configure(). This allows callers to probe encoder properties regardless of whether full creation succeeds or fails.

As a first use case, IsInputOnly() is added as a virtual property for encoders that produce no output frames (e.g. WhisperEncoder).

Note: This is a prerequisite for the upcoming Whisper STT improvement PR. The follow-up PR depends on this being merged first.