### PR TITLE
feat: redesign STT (Speech-to-Text) configuration and Whisper integration

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -50,6 +50,7 @@
           * [Send Subtitles](rest-api/v1/virtualhost/application/stream/send-event-1.md)
           * [HLS Dump](rest-api/v1/virtualhost/application/stream/hls-dump.md)
           * [Conclude HLS Live](rest-api/v1/virtualhost/application/stream/conclude-hls-live.md)
+          * [STT Control](rest-api/v1/virtualhost/application/stream/stt-control.md)
         * [ScheduledChannel](rest-api/v1/virtualhost/application/scheduledchannel-api.md)
         * [MultiplexChannel](rest-api/v1/virtualhost/application/scheduledchannel-api-1.md)
     * [Statistics](rest-api/v1/statistics/README.md)

--- a/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
@@ -1,0 +1,346 @@
+# STT Control
+
+These APIs pause and resume real-time Speech-to-Text (STT) inference for a specific stream at runtime, without restarting the server or recreating the stream.
+
+For full STT configuration, see [Realtime Speech-to-Text](../../../../../subtitles/realtime-speech-to-text.md).
+
+## Enable STT
+
+Resumes STT inference for the stream. Audio frames are passed to the Whisper model and subtitle cues are generated again.
+
+> ### Request
+
+<details>
+
+<summary><mark style="color:blue;">POST</mark> v1/vhosts/{vhost}/apps/{app}/streams/{stream}:enableStt</summary>
+
+#### Header
+
+```http
+Authorization: Basic {credentials}
+
+# Authorization
+    Credentials for HTTP Basic Authentication created with <AccessToken>
+```
+
+#### Body
+
+```json
+{}
+```
+
+</details>
+
+> ### Responses
+
+<details>
+
+<summary><mark style="color:blue;">200</mark> Ok</summary>
+
+The request has succeeded
+
+#### **Header**
+
+```
+Content-Type: application/json
+```
+
+#### **Body**
+
+```json
+{
+    "statusCode": 200,
+    "message": "OK",
+    "response": {
+        "enabled": true
+    }
+}
+
+# statusCode
+    Same as HTTP Status Code
+# message
+    A human-readable description of the response code
+# response.enabled
+    true if STT is now running
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">401</mark> Unauthorized</summary>
+
+Authentication required
+
+#### **Header**
+
+```http
+WWW-Authenticate: Basic realm="OvenMediaEngine"
+```
+
+#### **Body**
+
+```json
+{
+    "message": "[HTTP] Authorization header is required to call API (401)",
+    "statusCode": 401
+}
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">404</mark> Not Found</summary>
+
+The given vhost, app, or stream name could not be found, or no STT encoder exists for this stream.
+
+#### **Body**
+
+```json
+{
+    "statusCode": 404,
+    "message": "Could not find STT encoder for stream: [default/app/stream]"
+}
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">503</mark> Service Unavailable</summary>
+
+The Transcoder module is not running.
+
+</details>
+
+## Disable STT
+
+Pauses STT inference. Audio frames are dropped without processing, freeing GPU resources. Subtitle renditions remain in the stream but stop receiving new cues.
+
+> ### Request
+
+<details>
+
+<summary><mark style="color:blue;">POST</mark> v1/vhosts/{vhost}/apps/{app}/streams/{stream}:disableStt</summary>
+
+#### Header
+
+```http
+Authorization: Basic {credentials}
+
+# Authorization
+    Credentials for HTTP Basic Authentication created with <AccessToken>
+```
+
+#### Body
+
+```json
+{}
+```
+
+</details>
+
+> ### Responses
+
+<details>
+
+<summary><mark style="color:blue;">200</mark> Ok</summary>
+
+The request has succeeded
+
+#### **Header**
+
+```
+Content-Type: application/json
+```
+
+#### **Body**
+
+```json
+{
+    "statusCode": 200,
+    "message": "OK",
+    "response": {
+        "enabled": false
+    }
+}
+
+# statusCode
+    Same as HTTP Status Code
+# message
+    A human-readable description of the response code
+# response.enabled
+    false if STT is now paused
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">401</mark> Unauthorized</summary>
+
+Authentication required
+
+#### **Header**
+
+```http
+WWW-Authenticate: Basic realm="OvenMediaEngine"
+```
+
+#### **Body**
+
+```json
+{
+    "message": "[HTTP] Authorization header is required to call API (401)",
+    "statusCode": 401
+}
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">404</mark> Not Found</summary>
+
+The given vhost, app, or stream name could not be found, or no STT encoder exists for this stream.
+
+#### **Body**
+
+```json
+{
+    "statusCode": 404,
+    "message": "Could not find STT encoder for stream: [default/app/stream]"
+}
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">503</mark> Service Unavailable</summary>
+
+The Transcoder module is not running.
+
+</details>
+
+## Get STT Status
+
+Returns the current enabled state and configuration of all active STT renditions for the stream.
+
+> ### Request
+
+<details>
+
+<summary><mark style="color:blue;">POST</mark> v1/vhosts/{vhost}/apps/{app}/streams/{stream}:sttStatus</summary>
+
+#### Header
+
+```http
+Authorization: Basic {credentials}
+
+# Authorization
+    Credentials for HTTP Basic Authentication created with <AccessToken>
+```
+
+#### Body
+
+```json
+{}
+```
+
+</details>
+
+> ### Responses
+
+<details>
+
+<summary><mark style="color:blue;">200</mark> Ok</summary>
+
+The request has succeeded
+
+#### **Header**
+
+```
+Content-Type: application/json
+```
+
+#### **Body**
+
+```json
+{
+    "statusCode": 200,
+    "message": "OK",
+    "response": {
+        "enabled": true,
+        "renditions": [
+            {
+                "codec": "whisper",
+                "label": "Korean",
+                "model": "whisper_model/ggml-small.bin",
+                "language": "auto",
+                "translation": "false"
+            },
+            {
+                "codec": "whisper",
+                "label": "English",
+                "model": "whisper_model/ggml-small.bin",
+                "language": "auto",
+                "translation": "true"
+            }
+        ]
+    }
+}
+
+# statusCode
+    Same as HTTP Status Code
+# message
+    A human-readable description of the response code
+# response.enabled
+    true if STT inference is currently running, false if paused
+# response.renditions
+    List of active STT encoder instances for this stream
+    ## codec
+        STT engine in use. Currently always "whisper".
+    ## label
+        Subtitle rendition label this instance writes to.
+    ## model
+        Model file path used by this instance.
+    ## language
+        Configured source language ("auto" or a language code).
+    ## translation
+        "true" if translation to English is enabled.
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">401</mark> Unauthorized</summary>
+
+Authentication required
+
+#### **Header**
+
+```http
+WWW-Authenticate: Basic realm="OvenMediaEngine"
+```
+
+#### **Body**
+
+```json
+{
+    "message": "[HTTP] Authorization header is required to call API (401)",
+    "statusCode": 401
+}
+```
+
+</details>
+
+<details>
+
+<summary><mark style="color:red;">503</mark> Service Unavailable</summary>
+
+The Transcoder module is not running.
+
+</details>

--- a/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
@@ -116,7 +116,7 @@ The Transcoder module is not running.
 
 ## Disable STT
 
-Pauses STT inference. Audio frames are dropped without processing, freeing GPU resources. Subtitle renditions remain in the stream but stop receiving new cues.
+Pauses STT inference. Audio frames are dropped without processing, and subtitle renditions remain in the stream but stop receiving new cues. The underlying STT model and GPU allocations remain loaded.
 
 > ### Request
 
@@ -275,14 +275,14 @@ Content-Type: application/json
         "enabled": true,
         "renditions": [
             {
-                "codec": "whisper",
+                "codec": "WHISPER",
                 "label": "Korean",
                 "model": "whisper_model/ggml-small.bin",
                 "language": "auto",
                 "translation": "false"
             },
             {
-                "codec": "whisper",
+                "codec": "WHISPER",
                 "label": "English",
                 "model": "whisper_model/ggml-small.bin",
                 "language": "auto",

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -82,12 +82,34 @@ STT configuration is split across two sections:
 
 Declare the Whisper model files to load at server startup inside `<Modules><Whisper>`. Multiple `<PreloadModel>` entries are allowed. Models are loaded in descending file-size order to maximize GPU utilization.
 
+Each `<PreloadModel>` entry has the following fields:
+
+| Key | Description |
+|---|---|
+| Path | Path to the model file. Can be absolute or relative to the config directory. |
+| Devices | Comma-separated list of CUDA device indices to load the model onto (e.g. `0`, `0,1`, `2`). Omit or set to `all` to load on every available GPU. |
+
 ```xml
 <Server>
     <Modules>
         <Whisper>
-            <PreloadModel>whisper_model/ggml-small.bin</PreloadModel>
-            <PreloadModel>whisper_model/ggml-medium.bin</PreloadModel>
+            <!-- Load on all available GPUs (Devices omitted = all) -->
+            <PreloadModel>
+                <Path>whisper_model/ggml-small.bin</Path>
+                <Devices>all</Devices>
+            </PreloadModel>
+
+            <!-- Load on GPU 0 and GPU 1 only -->
+            <PreloadModel>
+                <Path>whisper_model/ggml-medium.bin</Path>
+                <Devices>0,1</Devices>
+            </PreloadModel>
+
+            <!-- Load on GPU 0 only -->
+            <PreloadModel>
+                <Path>whisper_model/ggml-large.bin</Path>
+                <Devices>0</Devices>
+            </PreloadModel>
         </Whisper>
     </Modules>
 </Server>
@@ -129,9 +151,11 @@ Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-
     <OutputProfiles>
         <MediaOptions>
             <STT>
+                <!-- Korean STT on GPU 0 -->
                 <Rendition>
                     <Engine>whisper</Engine>
                     <Model>whisper_model/ggml-small.bin</Model>
+                    <Modules>nv:0</Modules>
                     <InputAudioIndex>0</InputAudioIndex>
                     <OutputSubtitleLabel>Korean</OutputSubtitleLabel>
                     <SourceLanguage>auto</SourceLanguage>
@@ -141,9 +165,11 @@ Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-
                     <LengthMs>10000</LengthMs>
                     <KeepMs>1500</KeepMs>
                 </Rendition>
+                <!-- English STT on GPU 1 -->
                 <Rendition>
                     <Engine>whisper</Engine>
                     <Model>whisper_model/ggml-small.bin</Model>
+                    <Modules>nv:1</Modules>
                     <InputAudioIndex>0</InputAudioIndex>
                     <OutputSubtitleLabel>English</OutputSubtitleLabel>
                     <SourceLanguage>auto</SourceLanguage>
@@ -157,7 +183,7 @@ Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-
 
 The `<STT><Rendition>` configuration includes the following options:
 
-<table><thead><tr><th width="192">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only <code>whisper</code> is supported.</td></tr><tr><td>Model</td><td>Path to the whisper.cpp model file. Can be absolute or relative to the configuration directory (where Server.xml is located).</td></tr><tr><td>InputAudioIndex</td><td>Index of the audio track in the input stream to transcribe. Default is <code>0</code> (first audio track).</td></tr><tr><td>OutputSubtitleLabel</td><td>Label of the subtitle rendition (defined in <code>&lt;Subtitles&gt;</code>) to write the transcription output to.</td></tr><tr><td>SourceLanguage</td><td>Language code of the input audio (ISO 639-1, e.g., <code>ko</code>, <code>en</code>, <code>ja</code>). Set to <code>auto</code> to enable automatic detection.</td></tr><tr><td>Translation</td><td>When set to <code>true</code>, translates the recognized text into English. Whisper currently supports translation to English only.</td></tr><tr><td>StepMs</td><td>How many milliseconds of new audio to collect before running each inference call. Default is <code>2000</code>. Lower values reduce subtitle latency but increase GPU load.</td></tr><tr><td>LengthMs</td><td>Total size of the audio window (in milliseconds) passed to Whisper per inference call. Default is <code>10000</code>. Larger windows give the model more context and improve accuracy.</td></tr><tr><td>KeepMs</td><td>Amount of audio (in milliseconds) carried over from the previous window after a context reset. Default is <code>1500</code>. Helps avoid cut-off words at window boundaries.</td></tr></tbody></table>
+<table><thead><tr><th width="192">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only <code>whisper</code> is supported.</td></tr><tr><td>Model</td><td>Path to the whisper.cpp model file. Can be absolute or relative to the configuration directory (where Server.xml is located).</td></tr><tr><td>InputAudioIndex</td><td>Index of the audio track in the input stream to transcribe. Default is <code>0</code> (first audio track).</td></tr><tr><td>OutputSubtitleLabel</td><td>Label of the subtitle rendition (defined in <code>&lt;Subtitles&gt;</code>) to write the transcription output to.</td></tr><tr><td>SourceLanguage</td><td>Language code of the input audio (ISO 639-1, e.g., <code>ko</code>, <code>en</code>, <code>ja</code>). Set to <code>auto</code> to enable automatic detection.</td></tr><tr><td>Translation</td><td>When set to <code>true</code>, translates the recognized text into English. Whisper currently supports translation to English only.</td></tr><tr><td>StepMs</td><td>How many milliseconds of new audio to collect before running each inference call. Default is <code>2000</code>. Lower values reduce subtitle latency but increase GPU load.</td></tr><tr><td>LengthMs</td><td>Total size of the audio window (in milliseconds) passed to Whisper per inference call. Default is <code>10000</code>. Larger windows give the model more context and improve accuracy.</td></tr><tr><td>KeepMs</td><td>Amount of audio (in milliseconds) carried over from the previous window after a context reset. Default is <code>1500</code>. Helps avoid cut-off words at window boundaries.</td></tr><tr><td>Modules</td><td>Selects the GPU to run this STT rendition on, using the same format as video encoder modules (e.g. <code>nv:0</code>, <code>nv:1</code>). If omitted, GPU 0 is used. Use this to distribute multiple renditions across different GPUs.</td></tr></tbody></table>
 
 ### Model
 

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -87,28 +87,27 @@ Each `<PreloadModel>` entry has the following fields:
 | Key | Description |
 |---|---|
 | Path | Path to the model file. Can be absolute or relative to the config directory. |
-| Devices | Comma-separated list of CUDA device indices to load the model onto (e.g. `0`, `0,1`, `2`). Omit or set to `all` to load on every available GPU. |
+| Devices | Comma-separated list of CUDA device indices to load the model onto (e.g. `0`, `0,1`, `2`). Set to `all` to load on every available GPU. If omitted, defaults to device 0. |
 
 ```xml
 <Server>
     <Modules>
         <Whisper>
-            <!-- Load on all available GPUs (Devices omitted = all) -->
+            <!-- Load on GPU 0 (default when Devices is omitted) -->
             <PreloadModel>
                 <Path>whisper_model/ggml-small.bin</Path>
+            </PreloadModel>
+
+            <!-- Load on all available GPUs -->
+            <PreloadModel>
+                <Path>whisper_model/ggml-medium.bin</Path>
                 <Devices>all</Devices>
             </PreloadModel>
 
-            <!-- Load on GPU 0 and GPU 1 only -->
-            <PreloadModel>
-                <Path>whisper_model/ggml-medium.bin</Path>
-                <Devices>0,1</Devices>
-            </PreloadModel>
-
-            <!-- Load on GPU 0 only -->
+            <!-- Load on GPU 0 and GPU 1 -->
             <PreloadModel>
                 <Path>whisper_model/ggml-large.bin</Path>
-                <Devices>0</Devices>
+                <Devices>0,1</Devices>
             </PreloadModel>
         </Whisper>
     </Modules>

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -74,6 +74,10 @@ STT configuration is split across two sections:
 * **`<Application><Subtitles>`** — defines subtitle renditions (label, language, etc.) that STT output will be written to.
 * **`<Application><OutputProfiles><MediaOptions><STT>`** — connects an input audio track to a subtitle rendition via an STT engine.
 
+{% hint style="warning" %}
+**Breaking change:** The `<Transcription>` element inside `<Subtitles><Rendition>` has been removed. If your existing configuration uses `<Subtitles><Rendition><Transcription>`, it will no longer work. Please migrate to `<OutputProfiles><MediaOptions><STT><Rendition>` as described below.
+{% endhint %}
+
 ### Step 1: Preload Models (Server.xml)
 
 Declare the Whisper model files to load at server startup inside `<Modules><Whisper>`. Multiple `<PreloadModel>` entries are allowed. Models are loaded in descending file-size order to maximize GPU utilization.

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -136,6 +136,10 @@ Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-
                     <OutputSubtitleLabel>Korean</OutputSubtitleLabel>
                     <SourceLanguage>auto</SourceLanguage>
                     <Translation>false</Translation>
+                    <!-- Optional: sliding-window tuning -->
+                    <StepMs>2000</StepMs>
+                    <LengthMs>10000</LengthMs>
+                    <KeepMs>1500</KeepMs>
                 </Rendition>
                 <Rendition>
                     <Engine>whisper</Engine>
@@ -153,7 +157,7 @@ Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-
 
 The `<STT><Rendition>` configuration includes the following options:
 
-<table><thead><tr><th width="192">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only <code>whisper</code> is supported.</td></tr><tr><td>Model</td><td>Path to the whisper.cpp model file. Can be absolute or relative to the configuration directory (where Server.xml is located).</td></tr><tr><td>InputAudioIndex</td><td>Index of the audio track in the input stream to transcribe. Default is <code>0</code> (first audio track).</td></tr><tr><td>OutputSubtitleLabel</td><td>Label of the subtitle rendition (defined in <code>&lt;Subtitles&gt;</code>) to write the transcription output to.</td></tr><tr><td>SourceLanguage</td><td>Language code of the input audio (ISO 639-1, e.g., <code>ko</code>, <code>en</code>, <code>ja</code>). Set to <code>auto</code> to enable automatic detection.</td></tr><tr><td>Translation</td><td>When set to <code>true</code>, translates the recognized text into English. Whisper currently supports translation to English only.</td></tr></tbody></table>
+<table><thead><tr><th width="192">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only <code>whisper</code> is supported.</td></tr><tr><td>Model</td><td>Path to the whisper.cpp model file. Can be absolute or relative to the configuration directory (where Server.xml is located).</td></tr><tr><td>InputAudioIndex</td><td>Index of the audio track in the input stream to transcribe. Default is <code>0</code> (first audio track).</td></tr><tr><td>OutputSubtitleLabel</td><td>Label of the subtitle rendition (defined in <code>&lt;Subtitles&gt;</code>) to write the transcription output to.</td></tr><tr><td>SourceLanguage</td><td>Language code of the input audio (ISO 639-1, e.g., <code>ko</code>, <code>en</code>, <code>ja</code>). Set to <code>auto</code> to enable automatic detection.</td></tr><tr><td>Translation</td><td>When set to <code>true</code>, translates the recognized text into English. Whisper currently supports translation to English only.</td></tr><tr><td>StepMs</td><td>How many milliseconds of new audio to collect before running each inference call. Default is <code>2000</code>. Lower values reduce subtitle latency but increase GPU load.</td></tr><tr><td>LengthMs</td><td>Total size of the audio window (in milliseconds) passed to Whisper per inference call. Default is <code>10000</code>. Larger windows give the model more context and improve accuracy.</td></tr><tr><td>KeepMs</td><td>Amount of audio (in milliseconds) carried over from the previous window after a context reset. Default is <code>1500</code>. Helps avoid cut-off words at window boundaries.</td></tr></tbody></table>
 
 ### Model
 
@@ -168,3 +172,29 @@ $ wget https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2.b
 ```
 
 Smaller models such as `ggml-small.bin` provide faster inference with lower accuracy. Larger models like `ggml-medium.bin` or `ggml-large.bin` offer higher accuracy at the cost of increased GPU memory and computation time.
+
+## Runtime Control via REST API
+
+STT can be paused and resumed at runtime without restarting the server or recreating the stream. This is useful for temporarily disabling transcription for a specific stream (e.g., during ad breaks or when the stream is not speech-heavy) to save GPU resources.
+
+For full API reference including request/response details and error codes, see [STT Control](../rest-api/v1/virtualhost/application/stream/stt-control.md).
+
+| Endpoint | Description |
+|---|---|
+| `POST :enableStt` | Resume STT inference for the stream |
+| `POST :disableStt` | Pause STT inference, dropping audio frames without GPU processing |
+| `POST :sttStatus` | Get current enabled state and per-rendition configuration |
+
+### Disabling STT at Startup
+
+STT can be started in the disabled (paused) state by setting `<Enable>false</Enable>` inside the `<STT>` block. In this case, no GPU inference runs until the stream receives an `:enableStt` call.
+
+```xml
+<STT>
+    <Enable>false</Enable>
+    <Rendition>
+        ...
+    </Rendition>
+</STT>
+```
+

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -2,7 +2,7 @@
 
 OvenMediaEngine (OME) version 0.20.0 and later supports real-time automatic subtitles through integration with whisper.cpp. This feature converts live audio streams to text in real time and can optionally translate the recognized speech into English.
 
-For real-time performance, an NVIDIA GPU is strongly recommended. While whisper.cpp can run on the CPU, it may result in latency or incomplete transcription.
+An NVIDIA GPU is required. CPU inference is not supported because it is too slow for real-time live transcription.
 
 <figure><img src="../.gitbook/assets/image.png" alt=""><figcaption></figcaption></figure>
 
@@ -29,7 +29,7 @@ $ nvidia-smi
 | 30%   38C    P8               5W /  70W |    171MiB / 20475MiB |      0%      Default |
 |                                         |                      |                  N/A |
 +-----------------------------------------+----------------------+----------------------+
-                                                                                         
+
 +---------------------------------------------------------------------------------------+
 | Processes:                                                                            |
 |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
@@ -68,55 +68,92 @@ $ ./misc/prerequisites.sh --enable-nv
 
 ## Configuration
 
-Enable subtitles by using `<Subtitles>`. For more details, refer to the [Subtitles](./) section. Each `<Rendition>` can include a `<Transcription>` element to enable speech-to-text.
+STT configuration is split across two sections:
 
-Example configuration:
+* **`<Modules><Whisper>`** in `Server.xml` — preloads model files into GPU memory at startup.
+* **`<Application><Subtitles>`** — defines subtitle renditions (label, language, etc.) that STT output will be written to.
+* **`<Application><OutputProfiles><MediaOptions><STT>`** — connects an input audio track to a subtitle rendition via an STT engine.
+
+### Step 1: Preload Models (Server.xml)
+
+Declare the Whisper model files to load at server startup inside `<Modules><Whisper>`. Multiple `<PreloadModel>` entries are allowed. Models are loaded in descending file-size order to maximize GPU utilization.
+
+```xml
+<Server>
+    <Modules>
+        <Whisper>
+            <PreloadModel>whisper_model/ggml-small.bin</PreloadModel>
+            <PreloadModel>whisper_model/ggml-medium.bin</PreloadModel>
+        </Whisper>
+    </Modules>
+</Server>
+```
+
+{% hint style="info" %}
+`<PreloadModel>` is optional. If omitted, models are loaded on demand when the first stream that uses them is published. Preloading is recommended for production to avoid a delay on the first stream.
+{% endhint %}
+
+### Step 2: Define Subtitle Renditions
+
+Define the subtitle tracks that will receive STT output. For more details on `<Subtitles>`, refer to the [Subtitles](./) section.
 
 ```xml
 <Application>
     <Subtitles>
         <Enable>true</Enable>
-        <DefaultLabel>Origin</DefaultLabel>
+        <DefaultLabel>Korean</DefaultLabel>
         <Rendition>
-            <Language>auto</Language>
-            <Label>Origin</Label>
+            <Language>ko</Language>
+            <Label>Korean</Label>
             <AutoSelect>true</AutoSelect>
             <Forced>false</Forced>
-            <Transcription>
-                <Engine>whisper</Engine>
-                <Model>whisper_model/ggml-small.bin</Model>
-                <AudioIndexHint>0</AudioIndexHint>
-                <SourceLanguage>auto</SourceLanguage>
-                <Translation>false</Translation>
-            </Transcription>
         </Rendition>
         <Rendition>
             <Language>en</Language>
             <Label>English</Label>
-            <AutoSelect>true</AutoSelect>
-            <Forced>false</Forced>
-            <Transcription>
-                <Engine>whisper</Engine>
-                <Model>whisper_model/ggml-small.bin</Model>
-                <AudioIndexHint>0</AudioIndexHint>
-                <SourceLanguage>auto</SourceLanguage>
-                <Translation>true</Translation>
-            </Transcription>
         </Rendition>
     </Subtitles>
+</Application>
 ```
 
-{% hint style="warning" %}
-The `<Subtitles>` configuration has been moved from `<Application><OutputProfiles><MediaOptions><Subtitles>` to `<Application><Subtitles>`. Please update your existing configuration accordingly.
-{% endhint %}
+### Step 3: Configure STT in OutputProfiles
 
-The Transcription configuration includes the following options:
+Under `<OutputProfiles><MediaOptions><STT>`, add a `<Rendition>` for each audio-to-subtitle mapping. The `<OutputSubtitleLabel>` must match a `<Label>` defined in `<Subtitles>`.
 
-<table><thead><tr><th width="164">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only "whisper" is supported.</td></tr><tr><td>Model</td><td>Specifies the path to the whisper.cpp model file.</td></tr><tr><td>AudioIndexHint</td><td>Specifies the index of the audio track in the input stream. Default is 0</td></tr><tr><td>SourceLanguage</td><td>Specifies the language code of the input audio (ISO 639-1, e.g., ko, en, ja). Set to auto to enable automatic detection</td></tr><tr><td>Translation</td><td>When set to true, translates the recognized text into English. whisper currently supports translation to English only. If this is true, the resulting subtitle track language is automatically set to English (en)</td></tr></tbody></table>
+```xml
+<Application>
+    <OutputProfiles>
+        <MediaOptions>
+            <STT>
+                <Rendition>
+                    <Engine>whisper</Engine>
+                    <Model>whisper_model/ggml-small.bin</Model>
+                    <InputAudioIndex>0</InputAudioIndex>
+                    <OutputSubtitleLabel>Korean</OutputSubtitleLabel>
+                    <SourceLanguage>auto</SourceLanguage>
+                    <Translation>false</Translation>
+                </Rendition>
+                <Rendition>
+                    <Engine>whisper</Engine>
+                    <Model>whisper_model/ggml-small.bin</Model>
+                    <InputAudioIndex>0</InputAudioIndex>
+                    <OutputSubtitleLabel>English</OutputSubtitleLabel>
+                    <SourceLanguage>auto</SourceLanguage>
+                    <Translation>true</Translation>
+                </Rendition>
+            </STT>
+        </MediaOptions>
+    </OutputProfiles>
+</Application>
+```
+
+The `<STT><Rendition>` configuration includes the following options:
+
+<table><thead><tr><th width="192">Key</th><th>Description</th></tr></thead><tbody><tr><td>Engine</td><td>The STT engine to use. Currently, only <code>whisper</code> is supported.</td></tr><tr><td>Model</td><td>Path to the whisper.cpp model file. Can be absolute or relative to the configuration directory (where Server.xml is located).</td></tr><tr><td>InputAudioIndex</td><td>Index of the audio track in the input stream to transcribe. Default is <code>0</code> (first audio track).</td></tr><tr><td>OutputSubtitleLabel</td><td>Label of the subtitle rendition (defined in <code>&lt;Subtitles&gt;</code>) to write the transcription output to.</td></tr><tr><td>SourceLanguage</td><td>Language code of the input audio (ISO 639-1, e.g., <code>ko</code>, <code>en</code>, <code>ja</code>). Set to <code>auto</code> to enable automatic detection.</td></tr><tr><td>Translation</td><td>When set to <code>true</code>, translates the recognized text into English. Whisper currently supports translation to English only.</td></tr></tbody></table>
 
 ### Model
 
-The option specifies which whisper.cpp model is used for transcription. Model files can be downloaded from [https://huggingface.co/ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp) For example, you can download a model with the following command:
+Model files can be downloaded from [https://huggingface.co/ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp). For example:
 
 ```
 $ wget https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
@@ -126,4 +163,4 @@ $ wget https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large.bin
 $ wget https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2.bin
 ```
 
-The model path can be set either as a relative path based on the configuration directory (where Server.xml is located) or as an absolute path starting with /. Smaller models such as ggml-small.bin provide faster performance but lower accuracy, while larger models like ggml-base.bin or ggml-large.bin offer higher accuracy at the cost of increased computation and memory usage.
+Smaller models such as `ggml-small.bin` provide faster inference with lower accuracy. Larger models like `ggml-medium.bin` or `ggml-large.bin` offer higher accuracy at the cost of increased GPU memory and computation time.

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -455,11 +455,12 @@ install_whisper()
 			## NOTE: Legacy. Dropped in CUDA 12.0 and later. Requires CUDA 11.x or older to build.
 	# 70: Volta - Titan V, Tesla V100
 			## NOTE: Legacy. Dropped in CUDA 12.0 and later. Requires CUDA 11.x or older to build.
-	# 75: Turing - GeForce RTX 20 series & GTX 16 series, Tesla T4
-	# 80: Ampere - A100 (Datacenter GPU), A30
-	# 86: Ampere - GeForce RTX 30 series (Desktop/Laptop), Tesla A10
+	# 61: Pascal  - GeForce GTX 10 series (1050/1060/1070/1080)
+	# 75: Turing  - GeForce RTX 20 series & GTX 16 series, Tesla T4
+	# 80: Ampere  - A100 (Datacenter GPU), A30
+	# 86: Ampere  - GeForce RTX 30 series (Desktop/Laptop), Tesla A10
 	# 89: Ada Lovelace - GeForce RTX 40 series, Tesla L4
-	WHISPER_CUDA_ARCH="75;80;86;89"
+	WHISPER_CUDA_ARCH="61;75;80;86;89"
 
 	(DIR=${TEMP_PATH}/whisper && \
 	mkdir -p ${DIR} && \

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -455,12 +455,14 @@ install_whisper()
 			## NOTE: Legacy. Dropped in CUDA 12.0 and later. Requires CUDA 11.x or older to build.
 	# 70: Volta - Titan V, Tesla V100
 			## NOTE: Legacy. Dropped in CUDA 12.0 and later. Requires CUDA 11.x or older to build.
-	# 61: Pascal  - GeForce GTX 10 series (1050/1060/1070/1080)
-	# 75: Turing  - GeForce RTX 20 series & GTX 16 series, Tesla T4
-	# 80: Ampere  - A100 (Datacenter GPU), A30
-	# 86: Ampere  - GeForce RTX 30 series (Desktop/Laptop), Tesla A10
+	# 61: Pascal      - GeForce GTX 10 series (1050/1060/1070/1080)
+	# 70: Volta       - Tesla V100
+	# 75: Turing      - GeForce RTX 20 series & GTX 16 series, Tesla T4
+	# 80: Ampere      - A100 (Datacenter GPU), A30
+	# 86: Ampere      - GeForce RTX 30 series (Desktop/Laptop), Tesla A10
 	# 89: Ada Lovelace - GeForce RTX 40 series, Tesla L4
-	WHISPER_CUDA_ARCH="61;75;80;86;89"
+	# 90: Hopper      - H100
+	WHISPER_CUDA_ARCH="61;70;75;80;86;89;90"
 
 	(DIR=${TEMP_PATH}/whisper && \
 	mkdir -p ${DIR} && \

--- a/src/projects/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.cpp
@@ -19,6 +19,8 @@
 
 #include <base/event/command/commands.h>
 
+#include <transcoder/transcoder.h>
+
 #include "../../../../../api_private.h"
 
 namespace api
@@ -36,6 +38,11 @@ namespace api
 			RegisterPost(R"((concludeHlsLive))", &StreamActionsController::OnPostConcludeHlsLive);
 
 			RegisterPost(R"((sendSubtitles))", &StreamActionsController::OnPostSendSubtitles);
+
+			// STT control
+			RegisterPost(R"((enableStt))", &StreamActionsController::OnPostEnableStt);
+			RegisterPost(R"((disableStt))", &StreamActionsController::OnPostDisableStt);
+			RegisterPost(R"((sttStatus))", &StreamActionsController::OnPostSttStatus);
 		}
 
 		// POST /v1/vhosts/<vhost_name>/apps/<app_name>/streams/<stream_name>:hlsDumps
@@ -577,6 +584,104 @@ namespace api
 			}
 
 			return {http::StatusCode::OK};
+		}
+
+		static std::shared_ptr<Transcoder> GetTranscoder()
+		{
+			auto module = ocst::Orchestrator::GetInstance()->GetTranscoderModule();
+			return std::dynamic_pointer_cast<Transcoder>(module);
+		}
+
+		// POST :enableStt
+		ApiResponse StreamActionsController::OnPostEnableStt(const std::shared_ptr<http::svr::HttpExchange> &client,
+															 const Json::Value &request_body,
+															 const std::shared_ptr<mon::HostMetrics> &vhost,
+															 const std::shared_ptr<mon::ApplicationMetrics> &app,
+															 const std::shared_ptr<mon::StreamMetrics> &stream,
+															 const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams)
+		{
+			auto transcoder = GetTranscoder();
+			if (transcoder == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::ServiceUnavailable,
+									  "Transcoder module is not available");
+			}
+
+			if (transcoder->ResumeEncoders(app->GetVHostAppName(), stream->GetName(), cmn::MediaCodecId::Whisper) == false)
+			{
+				throw http::HttpError(http::StatusCode::NotFound,
+									  "Could not find STT encoder for stream: [%s/%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
+			}
+
+			Json::Value response;
+			response["enabled"] = true;
+			return {http::StatusCode::OK, response};
+		}
+
+		// POST :disableStt
+		ApiResponse StreamActionsController::OnPostDisableStt(const std::shared_ptr<http::svr::HttpExchange> &client,
+															  const Json::Value &request_body,
+															  const std::shared_ptr<mon::HostMetrics> &vhost,
+															  const std::shared_ptr<mon::ApplicationMetrics> &app,
+															  const std::shared_ptr<mon::StreamMetrics> &stream,
+															  const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams)
+		{
+			auto transcoder = GetTranscoder();
+			if (transcoder == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::ServiceUnavailable,
+									  "Transcoder module is not available");
+			}
+
+			if (transcoder->PauseEncoders(app->GetVHostAppName(), stream->GetName(), cmn::MediaCodecId::Whisper) == false)
+			{
+				throw http::HttpError(http::StatusCode::NotFound,
+									  "Could not find STT encoder for stream: [%s/%s/%s]",
+									  vhost->GetName().CStr(), app->GetVHostAppName().GetAppName().CStr(), stream->GetName().CStr());
+			}
+
+			Json::Value response;
+			response["enabled"] = false;
+			return {http::StatusCode::OK, response};
+		}
+
+		// POST :sttStatus
+		ApiResponse StreamActionsController::OnPostSttStatus(const std::shared_ptr<http::svr::HttpExchange> &client,
+															 const Json::Value &request_body,
+															 const std::shared_ptr<mon::HostMetrics> &vhost,
+															 const std::shared_ptr<mon::ApplicationMetrics> &app,
+															 const std::shared_ptr<mon::StreamMetrics> &stream,
+															 const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams)
+		{
+			auto transcoder = GetTranscoder();
+			if (transcoder == nullptr)
+			{
+				throw http::HttpError(http::StatusCode::ServiceUnavailable,
+									  "Transcoder module is not available");
+			}
+
+			auto info_list = transcoder->GetEncoderInfoList(app->GetVHostAppName(), stream->GetName(), cmn::MediaCodecId::Whisper);
+
+			Json::Value renditions(Json::arrayValue);
+			for (const auto &info : info_list)
+			{
+				Json::Value rendition;
+				rendition["codec"] = cmn::GetCodecIdString(info.codec_id);
+				for (const auto &[key, value] : info.properties)
+				{
+					rendition[key.CStr()] = value.CStr();
+				}
+				renditions.append(rendition);
+			}
+
+			// Reflect actual paused state
+			bool enabled = !info_list.empty() && !transcoder->IsEncoderPaused(app->GetVHostAppName(), stream->GetName(), cmn::MediaCodecId::Whisper);
+
+			Json::Value response;
+			response["enabled"]    = enabled;
+			response["renditions"] = renditions;
+			return {http::StatusCode::OK, response};
 		}
 
 		std::shared_ptr<pvd::Stream> StreamActionsController::GetSourceStream(const std::shared_ptr<mon::StreamMetrics> &stream)

--- a/src/projects/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.h
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/streams/stream_actions_controller.h
@@ -67,6 +67,30 @@ namespace api
 										   const std::shared_ptr<mon::StreamMetrics> &stream,
 										   const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams);
 
+			// POST /v1/vhosts/<vhost_name>/apps/<app_name>/streams/<stream_name>:enableStt
+			ApiResponse OnPostEnableStt(const std::shared_ptr<http::svr::HttpExchange> &client,
+									const Json::Value &request_body,
+									const std::shared_ptr<mon::HostMetrics> &vhost,
+									const std::shared_ptr<mon::ApplicationMetrics> &app,
+									const std::shared_ptr<mon::StreamMetrics> &stream,
+									const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams);
+
+			// POST /v1/vhosts/<vhost_name>/apps/<app_name>/streams/<stream_name>:disableStt
+			ApiResponse OnPostDisableStt(const std::shared_ptr<http::svr::HttpExchange> &client,
+									 const Json::Value &request_body,
+									 const std::shared_ptr<mon::HostMetrics> &vhost,
+									 const std::shared_ptr<mon::ApplicationMetrics> &app,
+									 const std::shared_ptr<mon::StreamMetrics> &stream,
+									 const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams);
+
+			// POST /v1/vhosts/<vhost_name>/apps/<app_name>/streams/<stream_name>:sttStatus
+			ApiResponse OnPostSttStatus(const std::shared_ptr<http::svr::HttpExchange> &client,
+										const Json::Value &request_body,
+										const std::shared_ptr<mon::HostMetrics> &vhost,
+										const std::shared_ptr<mon::ApplicationMetrics> &app,
+										const std::shared_ptr<mon::StreamMetrics> &stream,
+										const std::vector<std::shared_ptr<mon::StreamMetrics>> &output_streams);
+
 		private:
 			// TODO(Getroot): Move to mon::StreamMetrics
 			std::shared_ptr<pvd::Stream> GetSourceStream(const std::shared_ptr<mon::StreamMetrics> &stream);

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -312,13 +312,18 @@ void MediaTrack::SetDecoderConfigurationRecord(const std::shared_ptr<DecoderConf
 	std::atomic_store(&_decoder_configuration_record, dcr);
 }
 
-void MediaTrack::SetCodecStatus(CodecStatus status)
+void MediaTrack::SetCodecStatus(cmn::CodecStatus status)
 {
 	_codec_status = status;
 }
 
-MediaTrack::CodecStatus MediaTrack::GetCodecStatus() const
+cmn::CodecStatus MediaTrack::GetCodecStatus() const
 {
+	// Bypass tracks have no encoder init; they are always ready.
+	if (IsBypass())
+	{
+		return cmn::CodecStatus::Ready;
+	}
 	return _codec_status;
 }
 
@@ -389,6 +394,8 @@ ov::String MediaTrack::GetInfoString()
 {
 	ov::String out_str = "";
 
+	const char *codec_status_str = cmn::GetCodecStatusString(GetCodecStatus());
+
 	switch (GetMediaType())
 	{
 		case MediaType::Video:
@@ -397,7 +404,7 @@ ov::String MediaTrack::GetInfoString()
 				"Public Name(%s) "
 				"Variant Name(%s) "
 				"Bitrate(%s) "
-				"Codec(%s,%s:%d) "
+				"Codec(%s,%s:%d%s%s) "
 				"BSF(%s) "
 				"Resolution(%s) "
 				"MaxResolution(%s) "
@@ -409,6 +416,7 @@ ov::String MediaTrack::GetInfoString()
 				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
 				ov::Converter::BitToString(GetBitrate()).CStr(),
 				cmn::GetCodecIdString(GetCodecId()), IsBypass()?"Passthrough":cmn::GetCodecModuleIdString(GetCodecModuleId()), GetCodecDeviceId(),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
 				GetBitstreamFormatString(GetOriginBitstream()),
 				GetResolution().ToString().CStr(),
 				GetMaxResolution().ToString().CStr(),
@@ -425,7 +433,7 @@ ov::String MediaTrack::GetInfoString()
 				"Public Name(%s) "
 				"Variant Name(%s) "
 				"Bitrate(%s) "
-				"Codec(%s,%s:%d) "
+				"Codec(%s,%s:%d%s%s) "
 				"BSF(%s) "
 				"Samplerate(%s) "
 				"Format(%s) "
@@ -433,42 +441,38 @@ ov::String MediaTrack::GetInfoString()
 				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
 				ov::Converter::BitToString(GetBitrate()).CStr(),
 				cmn::GetCodecIdString(GetCodecId()), IsBypass()?"Passthrough":cmn::GetCodecModuleIdString(GetCodecModuleId()), GetCodecDeviceId(),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
 				GetBitstreamFormatString(GetOriginBitstream()),
 				ov::Converter::ToSiString(GetSampleRate(), 1).CStr(),
 				GetSample().GetName(),
 				GetChannel().GetName());
 			break;
+
 		case MediaType::Data:
 			out_str.AppendFormat(
 				"Data  Track #%d: "
 				"Public Name(%s) "
 				"Variant Name(%s) "
-				"Codec(%s,%s) "
+				"Codec(%s,%s%s%s) "
 				"BSF(%s) ",
 				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
 				cmn::GetCodecIdString(GetCodecId()), IsBypass()?"Passthrough":cmn::GetCodecModuleIdString(GetCodecModuleId()),
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
 				GetBitstreamFormatString(GetOriginBitstream()));
 			break;
+
 		case MediaType::Subtitle:
 		{
-			const char *codec_status_str = "Unknown";
-			switch (GetCodecStatus())
-			{
-				case CodecStatus::Ready:  codec_status_str = "Ready";  break;
-				case CodecStatus::Failed: codec_status_str = "Failed"; break;
-				default: break;
-			}
 			auto extra_info = GetExtraInfo();
 			out_str.AppendFormat(
 				"Subtitle Track #%d: "
 				"Public Name(%s) "
 				"Variant Name(%s) "
-				"Codec(%s) "
-				"CodecStatus(%s) "
+				"Codec(%s%s%s) "
 				"timebase(%s)",
 				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
 				cmn::GetCodecIdString(GetCodecId()),
-				codec_status_str,
+				codec_status_str ? "," : "", codec_status_str ? codec_status_str : "",
 				GetTimeBase().ToString().CStr());
 			if (extra_info.IsEmpty() == false)
 			{
@@ -575,7 +579,7 @@ bool MediaTrack::IsValid()
 		}
 		break;
 		case MediaCodecId::Whisper: {
-			if (_codec_status != CodecStatus::Unknown)
+			if (_codec_status != cmn::CodecStatus::Unknown)
 			{
 				_is_valid = true;
 				return true;

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -103,6 +103,10 @@ bool MediaTrack::Update(const MediaTrack &media_track)
 	_source_language = media_track._source_language;
 	_translation = media_track._translation.load();
 
+	_codec_status = media_track._codec_status.load();
+	_extra_info = media_track._extra_info;
+	_essential_track = media_track._essential_track.load();
+
 	return true;
 }
 
@@ -308,6 +312,38 @@ void MediaTrack::SetDecoderConfigurationRecord(const std::shared_ptr<DecoderConf
 	std::atomic_store(&_decoder_configuration_record, dcr);
 }
 
+void MediaTrack::SetCodecStatus(CodecStatus status)
+{
+	_codec_status = status;
+}
+
+MediaTrack::CodecStatus MediaTrack::GetCodecStatus() const
+{
+	return _codec_status;
+}
+
+void MediaTrack::SetExtraInfo(const ov::String &info)
+{
+	std::scoped_lock lock(_media_mutex);
+	_extra_info = info;
+}
+
+ov::String MediaTrack::GetExtraInfo() const
+{
+	std::shared_lock lock(_media_mutex);
+	return _extra_info;
+}
+
+void MediaTrack::SetEssentialTrack(bool essential)
+{
+	_essential_track = essential;
+}
+
+bool MediaTrack::IsEssentialTrack() const
+{
+	return _essential_track;
+}
+
 ov::String MediaTrack::GetCodecsParameter() const
 {
 	switch (GetCodecId())
@@ -414,22 +450,41 @@ ov::String MediaTrack::GetInfoString()
 				GetBitstreamFormatString(GetOriginBitstream()));
 			break;
 		case MediaType::Subtitle:
+		{
+			const char *codec_status_str = "Unknown";
+			switch (GetCodecStatus())
+			{
+				case CodecStatus::Ready:  codec_status_str = "Ready";  break;
+				case CodecStatus::Failed: codec_status_str = "Failed"; break;
+				default: break;
+			}
+			auto extra_info = GetExtraInfo();
 			out_str.AppendFormat(
 				"Subtitle Track #%d: "
 				"Public Name(%s) "
 				"Variant Name(%s) "
-				"Codec(%s,%s:%d) "
-				"BSF(%s) ",
+				"Codec(%s) "
+				"CodecStatus(%s) "
+				"timebase(%s)",
 				GetId(), GetPublicName().CStr(), GetVariantName().CStr(),
-				cmn::GetCodecIdString(GetCodecId()), IsBypass()?"Passthrough":cmn::GetCodecModuleIdString(GetCodecModuleId()), GetCodecDeviceId(),
-				GetBitstreamFormatString(GetOriginBitstream()));
+				cmn::GetCodecIdString(GetCodecId()),
+				codec_status_str,
+				GetTimeBase().ToString().CStr());
+			if (extra_info.IsEmpty() == false)
+			{
+				out_str.AppendFormat(" %s", extra_info.CStr());
+			}
 			break;
+		}
 
 		default:
 			break;
 	}
 
-	out_str.AppendFormat("timebase(%s)", GetTimeBase().ToString().CStr());
+	if (GetMediaType() != MediaType::Subtitle)
+	{
+		out_str.AppendFormat("timebase(%s)", GetTimeBase().ToString().CStr());
+	}
 
 	return out_str;
 }
@@ -442,8 +497,7 @@ bool MediaTrack::IsValid()
 	}
 
 	// data type is always valid
-	if(GetMediaType() == MediaType::Data || 
-		GetMediaType() == MediaType::Subtitle)
+	if (GetMediaType() == MediaType::Data)
 	{
 		_is_valid = true;
 		return true;
@@ -520,6 +574,18 @@ bool MediaTrack::IsValid()
 			}
 		}
 		break;
+		case MediaCodecId::Whisper: {
+			if (_codec_status != CodecStatus::Unknown)
+			{
+				_is_valid = true;
+				return true;
+			}
+		}
+		break;
+		case MediaCodecId::WebVTT: {
+			_is_valid = true;
+			return true;
+		}
 
 		default:
 			break;

--- a/src/projects/base/info/media_track.h
+++ b/src/projects/base/info/media_track.h
@@ -142,6 +142,24 @@ public:
 
 	ov::String GetInfoString();
 
+	// Codec status: set by encoder/decoder after initialization
+	enum class CodecStatus : uint8_t
+	{
+		Unknown,
+		Ready,
+		Failed,
+	};
+	void SetCodecStatus(CodecStatus status);
+	CodecStatus GetCodecStatus() const;
+
+	// Extra info: codec-specific human-readable metadata (e.g. Engine/Model/Source for Whisper)
+	void SetExtraInfo(const ov::String &info);
+	ov::String GetExtraInfo() const;
+
+	// If false, encoder failure for this track is non-fatal and the stream continues without it.
+	void SetEssentialTrack(bool essential);
+	bool IsEssentialTrack() const;
+
 protected:
 	mutable std::shared_mutex _media_mutex;
 
@@ -219,4 +237,11 @@ protected:
 	// Codec specific object
 	// AVCDecoderConfigurationRecord, HEVCDecoderConfigurationRecord, AudioSpecificConfig 
 	std::shared_ptr<DecoderConfigurationRecord> _decoder_configuration_record = nullptr;
+
+	// Codec status and extra info
+	std::atomic<CodecStatus> _codec_status = CodecStatus::Unknown;
+	ov::String _extra_info;
+
+	// If false, encoder failure for this track is non-fatal and the stream continues without it.
+	std::atomic<bool> _essential_track = true;
 };

--- a/src/projects/base/info/media_track.h
+++ b/src/projects/base/info/media_track.h
@@ -143,14 +143,9 @@ public:
 	ov::String GetInfoString();
 
 	// Codec status: set by encoder/decoder after initialization
-	enum class CodecStatus : uint8_t
-	{
-		Unknown,
-		Ready,
-		Failed,
-	};
-	void SetCodecStatus(CodecStatus status);
-	CodecStatus GetCodecStatus() const;
+	using CodecStatus = cmn::CodecStatus;
+	void SetCodecStatus(cmn::CodecStatus status);
+	cmn::CodecStatus GetCodecStatus() const;
 
 	// Extra info: codec-specific human-readable metadata (e.g. Engine/Model/Source for Whisper)
 	void SetExtraInfo(const ov::String &info);
@@ -239,7 +234,7 @@ protected:
 	std::shared_ptr<DecoderConfigurationRecord> _decoder_configuration_record = nullptr;
 
 	// Codec status and extra info
-	std::atomic<CodecStatus> _codec_status = CodecStatus::Unknown;
+	std::atomic<cmn::CodecStatus> _codec_status = cmn::CodecStatus::Unknown;
 	ov::String _extra_info;
 
 	// If false, encoder failure for this track is non-fatal and the stream continues without it.

--- a/src/projects/base/info/stream.h
+++ b/src/projects/base/info/stream.h
@@ -73,6 +73,11 @@ namespace info
 		StreamRepresentationType GetRepresentationType() const;
 		void SetRepresentationType(const StreamRepresentationType &type);
 
+		// Internal streams are used for internal processing (e.g. STT) and must not
+		// be exposed to Publishers.
+		bool IsInternal() const { return _internal; }
+		void SetInternal(bool internal) { _internal = internal; }
+
 		uint32_t IssueUniqueTrackId();
 		bool AddTrack(const std::shared_ptr<MediaTrack> &track);
 		bool UpdateTrack(const std::shared_ptr<MediaTrack> &track);
@@ -197,6 +202,7 @@ namespace info
 		// Relay Type : [Provider -> Publisher]
 		// 		- It is sent directly to the Publisher without affecting the Output Profile.
 		StreamRepresentationType _representation_type = StreamRepresentationType::Source;
+		bool _internal = false;
 
 		std::shared_ptr<Application> _app_info = nullptr;
 

--- a/src/projects/base/info/subtitle_track.cpp
+++ b/src/projects/base/info/subtitle_track.cpp
@@ -96,3 +96,6 @@ int32_t SubtitleTrack::GetLengthMs() const { return _length_ms; }
 
 void SubtitleTrack::SetKeepMs(int32_t keep_ms) { _keep_ms = keep_ms; }
 int32_t SubtitleTrack::GetKeepMs() const { return _keep_ms; }
+
+void SubtitleTrack::SetSttEnabled(bool enabled) { _stt_enabled = enabled; }
+bool SubtitleTrack::IsSttEnabled() const { return _stt_enabled; }

--- a/src/projects/base/info/subtitle_track.cpp
+++ b/src/projects/base/info/subtitle_track.cpp
@@ -87,3 +87,12 @@ ov::String SubtitleTrack::GetOutputTrackLabel() const
 	std::shared_lock lock(_subtitle_mutex);
 	return _output_track_label;
 }
+
+void SubtitleTrack::SetStepMs(int32_t step_ms) { _step_ms = step_ms; }
+int32_t SubtitleTrack::GetStepMs() const { return _step_ms; }
+
+void SubtitleTrack::SetLengthMs(int32_t length_ms) { _length_ms = length_ms; }
+int32_t SubtitleTrack::GetLengthMs() const { return _length_ms; }
+
+void SubtitleTrack::SetKeepMs(int32_t keep_ms) { _keep_ms = keep_ms; }
+int32_t SubtitleTrack::GetKeepMs() const { return _keep_ms; }

--- a/src/projects/base/info/subtitle_track.h
+++ b/src/projects/base/info/subtitle_track.h
@@ -37,7 +37,14 @@ public:
 	void SetOutputLabel(const ov::String &label);
 	ov::String GetOutputTrackLabel() const;
 
-protected:
+        void SetStepMs(int32_t step_ms);
+        int32_t GetStepMs() const;
+
+        void SetLengthMs(int32_t length_ms);
+        int32_t GetLengthMs() const;
+
+        void SetKeepMs(int32_t keep_ms);
+        int32_t GetKeepMs() const;
 	mutable std::shared_mutex _subtitle_mutex;
 
 	// For subtitle 
@@ -52,4 +59,7 @@ protected:
 	ov::String _source_language = "auto"; // input language
 	std::atomic<bool> _translation = false; // whisper only supports english translation
 	ov::String _output_track_label = ""; // input audio track label for speech to text
+	std::atomic<int32_t> _step_ms = 2000;
+	std::atomic<int32_t> _length_ms = 10000;
+	std::atomic<int32_t> _keep_ms = 1500;
 };

--- a/src/projects/base/info/subtitle_track.h
+++ b/src/projects/base/info/subtitle_track.h
@@ -45,6 +45,10 @@ public:
 
         void SetKeepMs(int32_t keep_ms);
         int32_t GetKeepMs() const;
+
+	void SetSttEnabled(bool enabled);
+	bool IsSttEnabled() const;
+
 	mutable std::shared_mutex _subtitle_mutex;
 
 	// For subtitle 
@@ -62,4 +66,5 @@ public:
 	std::atomic<int32_t> _step_ms = 2000;
 	std::atomic<int32_t> _length_ms = 10000;
 	std::atomic<int32_t> _keep_ms = 1500;
+	std::atomic<bool> _stt_enabled = true;
 };

--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -491,6 +491,23 @@ namespace cmn
 		return false;
 	}
 
+	enum class CodecStatus : uint8_t
+	{
+		Unknown,
+		Ready,
+		Failed,
+	};
+
+	constexpr const char *GetCodecStatusString(CodecStatus status)
+	{
+		switch (status)
+		{
+			case CodecStatus::Ready:  return "Ready";
+			case CodecStatus::Failed: return "Failed";
+			default:                  return nullptr;  // Unknown: don't print
+		}
+	}
+
 	constexpr const char *GetCodecIdString(cmn::MediaCodecId id)
 	{
 		switch (id)

--- a/src/projects/config/items/modules/modules.h
+++ b/src/projects/config/items/modules/modules.h
@@ -10,6 +10,7 @@
 
 #include "p2p.h"
 #include "recovery.h"
+#include "whisper.h"
 
 namespace cfg
 {
@@ -29,6 +30,7 @@ namespace cfg
 			ModuleTemplate _etag{false};
 			// Experimental feature is disabled by default
 			ModuleTemplate _ertmp{false};
+			Whisper _whisper;
 
 		public:
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetHttp2, _http2)
@@ -38,6 +40,7 @@ namespace cfg
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetDynamicAppRemoval, _dynamic_app_removal)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetETag, _etag)
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetERTMP, _ertmp)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetWhisper, _whisper)
 
 		protected:
 			void MakeList() override
@@ -49,6 +52,7 @@ namespace cfg
 				Register<Optional>("DynamicAppRemoval", &_dynamic_app_removal);
 				Register<Optional>("ETag", &_etag);
 				Register<Optional>("ERTMP", &_ertmp);
+				Register<Optional>("Whisper", &_whisper);
 			}
 		};
 	}  // namespace modules

--- a/src/projects/config/items/modules/whisper.h
+++ b/src/projects/config/items/modules/whisper.h
@@ -14,8 +14,8 @@ namespace cfg
 	{
 		// Represents a single <PreloadModel> entry.
 		// <Path> is the model file path (absolute or relative to config dir).
-		// <Devices> is a comma-separated list of CUDA device indices to preload onto,
-		// or "all" (or omitted) to load on every available GPU.
+		// <Devices> is a comma-separated list of CUDA device indices to preload onto.
+		// Use "all" to load on every available GPU. If omitted, defaults to device 0.
 		struct WhisperPreloadModel : public Item
 		{
 		protected:

--- a/src/projects/config/items/modules/whisper.h
+++ b/src/projects/config/items/modules/whisper.h
@@ -1,0 +1,32 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+namespace cfg
+{
+	namespace modules
+	{
+		struct Whisper : public Item
+		{
+		protected:
+			// List of model file paths to preload at server start.
+			// Each path may be absolute or relative to the config file directory.
+			std::vector<ov::String> _preload_model_list;
+
+		public:
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetPreloadModels, _preload_model_list)
+
+		protected:
+			void MakeList() override
+			{
+				Register<Optional>("PreloadModel", &_preload_model_list);
+			}
+		};
+	}  // namespace modules
+}  // namespace cfg

--- a/src/projects/config/items/modules/whisper.h
+++ b/src/projects/config/items/modules/whisper.h
@@ -12,12 +12,32 @@ namespace cfg
 {
 	namespace modules
 	{
+		// Represents a single <PreloadModel> entry.
+		// <Path> is the model file path (absolute or relative to config dir).
+		// <Devices> is a comma-separated list of CUDA device indices to preload onto,
+		// or "all" (or omitted) to load on every available GPU.
+		struct WhisperPreloadModel : public Item
+		{
+		protected:
+			ov::String _path;
+			ov::String _devices;  // "", "all", "0", "0,1", "2", etc.
+
+		public:
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetPath, _path)
+			CFG_DECLARE_CONST_REF_GETTER_OF(GetDevices, _devices)
+
+		protected:
+			void MakeList() override
+			{
+				Register("Path", &_path);
+				Register<Optional>("Devices", &_devices);
+			}
+		};
+
 		struct Whisper : public Item
 		{
 		protected:
-			// List of model file paths to preload at server start.
-			// Each path may be absolute or relative to the config file directory.
-			std::vector<ov::String> _preload_model_list;
+			std::vector<WhisperPreloadModel> _preload_model_list;
 
 		public:
 			CFG_DECLARE_CONST_REF_GETTER_OF(GetPreloadModels, _preload_model_list)

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
@@ -35,6 +35,8 @@ namespace cfg
 					int32_t _length_ms = 10000;
 					int32_t _keep_ms = 1500;
 
+					bool _stt_enabled = true;
+
 				public:
 					SpeechToTextProfile(const ov::String &name, const ov::String &engine, const ov::String &model, uint32_t input_track_id, uint32_t output_track_id)
 						: _name(name), _engine(engine), _model(model), _input_track_id(input_track_id), _output_track_id(output_track_id)
@@ -103,6 +105,9 @@ namespace cfg
 
 					void SetKeepMs(int32_t keep_ms) { _keep_ms = keep_ms; }
 					int32_t GetKeepMs() const { return _keep_ms; }
+
+					void SetSttEnabled(bool enabled) { _stt_enabled = enabled; }
+					bool IsSttEnabled() const { return _stt_enabled; }
 				};
 			}  // namespace oprf
 		}  // namespace app

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
@@ -31,6 +31,10 @@ namespace cfg
 					uint32_t _output_track_id; // subtitle track id
 					ov::String _output_track_label; // subtitle track label
 
+					int32_t _step_ms = 2000;
+					int32_t _length_ms = 10000;
+					int32_t _keep_ms = 1500;
+
 				public:
 					SpeechToTextProfile(const ov::String &name, const ov::String &engine, const ov::String &model, uint32_t input_track_id, uint32_t output_track_id)
 						: _name(name), _engine(engine), _model(model), _input_track_id(input_track_id), _output_track_id(output_track_id)
@@ -90,6 +94,15 @@ namespace cfg
 					{
 						return _output_track_label;
 					}
+
+					void SetStepMs(int32_t step_ms) { _step_ms = step_ms; }
+					int32_t GetStepMs() const { return _step_ms; }
+
+					void SetLengthMs(int32_t length_ms) { _length_ms = length_ms; }
+					int32_t GetLengthMs() const { return _length_ms; }
+
+					void SetKeepMs(int32_t keep_ms) { _keep_ms = keep_ms; }
+					int32_t GetKeepMs() const { return _keep_ms; }
 				};
 			}  // namespace oprf
 		}  // namespace app

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/speech_to_text_profile.h
@@ -36,6 +36,7 @@ namespace cfg
 					int32_t _keep_ms = 1500;
 
 					bool _stt_enabled = true;
+				ov::String _modules;
 
 				public:
 					SpeechToTextProfile(const ov::String &name, const ov::String &engine, const ov::String &model, uint32_t input_track_id, uint32_t output_track_id)
@@ -108,6 +109,9 @@ namespace cfg
 
 					void SetSttEnabled(bool enabled) { _stt_enabled = enabled; }
 					bool IsSttEnabled() const { return _stt_enabled; }
+
+					void SetModules(const ov::String &modules) { _modules = modules; }
+					ov::String GetModules() const { return _modules; }
 				};
 			}  // namespace oprf
 		}  // namespace app

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/media_options.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/media_options.h
@@ -10,6 +10,7 @@
 
 #include "../../subtitle/subtitle.h"
 #include "./overlays/overlays.h"
+#include "stt.h"
 
 namespace cfg
 {
@@ -24,57 +25,59 @@ namespace cfg
 				protected:
 					subt::Subtitle _subtitle; 
 					Overlays _overlays;
+					Stt _stt;
 
 				public:
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetSubtitle, _subtitle)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetOverlays, _overlays);
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetStt, _stt)
 
 				protected:
 					void MakeList() override
 					{
 						Register<Optional>("Subtitles", &_subtitle, nullptr,
 							[=]() -> std::shared_ptr<ConfigError> {
-								if (_subtitle.IsEnabled() && _subtitle.GetRenditions().empty())
-								{
-									return CreateConfigErrorPtr("Subtitle is enabled but no renditions are defined");
-								}
-								
-								// Check default label
-								auto default_label = _subtitle.GetDefaultLabel();
-								if (default_label.IsEmpty() == false)
-								{
-									bool found = false;
-									for (auto &rendition : _subtitle.GetRenditions())
+									if (_subtitle.IsEnabled() && _subtitle.GetRenditions().empty())
 									{
-										if (rendition.GetLabel() == default_label)
+										return CreateConfigErrorPtr("Subtitle is enabled but no renditions are defined");
+									}
+
+									// Check default label
+									auto default_label = _subtitle.GetDefaultLabel();
+									if (default_label.IsEmpty() == false)
+									{
+										bool found = false;
+										for (auto &rendition : _subtitle.GetRenditions())
 										{
-											rendition.SetDefault(true);
-											if (rendition.IsAutoSelect() == false)
-											{
-												logw("Config", "Default subtitle rendition '%s' must have AutoSelect enabled. Enabling it automatically.", default_label.CStr());
-												rendition.SetAutoSelect(true);
-											}
-											found = true;
+												   if (rendition.GetLabel() == default_label)
+												   {
+												   rendition.SetDefault(true);
+												   if (rendition.IsAutoSelect() == false)
+												   {
+												   logw("Config", "Default subtitle rendition '%s' must have AutoSelect enabled. Enabling it automatically.", default_label.CStr());
+												   rendition.SetAutoSelect(true);
+												   }
+												   found = true;
+												   }
+										}
+
+										if (found == false)
+										{
+											   return CreateConfigErrorPtr("Default label '%s' not found in subtitle renditions", default_label.CStr());
 										}
 									}
 
-									if (found == false)
-									{
-										return CreateConfigErrorPtr("Default label '%s' not found in subtitle renditions", default_label.CStr());
-									}
+									// moved to <Application><Subtitle>, this Subtitles will be deprecated soon
+									logw("Config", "<Subtitles> configuration is moved to <Application><Subtitle>. Please update your configuration accordingly. This may be deprecated in future versions.");
+
+									return nullptr;
 								}
-
-								// moved to <Application><Subtitle>, this Subtitles will be deprecated soon
-								logw("Config", "<Subtitles> configuration is moved to <Application><Subtitle>. Please update your configuration accordingly. This may be deprecated in future versions.");
-
-								return nullptr;
-							}
 						);
 						Register<Optional>({"Overlays", "overlays"}, &_overlays);
-
+						Register<Optional>("STT", &_stt);
 					}
 				};
 			}  // namespace oprf
-		} // namespace app
-	} // namespace vhost
+			} // namespace app
+		} // namespace vhost
 }  // namespace cfg

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt.h
@@ -21,14 +21,17 @@ namespace cfg
 				struct Stt : public Item
 				{
 				protected:
+					bool _enable = true;
 					std::vector<SttRendition> _renditions;
 
 				public:
+					CFG_DECLARE_CONST_REF_GETTER_OF(IsEnabled, _enable)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetRenditions, _renditions)
 
 				protected:
 					void MakeList() override
 					{
+						Register<Optional>("Enable", &_enable);
 						Register<Optional>("Rendition", &_renditions);
 					}
 				};

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt.h
@@ -1,0 +1,38 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "stt_rendition.h"
+
+namespace cfg
+{
+	namespace vhost
+	{
+		namespace app
+		{
+			namespace oprf
+			{
+				struct Stt : public Item
+				{
+				protected:
+					std::vector<SttRendition> _renditions;
+
+				public:
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetRenditions, _renditions)
+
+				protected:
+					void MakeList() override
+					{
+						Register<Optional>("Rendition", &_renditions);
+					}
+				};
+			}  // namespace oprf
+		}  // namespace app
+	}  // namespace vhost
+}  // namespace cfg

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
@@ -31,6 +31,13 @@ namespace cfg
 					ov::String _source_language = "auto";
 					// Translate output to English (whisper only)
 					bool _translation = false;
+					// Whisper sliding-window tuning parameters.
+					// StepMs: how many ms of new audio to collect before running inference (default 2000).
+					// LengthMs: total audio window passed to Whisper per inference call (default 10000).
+					// KeepMs: audio overlap carried over from the previous window after a context reset (default 1500).
+					int32_t _step_ms = 2000;
+					int32_t _length_ms = 10000;
+					int32_t _keep_ms = 1500;
 
 				public:
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetEngine, _engine)
@@ -39,6 +46,9 @@ namespace cfg
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetInputAudioIndex, _input_audio_index)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetSourceLanguage, _source_language)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetTranslation, _translation)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetStepMs, _step_ms)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetLengthMs, _length_ms)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetKeepMs, _keep_ms)
 
 				protected:
 					void MakeList() override
@@ -49,6 +59,9 @@ namespace cfg
 						Register<Optional>("InputAudioIndex", &_input_audio_index);
 						Register<Optional>("SourceLanguage", &_source_language);
 						Register<Optional>("Translation", &_translation);
+						Register<Optional>("StepMs", &_step_ms);
+						Register<Optional>("LengthMs", &_length_ms);
+						Register<Optional>("KeepMs", &_keep_ms);
 					}
 				};
 			}  // namespace oprf

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
@@ -38,6 +38,8 @@ namespace cfg
 					int32_t _step_ms = 2000;
 					int32_t _length_ms = 10000;
 					int32_t _keep_ms = 1500;
+					// Hardware module selection, e.g. "nv:0", "nv:1" (same format as <Video><Modules>)
+					ov::String _modules;
 
 				public:
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetEngine, _engine)
@@ -49,6 +51,7 @@ namespace cfg
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetStepMs, _step_ms)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetLengthMs, _length_ms)
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetKeepMs, _keep_ms)
+						CFG_DECLARE_CONST_REF_GETTER_OF(GetModules, _modules)
 
 				protected:
 					void MakeList() override
@@ -62,6 +65,7 @@ namespace cfg
 						Register<Optional>("StepMs", &_step_ms);
 						Register<Optional>("LengthMs", &_length_ms);
 						Register<Optional>("KeepMs", &_keep_ms);
+						Register<Optional>("Modules", &_modules);
 					}
 				};
 			}  // namespace oprf

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/stt_rendition.h
@@ -1,0 +1,57 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+namespace cfg
+{
+	namespace vhost
+	{
+		namespace app
+		{
+			namespace oprf
+			{
+				struct SttRendition : public Item
+				{
+				protected:
+					// STT engine to use (e.g. "whisper")
+					ov::String _engine;
+					// Label of the subtitle rendition (must match a <Subtitle><Rendition><Label>)
+					ov::String _output_subtitle_label;
+					// Absolute or config-relative path to the model file
+					ov::String _model;
+					// Index of the input audio track to transcribe (0 = first audio track)
+					int _input_audio_index = 0;
+					// Input language for transcription ("auto" enables auto-detection)
+					ov::String _source_language = "auto";
+					// Translate output to English (whisper only)
+					bool _translation = false;
+
+				public:
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetEngine, _engine)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetOutputSubtitleLabel, _output_subtitle_label)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetModel, _model)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetInputAudioIndex, _input_audio_index)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetSourceLanguage, _source_language)
+					CFG_DECLARE_CONST_REF_GETTER_OF(GetTranslation, _translation)
+
+				protected:
+					void MakeList() override
+					{
+						Register("Engine", &_engine);
+						Register("OutputSubtitleLabel", &_output_subtitle_label);
+						Register("Model", &_model);
+						Register<Optional>("InputAudioIndex", &_input_audio_index);
+						Register<Optional>("SourceLanguage", &_source_language);
+						Register<Optional>("Translation", &_translation);
+					}
+				};
+			}  // namespace oprf
+		}  // namespace app
+	}  // namespace vhost
+}  // namespace cfg

--- a/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
@@ -53,7 +53,17 @@ namespace cfg
 						Register("Language", &_language);
 						Register<Optional>("AutoSelect", &_auto_select);
 						Register<Optional>("Forced", &_forced);
-						Register<Optional>("Transcription", &_transcription);
+						Register<Optional>("Transcription", &_transcription, nullptr,
+							[=]() -> std::shared_ptr<ConfigError> {
+								if (_transcription.IsParsed())
+								{
+									return CreateConfigErrorPtr(
+										"<Subtitle><Rendition><Transcription> is no longer supported. "
+										"Please use <OutputProfiles><MediaOptions><STT><Rendition> instead. "
+										"Refer to the OvenMediaEngine manual for details.");
+								}
+								return nullptr;
+							});
 					}
 				};
 			}  // namespace oprf

--- a/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
@@ -57,10 +57,10 @@ namespace cfg
 							[=]() -> std::shared_ptr<ConfigError> {
 								if (_transcription.IsParsed())
 								{
-									return CreateConfigErrorPtr(
-										"<Subtitle><Rendition><Transcription> is no longer supported. "
-										"Please use <OutputProfiles><MediaOptions><STT><Rendition> instead. "
-										"Refer to the OvenMediaEngine manual for details.");
+								logtw("<Subtitle><Rendition><Transcription> is no longer supported. "
+									"Please use <OutputProfiles><MediaOptions><STT><Rendition> instead. "
+									"Refer to the OvenMediaEngine manual for details. "
+									"STT will be disabled for this rendition.");
 								}
 								return nullptr;
 							});

--- a/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
+++ b/src/projects/config/items/virtual_hosts/applications/subtitle/subtitle_rendition.h
@@ -57,7 +57,7 @@ namespace cfg
 							[=]() -> std::shared_ptr<ConfigError> {
 								if (_transcription.IsParsed())
 								{
-								logtw("<Subtitle><Rendition><Transcription> is no longer supported. "
+								logw("Config", "<Subtitle><Rendition><Transcription> is no longer supported. "
 									"Please use <OutputProfiles><MediaOptions><STT><Rendition> instead. "
 									"Refer to the OvenMediaEngine manual for details. "
 									"STT will be disabled for this rendition.");

--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -576,6 +576,10 @@ bool MediaRouteApplication::OnStreamUpdated(const std::shared_ptr<MediaRouterApp
 		if (stream)
 		{
 			//stream->Flush();
+			if (stream->IsStreamPrepared() == false && stream->IsStreamReady() == true)
+			{
+				NotifyStreamPrepared(stream);
+			}
 		}
 	}
 	else

--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -339,7 +339,7 @@ bool MediaRouteApplication::OnStreamCreated(const std::shared_ptr<MediaRouterApp
 		return false;
 	}
 
-	logti("[%s/%s(%u)] Trying to create a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId());
+	logti("[%s/%s(%u)] %sTrying to create a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "");
 
 	auto connector_type = app_conn->GetConnectorType();
 	auto representation_type = stream_info->GetRepresentationType();
@@ -455,7 +455,12 @@ bool MediaRouteApplication::NotifyStreamCreate(const std::shared_ptr<info::Strea
 	auto observers = _observers; // Avoid deadlock
 	lock.unlock();
 
-	logti("[%s/%s(%u)] Stream has been created", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId());
+	logti("[%s/%s(%u)] %sStream has been created", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "");
+
+	if (stream_info->IsInternal())
+	{
+		return true;
+	}
 
 	auto representation_type = stream_info->GetRepresentationType();
 
@@ -494,7 +499,13 @@ bool MediaRouteApplication::NotifyStreamPrepared(std::shared_ptr<MediaRouteStrea
 	auto observers = _observers;  // Avoid deadlock
 	lock.unlock();
 
-	logti("[%s/%s(%u)] Stream has been prepared %s", _application_info.GetVHostAppName().CStr(), stream->GetStream()->GetName().CStr(), stream->GetStream()->GetId(), stream->GetStream()->GetInfoString().CStr());
+	logti("[%s/%s(%u)] %sStream has been prepared %s", _application_info.GetVHostAppName().CStr(), stream->GetStream()->GetName().CStr(), stream->GetStream()->GetId(), stream->GetStream()->IsInternal() ? "[Internal] " : "", stream->GetStream()->GetInfoString().CStr());
+
+	if (stream->GetStream()->IsInternal())
+	{
+		stream->OnStreamPrepared(true);
+		return true;
+	}
 
 	for (auto observer : observers)
 	{
@@ -534,7 +545,7 @@ bool MediaRouteApplication::NotifyStreamPrepared(std::shared_ptr<MediaRouteStrea
 
 bool MediaRouteApplication::OnStreamUpdated(const std::shared_ptr<MediaRouterApplicationConnector> &app_conn, const std::shared_ptr<info::Stream> &stream_info)
 {
-	logti(" [%s/%s(%u)] Trying to update a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId());
+	logti(" [%s/%s(%u)] %sTrying to update a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "");
 
 	if (!app_conn || !stream_info)
 	{
@@ -583,7 +594,7 @@ bool MediaRouteApplication::OnStreamUpdated(const std::shared_ptr<MediaRouterApp
 
 bool MediaRouteApplication::OnStreamDeleted(const std::shared_ptr<MediaRouterApplicationConnector> &app_conn, const std::shared_ptr<info::Stream> &stream_info)
 {
-	logti("[%s/%s(%u)] Trying to delete a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId());
+	logti("[%s/%s(%u)] %sTrying to delete a stream", _application_info.GetVHostAppName().CStr(), stream_info->GetName().CStr(), stream_info->GetId(), stream_info->IsInternal() ? "[Internal] " : "");
 
 	if (!app_conn || !stream_info)
 	{
@@ -663,6 +674,11 @@ bool MediaRouteApplication::NotifyStreamDeleted(const std::shared_ptr<info::Stre
 
 	auto representation_type = stream_info->GetRepresentationType();
 
+	if (stream_info->IsInternal())
+	{
+		return true;
+	}
+
 	for (auto it = observers.begin(); it != observers.end(); ++it)
 	{
 		auto observer = *it;
@@ -708,6 +724,11 @@ bool MediaRouteApplication::NotifyStreamUpdated(const std::shared_ptr<info::Stre
 	lock_guard.unlock();
 
 	auto representation_type = stream_info->GetRepresentationType();
+
+	if (stream_info->IsInternal())
+	{
+		return true;
+	}
 
 	for (auto it = observers.begin(); it != observers.end(); ++it)
 	{

--- a/src/projects/modules/json_serdes/stream.cpp
+++ b/src/projects/modules/json_serdes/stream.cpp
@@ -23,6 +23,15 @@ namespace serdes
 		SetInt(object, "den", timebase.GetDen());
 	}
 
+	static void SetCodecStatus(Json::Value &parent_object, const char *key, const std::shared_ptr<const MediaTrack> &track, Optional optional)
+	{
+		auto status_str = cmn::GetCodecStatusString(track->GetCodecStatus());
+		if (status_str != nullptr)
+		{
+			SetString(parent_object, key, status_str, optional);
+		}
+	}
+
 	static void SetVideoTrack(Json::Value &parent_object, const char *key, const std::shared_ptr<const MediaTrack> &track, Optional optional)
 	{
 		CONVERTER_RETURN_IF(track == nullptr, Json::objectValue);
@@ -30,6 +39,13 @@ namespace serdes
 		SetBool(object, "bypass", track->IsBypass());
 
 		SetString(object, "codec", cmn::GetCodecIdString(track->GetCodecId()), Optional::False);
+		if (!track->IsBypass())
+		{
+			SetString(object, "codecModule", cmn::GetCodecModuleIdString(track->GetCodecModuleId()), Optional::True);
+		}
+		SetCodecStatus(object, "codecStatus", track, Optional::True);
+		SetString(object, "language", track->GetLanguage(), Optional::True);
+		SetString(object, "characteristics", track->GetCharacteristics(), Optional::True);
 		auto resolution = track->GetResolution();
 		auto max_resolution = track->GetMaxResolution();
 		SetInt(object, "width", resolution.width);
@@ -69,6 +85,13 @@ namespace serdes
 		SetBool(object, "bypass", track->IsBypass());
 
 		SetString(object, "codec", cmn::GetCodecIdString(track->GetCodecId()), Optional::False);
+		if (!track->IsBypass())
+		{
+			SetString(object, "codecModule", cmn::GetCodecModuleIdString(track->GetCodecModuleId()), Optional::True);
+		}
+		SetCodecStatus(object, "codecStatus", track, Optional::True);
+		SetString(object, "language", track->GetLanguage(), Optional::True);
+		SetString(object, "characteristics", track->GetCharacteristics(), Optional::True);
 		SetInt(object, "samplerate", track->GetSampleRate());
 		// SetAudioChannel(object, "channel", track->GetChannel(), Optional::False);
 		SetInt(object, "channel", track->GetChannel().GetCounts());
@@ -96,11 +119,40 @@ namespace serdes
 				SetAudioTrack(object, "audio", track, Optional::False);
 				break;
 
-			case cmn::MediaType::Unknown:
-				[[fallthrough]];
 			case cmn::MediaType::Data:
-				[[fallthrough]];
+			{
+				Json::Value data_object(Json::objectValue);
+				SetString(data_object, "codec", cmn::GetCodecIdString(track->GetCodecId()), Optional::False);
+				object["data"] = data_object;
+				break;
+			}
 			case cmn::MediaType::Subtitle:
+			{
+				Json::Value subtitle_object(Json::objectValue);
+				// Common subtitle metadata
+				SetString(subtitle_object, "codec", cmn::GetCodecIdString(track->GetCodecId()), Optional::False);
+				SetCodecStatus(subtitle_object, "codecStatus", track, Optional::True);
+				SetString(subtitle_object, "language", track->GetLanguage(), Optional::True);
+				SetString(subtitle_object, "characteristics", track->GetCharacteristics(), Optional::True);
+				SetBool(subtitle_object, "autoSelect", track->IsAutoSelect());
+				SetBool(subtitle_object, "default", track->IsDefault());
+				SetBool(subtitle_object, "forced", track->IsForced());
+				SetTimebase(subtitle_object, "timebase", track->GetTimeBase(), Optional::True);
+				// STT-specific metadata (Whisper)
+				if (track->GetCodecId() == cmn::MediaCodecId::Whisper)
+				{
+					Json::Value stt_object(Json::objectValue);
+					SetString(stt_object, "engine", track->GetEngine(), Optional::True);
+					SetString(stt_object, "model", track->GetModel(), Optional::True);
+					SetString(stt_object, "sourceLanguage", track->GetSourceLanguage(), Optional::True);
+					SetBool(stt_object, "translation", track->ShouldTranslate());
+					SetString(stt_object, "outputLabel", track->GetOutputTrackLabel(), Optional::True);
+					subtitle_object["stt"] = stt_object;
+				}
+				object["subtitle"] = subtitle_object;
+				break;
+			}
+			case cmn::MediaType::Unknown:
 				[[fallthrough]];
 			case cmn::MediaType::Attachment:
 				[[fallthrough]];

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -751,6 +751,19 @@ namespace ocst
 		return nullptr;
 	}
 
+	std::shared_ptr<TranscoderModuleInterface> Orchestrator::GetTranscoderModule()
+	{
+		auto module_list = GetModuleList();
+		for (auto &module : module_list)
+		{
+			if (module.GetType() == ModuleType::Transcoder)
+			{
+				return module.GetModuleAs<TranscoderModuleInterface>();
+			}
+		}
+		return nullptr;
+	}
+
 	std::shared_ptr<pvd::Stream> Orchestrator::GetProviderStream(const std::shared_ptr<const info::Stream> &stream_info)
 	{
 		// Get ProviderType from SourceType

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -217,6 +217,8 @@ namespace ocst
 		std::shared_ptr<pvd::Provider> GetProviderFromType(const ProviderType type);
 		/// Find Publisher from PublisherType
 		std::shared_ptr<pub::Publisher> GetPublisherFromType(const PublisherType type);
+		/// Get the Transcoder module
+		std::shared_ptr<TranscoderModuleInterface> GetTranscoderModule();
 
 		/// Find Provider Stream from StreamInfo
 		std::shared_ptr<pvd::Stream> GetProviderStream(const std::shared_ptr<const info::Stream> &stream_info);

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -126,7 +126,7 @@ void EncoderWhisper::CodecThread()
 	ov::logger::ThreadHelper thread_helper;
 
 	// Initialize the codec and notify the main thread.
-	if(_codec_init_event.Submit(InitCodec()) == false)
+	if (_codec_init_event.Submit(InitCodecInteral()) == false)
 	{
 		return;
 	}

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -115,8 +115,17 @@ bool EncoderWhisper::InitCodec()
 		return false;
 	}
 
+	// Resolve the CUDA device index for this encoder instance.
+	// _track->GetCodecDeviceId() returns the OME device index (from <Modules>nv:N</Modules>).
+	// TranscodeGPU maps it to the actual CUDA device index.
+	int32_t cuda_id = TranscodeGPU::GetInstance()->GetExternalDeviceId(cmn::MediaCodecModuleId::NVENC, _track->GetCodecDeviceId());
+	if (cuda_id < 0)
+	{
+		cuda_id = 0;
+	}
+
 	// Acquire the shared model context from the registry.
-	_whisper_ctx = WhisperModelRegistry::GetInstance()->GetModelContext(_track->GetModel());
+	_whisper_ctx = WhisperModelRegistry::GetInstance()->GetModelContext(_track->GetModel(), cuda_id);
 	if (_whisper_ctx == nullptr)
 	{
 		// Error already logged by the registry.
@@ -125,7 +134,7 @@ bool EncoderWhisper::InitCodec()
 
 	// Create a per-instance inference state via the registry.
 	// The registry serializes allocation and pre-checks GPU memory to prevent ggml crash.
-	_whisper_state = WhisperModelRegistry::GetInstance()->NewState(_track->GetModel());
+	_whisper_state = WhisperModelRegistry::GetInstance()->NewState(_track->GetModel(), cuda_id);
 	if (_whisper_state == nullptr)
 	{
 		logte("Failed to create whisper state. stream=%s, track_id=%d, label=%s, model=%s",

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -1,22 +1,18 @@
 //==============================================================================
 //
-//  Transcode
+//  Whisper encoder for speech recognition and subtitle generation.
 //
-//  Created by Kwon Keuk Han
-//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//  Created by Getroot
+//  Copyright (c) 2025 AirenSoft. All rights reserved.
 //
 //==============================================================================
-#include <sys/stat.h>
-
-#ifdef HWACCELS_NVIDIA_ENABLED
-#include <cuda_runtime.h>
-#endif
 #include <orchestrator/orchestrator.h>
 #include <base/modules/data_format/webvtt/webvtt_frame.h>
 #include <base/event/command/commands.h>
 
 #include "encoder_whisper.h"
 #include "../../transcoder_private.h"
+#include "../../transcoder_whisper_model_registry.h"
 
 EncoderWhisper::EncoderWhisper(const info::Stream &stream_info)
 	: TranscodeEncoder(stream_info)
@@ -100,85 +96,27 @@ bool EncoderWhisper::InitCodec()
 		return false;
 	}
 
-	struct whisper_context_params cparams = whisper_context_default_params();
-	cparams.flash_attn = true;
-
-	// libcublas lazy-initializes its global state (heap buffers, pthread_rwlock_t)
-	// in two phases without thread safety.  Serialise both phases under a static
-	// mutex so concurrent EncoderWhisper instances never race inside libcublas.
-	// Phase 1: whisper_init_from_file_with_params() → cublasCreate().
-	// Phase 2: first GEMM call → pthread_rwlock_init. whisper_pcm_to_mel() does
-	//          NOT reach the GEMM path, so a full whisper_full() warmup is needed.
-	{
-		static std::mutex _cublas_init_mutex;
-		std::lock_guard<std::mutex> lock(_cublas_init_mutex);
-
-		// Determine whether there is enough free GPU memory BEFORE calling
-		// whisper_init_from_file_with_params().  If CUDA OOM is hit inside that
-		// function, ggml may crash (SIGSEGV) instead of returning an error code, so we must avoid it entirely.
-		// Pre-flight check: model file size * 1.25 (weights + compute graph overhead)
-		// must fit in available CUDA free memory.
-		bool use_gpu = false;
-		{
-#ifdef HWACCELS_NVIDIA_ENABLED
-			struct stat model_stat{};
-			size_t model_file_bytes = 0;
-			if (::stat(_track->GetModel().CStr(), &model_stat) == 0)
-			{
-				model_file_bytes = static_cast<size_t>(model_stat.st_size);
-			}
-
-			// ggml allocates weights + kv cache + compute buffers.
-			// Observed ratio for ggml-small: ~729 MB from a 466 MB file (1.57×).
-			// 2× the file size is a safe upper bound across all whisper model sizes.
-			size_t required_bytes = model_file_bytes * 2;
-			size_t free_mem = 0, total_mem = 0;
-			if (cudaMemGetInfo(&free_mem, &total_mem) == cudaSuccess)
-			{
-				if (free_mem >= required_bytes)
-				{
-					use_gpu = true;
-					logti("GPU init: free=%.1f MiB, required=%.1f MiB → using GPU",
-						static_cast<double>(free_mem) / (1024.0 * 1024.0),
-						static_cast<double>(required_bytes) / (1024.0 * 1024.0));
-				}
-				else
-				{
-					logtw("Not enough GPU memory for Whisper (free=%.1f MiB, required≈%.1f MiB). Falling back to CPU.",
-						static_cast<double>(free_mem) / (1024.0 * 1024.0),
-						static_cast<double>(required_bytes) / (1024.0 * 1024.0));
-				}
-			}
-			else
-			{
-				logtw("cudaMemGetInfo failed. Falling back to CPU for Whisper.");
-			}
-#endif
-		}
-
-		cparams.use_gpu = use_gpu;
-		_whisper_ctx = whisper_init_from_file_with_params(_track->GetModel().CStr(), cparams);
-
-		if (_whisper_ctx != nullptr)
-		{
-			std::vector<float> warmup(WHISPER_SAMPLE_RATE, 0.0f);  // 1 s of silence
-			whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
-			wparams.print_progress   = false;
-			wparams.print_special    = false;
-			wparams.print_realtime   = false;
-			wparams.print_timestamps = false;
-			wparams.n_threads        = 1;
-			wparams.language         = "en";
-			wparams.no_context       = true;
-			whisper_full(_whisper_ctx, wparams, warmup.data(), static_cast<int>(warmup.size()));
-		}
-	}
-
+	// Acquire the shared model context from the registry.
+	_whisper_ctx = WhisperModelRegistry::GetInstance()->GetModelContext(_track->GetModel());
 	if (_whisper_ctx == nullptr)
 	{
-		logte("Whisper model could not be loaded. model=%s", _track->GetModel().CStr());
+		// Error already logged by the registry.
 		return false;
 	}
+
+	// Create a per-instance inference state via the registry.
+	// The registry serializes allocation and pre-checks GPU memory to prevent ggml crash.
+	_whisper_state = WhisperModelRegistry::GetInstance()->NewState(_track->GetModel());
+	if (_whisper_state == nullptr)
+	{
+		logte("Failed to create whisper state. stream=%s, track_id=%d, label=%s, model=%s",
+			  _stream_info.GetName().CStr(), _track->GetId(), _output_track_label.CStr(), _track->GetModel().CStr());
+		_whisper_ctx.reset();
+		return false;
+	}
+
+	logti("Whisper state created. stream=%s, track_id=%d, label=%s, model=%s",
+		  _stream_info.GetName().CStr(), _track->GetId(), _output_track_label.CStr(), _track->GetModel().CStr());
 
 	return true;
 }
@@ -308,14 +246,14 @@ void EncoderWhisper::CodecThread()
 		// Auto detect language if needed.
 		if (_source_language == "auto" && _translate == false)
 		{
-			if (whisper_pcm_to_mel(_whisper_ctx, pcmf32_buffer.data(), pcmf32_buffer.size(), 4) != 0)
+			if (whisper_pcm_to_mel_with_state(_whisper_ctx.get(), _whisper_state, pcmf32_buffer.data(), pcmf32_buffer.size(), 4) != 0)
 			{
 				logte("Failed to process audio samples for language detection with Whisper");
 				continue;
 			}
 
 			std::vector<float> probs(whisper_lang_max_id() + 1, 0.0f);
-			const auto lang_id = whisper_lang_auto_detect(_whisper_ctx, 0, 4, probs.data());
+			const auto lang_id = whisper_lang_auto_detect_with_state(_whisper_ctx.get(), _whisper_state, 0, 4, probs.data());
 			if (lang_id < 0)
 			{
 				logte("Failed to detect language with Whisper");
@@ -369,7 +307,7 @@ void EncoderWhisper::CodecThread()
 		logtt("Starting Whisper processing with %d samples", static_cast<int>(pcmf32_buffer.size()));
 		logtt("Audio buffer time range for Whisper: %" PRId64 " ~ %" PRId64 " (last_commit_end_cs=%" PRId64 ")",
 			buffer_start_cs, buffer_end_cs, last_commit_end_cs);
-		if (whisper_full(_whisper_ctx, wparams, pcmf32_buffer.data(), pcmf32_buffer.size()) != 0)
+		if (whisper_full_with_state(_whisper_ctx.get(), _whisper_state, wparams, pcmf32_buffer.data(), pcmf32_buffer.size()) != 0)
 		{
 			logte("Failed to process audio samples with Whisper");
 			continue;
@@ -378,10 +316,10 @@ void EncoderWhisper::CodecThread()
 
 		ov::String result_text;
 		
-		const int n_segments = whisper_full_n_segments(_whisper_ctx);
+		const int n_segments = whisper_full_n_segments_from_state(_whisper_state);
 		for (int i = 0; i < n_segments; ++i) 
 		{
-			const char *text = whisper_full_get_segment_text(_whisper_ctx, i);
+			const char *text = whisper_full_get_segment_text_from_state(_whisper_state, i);
 
 			// How to output subtitles without overlapping : but the quality is low - commented out for now.
 			// int64_t t0 = whisper_full_get_segment_t0(_whisper_ctx, i);
@@ -458,23 +396,24 @@ void EncoderWhisper::CodecThread()
 			pcmf32_buffer_old = std::vector<float>(pcmf32_buffer.end() - _n_samples_keep, pcmf32_buffer.end());
 			prompt_tokens.clear();
 
-			const int n_segments = whisper_full_n_segments(_whisper_ctx);
+			const int n_segments = whisper_full_n_segments_from_state(_whisper_state);
 			for (int i = 0; i < n_segments; ++i)
 			{
-				const int nt = whisper_full_n_tokens(_whisper_ctx, i);
+				const int nt = whisper_full_n_tokens_from_state(_whisper_state, i);
 				for (int it = 0; it < nt; ++it)
 				{
-					prompt_tokens.push_back(whisper_full_get_token_id(_whisper_ctx, i, it));
+					prompt_tokens.push_back(whisper_full_get_token_id_from_state(_whisper_state, i, it));
 				}
 			}
 		}
 	}
 
-	if (_whisper_ctx)
+	if (_whisper_state != nullptr)
 	{
-		whisper_free(_whisper_ctx);
-		_whisper_ctx = nullptr;
+		WhisperModelRegistry::GetInstance()->DeleteState(_whisper_state);
+		_whisper_state = nullptr;
 	}
+	_whisper_ctx.reset();
 }
 
 bool EncoderWhisper::SendVttToProvider(const ov::String &text)

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -13,6 +13,7 @@
 #include "encoder_whisper.h"
 #include "../../transcoder_private.h"
 #include "../../transcoder_whisper_model_registry.h"
+#include "../../transcoder_gpu.h"
 
 EncoderWhisper::EncoderWhisper(const info::Stream &stream_info)
 	: TranscodeEncoder(stream_info)
@@ -30,6 +31,17 @@ bool EncoderWhisper::SetCodecParams()
 
 bool EncoderWhisper::Configure(std::shared_ptr<MediaTrack> context)
 {
+#ifdef HWACCELS_NVIDIA_ENABLED
+	if (TranscodeGPU::GetInstance()->GetDeviceCount(cmn::MediaCodecModuleId::NVENC) == 0)
+	{
+		logtw("Whisper STT requires an NVIDIA GPU, but no NVIDIA device is available. STT track will be disabled.");
+		return false;
+	}
+#else
+	logtw("Whisper STT requires an NVIDIA GPU, but this build does not include NVIDIA support. STT track will be disabled.");
+	return false;
+#endif
+
 	auto parent_stream_info = _stream_info.GetLinkedInputStream();
 	if (parent_stream_info == nullptr)
 	{

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -68,6 +68,9 @@ bool EncoderWhisper::Configure(std::shared_ptr<MediaTrack> context)
 	_translate = context->ShouldTranslate();
 	_output_track_label = context->GetOutputTrackLabel();
 
+	// Initialize muted state from config (can be changed at runtime via API).
+	_audio_muted.store(!context->IsSttEnabled(), std::memory_order_relaxed);
+
 	if (TranscodeEncoder::Configure(context, _n_samples_step) == false)
 	{
 		return false;
@@ -176,6 +179,12 @@ void EncoderWhisper::CodecThread()
 		{
 			auto obj = _input_buffer.Dequeue();
 			if (obj.has_value() == false)
+			{
+				continue;
+			}
+
+			// When muted, drop the frame without inference to save GPU resources.
+			if (_audio_muted.load(std::memory_order_relaxed))
 			{
 				continue;
 			}

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.cpp
@@ -56,6 +56,10 @@ bool EncoderWhisper::Configure(std::shared_ptr<MediaTrack> context)
 		return false;
 	}
 
+	_step_ms = context->GetStepMs();
+	_length_ms = context->GetLengthMs();
+	_keep_ms = context->GetKeepMs();
+
 	_n_samples_step = (static_cast<double>(_step_ms) / 1000.0) * WHISPER_SAMPLE_RATE;
 	_n_samples_length = (static_cast<double>(_length_ms) / 1000.0) * WHISPER_SAMPLE_RATE;
 	_n_samples_keep = (static_cast<double>(_keep_ms) / 1000.0) * WHISPER_SAMPLE_RATE;

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.h
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.h
@@ -65,11 +65,27 @@ public:
 	bool InitCodec() override;
 	void CodecThread() override;
 
+	void Pause()  override { _audio_muted.store(true,  std::memory_order_relaxed); }
+	void Resume() override { _audio_muted.store(false, std::memory_order_relaxed); }
+	bool IsPaused() const override { return _audio_muted.load(std::memory_order_relaxed); }
+
+	EncoderInfo GetInfo() const override
+	{
+		EncoderInfo info = TranscodeEncoder::GetInfo();
+		info.properties["label"]       = _output_track_label;
+		info.properties["model"]       = _track ? _track->GetModel() : "";
+		info.properties["language"]    = _source_language;
+		info.properties["translation"] = _translate ? "true" : "false";
+		return info;
+	}
+
 private:
 	bool SetCodecParams() override;	
 	ov::String ToTimeString(int64_t ten_ms);
 	bool SendVttToProvider(const ov::String &text);
 	bool SendLangDetectionEvent(const ov::String &label, const ov::String &language);
+
+	std::atomic<bool> _audio_muted{false};
 
 	int32_t _step_ms = 2000;
 	int32_t _length_ms = 10000;

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.h
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.h
@@ -1,14 +1,17 @@
 //==============================================================================
 //
-//  Machine 
+//  Whisper encoder for speech recognition and subtitle generation.
 //
-//  Created by Kwon Keuk Han
-//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//  Created by Getroot
+//  Copyright (c) 2025 AirenSoft. All rights reserved.
 //
 //==============================================================================
 #pragma once
 
 #include <whisper.h>
+
+#include <memory>
+
 #include <base/provider/stream.h>
 #include "../../transcoder_encoder.h"
 
@@ -66,11 +69,14 @@ private:
 	int32_t _step_ms = 2000;
 	int32_t _length_ms = 8000;
 	int32_t _keep_ms = 100;
-	struct whisper_context * _whisper_ctx = nullptr;
+        // Shared model weights: owned by WhisperModelRegistry, reference-counted here.
+        std::shared_ptr<whisper_context> _whisper_ctx;
+        // Per-instance inference state: isolates all mutable buffers from other instances.
+        struct whisper_state * _whisper_state = nullptr;
 
-	int32_t _n_samples_step = 0;
-	int32_t _n_samples_length = 0;
-	int32_t _n_samples_keep = 0;
+        int32_t _n_samples_step = 0;
+        int32_t _n_samples_length = 0;
+        int32_t _n_samples_keep = 0;
 
 	ov::String _source_language = "auto";
 	bool _translate = false;

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.h
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.h
@@ -72,8 +72,8 @@ private:
 	bool SendLangDetectionEvent(const ov::String &label, const ov::String &language);
 
 	int32_t _step_ms = 2000;
-	int32_t _length_ms = 8000;
-	int32_t _keep_ms = 100;
+	int32_t _length_ms = 10000;
+	int32_t _keep_ms = 1500;
         // Shared model weights: owned by WhisperModelRegistry, reference-counted here.
         std::shared_ptr<whisper_context> _whisper_ctx;
         // Per-instance inference state: isolates all mutable buffers from other instances.

--- a/src/projects/transcoder/codec/encoder/encoder_whisper.h
+++ b/src/projects/transcoder/codec/encoder/encoder_whisper.h
@@ -55,6 +55,11 @@ public:
 	{
 		return cmn::BitstreamFormat::WebVTT;
 	}
+
+	bool IsInputOnly() const noexcept override
+	{
+		return true;
+	}
 	
 	bool Configure(std::shared_ptr<MediaTrack> context) override;
 	bool InitCodec() override;

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -46,12 +46,31 @@ bool Transcoder::Start()
 	{
 		auto &whisper_cfg = cfg::ConfigManager::GetInstance()->GetServer()->GetModules().GetWhisper();
 		const auto &config_path = cfg::ConfigManager::GetInstance()->GetConfigPath();
-		std::vector<ov::String> resolved_paths;
-		for (const auto &p : whisper_cfg.GetPreloadModels())
+
+		std::vector<std::pair<ov::String, std::vector<int32_t>>> preload_models;
+		for (const auto &entry : whisper_cfg.GetPreloadModels())
 		{
-			resolved_paths.push_back(ov::GetFilePath(p, config_path));
+			ov::String resolved = ov::GetFilePath(entry.GetPath(), config_path);
+
+			// Parse <Devices>: "" or "all" → empty list (= all GPUs).
+			// Otherwise comma-separated integers, e.g. "0,1" or "2".
+			std::vector<int32_t> device_ids;
+			const ov::String &devices_str = entry.GetDevices();
+			if (!devices_str.IsEmpty() && devices_str.LowerCaseString() != "all")
+			{
+				for (const auto &token : devices_str.Split(","))
+				{
+					ov::String trimmed = token.Trim();
+					if (!trimmed.IsEmpty())
+					{
+						device_ids.push_back(ov::Converter::ToInt32(trimmed));
+					}
+				}
+			}
+
+			preload_models.emplace_back(std::move(resolved), std::move(device_ids));
 		}
-		WhisperModelRegistry::GetInstance()->Preload(resolved_paths);
+		WhisperModelRegistry::GetInstance()->Preload(preload_models);
 	}
 
 	return true;

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -52,11 +52,17 @@ bool Transcoder::Start()
 		{
 			ov::String resolved = ov::GetFilePath(entry.GetPath(), config_path);
 
-			// Parse <Devices>: "" or "all" → empty list (= all GPUs).
-			// Otherwise comma-separated integers, e.g. "0,1" or "2".
+			// Parse <Devices>:
+			// - Omitted/empty → device 0 (default)
+			// - "all" → empty list passed to Preload (= load on every available GPU)
+			// - "0,1" etc → specific device indices
 			std::vector<int32_t> device_ids;
 			const ov::String &devices_str = entry.GetDevices();
-			if (!devices_str.IsEmpty() && devices_str.LowerCaseString() != "all")
+			if (devices_str.IsEmpty())
+			{
+				device_ids.push_back(0);
+			}
+			else if (devices_str.LowerCaseString() != "all")
 			{
 				for (const auto &token : devices_str.Split(","))
 				{
@@ -67,6 +73,7 @@ bool Transcoder::Start()
 					}
 				}
 			}
+			// "all" → device_ids remains empty → Preload loads on all available GPUs
 
 			preload_models.emplace_back(std::move(resolved), std::move(device_ids));
 		}

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -16,6 +16,7 @@
 #include "config/config_manager.h"
 #include "transcoder.h"
 #include "transcoder_gpu.h"
+#include "transcoder_whisper_model_registry.h"
 #include "transcoder_private.h"
 
 std::shared_ptr<Transcoder> Transcoder::Create(std::shared_ptr<MediaRouterInterface> router)
@@ -42,6 +43,17 @@ bool Transcoder::Start()
 
 	TranscodeGPU::GetInstance()->Initialize();
 
+	{
+		auto &whisper_cfg = cfg::ConfigManager::GetInstance()->GetServer()->GetModules().GetWhisper();
+		const auto &config_path = cfg::ConfigManager::GetInstance()->GetConfigPath();
+		std::vector<ov::String> resolved_paths;
+		for (const auto &p : whisper_cfg.GetPreloadModels())
+		{
+			resolved_paths.push_back(ov::GetFilePath(p, config_path));
+		}
+		WhisperModelRegistry::GetInstance()->Preload(resolved_paths);
+	}
+
 	return true;
 }
 
@@ -49,6 +61,7 @@ bool Transcoder::Stop()
 {
 	logtt("Transcoder has been stopped");
 
+	WhisperModelRegistry::GetInstance()->Uninitialize();
 	TranscodeGPU::GetInstance()->Uninitialize();
 
 	return true;

--- a/src/projects/transcoder/transcoder.cpp
+++ b/src/projects/transcoder/transcoder.cpp
@@ -171,3 +171,55 @@ std::shared_ptr<TranscodeApplication> Transcoder::GetApplicationById(info::appli
 
 	return obj->second;
 }
+
+bool Transcoder::PauseEncoders(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> lock(_transcode_apps_mutex);
+	for (auto &[id, app] : _transcode_apps)
+	{
+		if (app && app->GetApplicationInfo().GetVHostAppName() == vhost_app_name)
+		{
+			return app->PauseEncoders(stream_name, codec_id);
+		}
+	}
+	return false;
+}
+
+bool Transcoder::ResumeEncoders(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> lock(_transcode_apps_mutex);
+	for (auto &[id, app] : _transcode_apps)
+	{
+		if (app && app->GetApplicationInfo().GetVHostAppName() == vhost_app_name)
+		{
+			return app->ResumeEncoders(stream_name, codec_id);
+		}
+	}
+	return false;
+}
+
+bool Transcoder::IsEncoderPaused(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> lock(_transcode_apps_mutex);
+	for (auto &[id, app] : _transcode_apps)
+	{
+		if (app && app->GetApplicationInfo().GetVHostAppName() == vhost_app_name)
+		{
+			return app->IsEncoderPaused(stream_name, codec_id);
+		}
+	}
+	return false;
+}
+
+std::vector<TranscodeEncoder::EncoderInfo> Transcoder::GetEncoderInfoList(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> lock(_transcode_apps_mutex);
+	for (auto &[id, app] : _transcode_apps)
+	{
+		if (app && app->GetApplicationInfo().GetVHostAppName() == vhost_app_name)
+		{
+			return app->GetEncoderInfoList(stream_name, codec_id);
+		}
+	}
+	return {};
+}

--- a/src/projects/transcoder/transcoder.h
+++ b/src/projects/transcoder/transcoder.h
@@ -45,6 +45,12 @@ public:
 	bool OnCreateApplication(const info::Application &app_info) override;
 	bool OnDeleteApplication(const info::Application &app_info) override;
 
+	// Encoder pause/resume by codec
+	bool PauseEncoders(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	bool ResumeEncoders(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	bool IsEncoderPaused(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	std::vector<TranscodeEncoder::EncoderInfo> GetEncoderInfoList(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, cmn::MediaCodecId codec_id);
+
 private:
 	// Application Name으로 RouteApplication을 찾음
 	std::shared_ptr<TranscodeApplication> GetApplicationById(info::application_id_t application_id);

--- a/src/projects/transcoder/transcoder_application.cpp
+++ b/src/projects/transcoder/transcoder_application.cpp
@@ -163,6 +163,58 @@ std::shared_ptr<TranscoderStream> TranscodeApplication::GetStream(const std::sha
 	return stream;
 }
 
+bool TranscodeApplication::PauseEncoders(const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> read_lock(_mutex);
+	for (auto &[id, stream] : _streams)
+	{
+		if (stream && stream->GetInputStreamName() == stream_name)
+		{
+			return stream->PauseEncoders(codec_id);
+		}
+	}
+	return false;
+}
+
+bool TranscodeApplication::ResumeEncoders(const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> read_lock(_mutex);
+	for (auto &[id, stream] : _streams)
+	{
+		if (stream && stream->GetInputStreamName() == stream_name)
+		{
+			return stream->ResumeEncoders(codec_id);
+		}
+	}
+	return false;
+}
+
+bool TranscodeApplication::IsEncoderPaused(const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> read_lock(_mutex);
+	for (auto &[id, stream] : _streams)
+	{
+		if (stream && stream->GetInputStreamName() == stream_name)
+		{
+			return stream->IsEncoderPaused(codec_id);
+		}
+	}
+	return false;
+}
+
+std::vector<TranscodeEncoder::EncoderInfo> TranscodeApplication::GetEncoderInfoList(const ov::String &stream_name, cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> read_lock(_mutex);
+	for (auto &[id, stream] : _streams)
+	{
+		if (stream && stream->GetInputStreamName() == stream_name)
+		{
+			return stream->GetEncoderInfoList(codec_id);
+		}
+	}
+	return {};
+}
+
 bool TranscodeApplication::ValidateAppConfiguration()
 {
 	auto &cfg_output_profile_list = _application_info.GetConfig().GetOutputProfileList();

--- a/src/projects/transcoder/transcoder_application.h
+++ b/src/projects/transcoder/transcoder_application.h
@@ -34,6 +34,8 @@ public:
 	bool Start();
 	bool Stop();
 
+	const info::Application &GetApplicationInfo() const { return _application_info; }
+
 	MediaRouterApplicationObserver::ObserverType GetObserverType() override
 	{
 		return MediaRouterApplicationObserver::ObserverType::Transcoder;
@@ -53,6 +55,11 @@ public:
 	bool OnStreamUpdated(const std::shared_ptr<info::Stream> &stream) override;
 
 	bool OnSendFrame(const std::shared_ptr<info::Stream> &stream, const std::shared_ptr<MediaPacket> &packet) override;
+
+	bool PauseEncoders(const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	bool ResumeEncoders(const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	bool IsEncoderPaused(const ov::String &stream_name, cmn::MediaCodecId codec_id);
+	std::vector<TranscodeEncoder::EncoderInfo> GetEncoderInfoList(const ov::String &stream_name, cmn::MediaCodecId codec_id);
 
 private:
 	bool ValidateAppConfiguration();

--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -207,7 +207,6 @@ std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Instantiate(
 	return nullptr;
 }
 
-
 std::shared_ptr<TranscodeEncoder> TranscodeEncoder::Create(
 	int32_t encoder_id,
 	std::shared_ptr<info::Stream> info,
@@ -411,7 +410,7 @@ bool TranscodeEncoder::InitCodecInteral()
 	auto result = InitCodec();
 	if (_track != nullptr)
 	{
-		_track->SetCodecStatus(result ? MediaTrack::CodecStatus::Ready : MediaTrack::CodecStatus::Failed);
+		_track->SetCodecStatus(result ? cmn::CodecStatus::Ready : cmn::CodecStatus::Failed);
 	}
 	return result;
 }

--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -408,7 +408,12 @@ bool TranscodeEncoder::InitCodecInteral()
 	_frame = ::av_frame_alloc();
 
 	// Called the codec specific initialization function.
-	return InitCodec();
+	auto result = InitCodec();
+	if (_track != nullptr)
+	{
+		_track->SetCodecStatus(result ? MediaTrack::CodecStatus::Ready : MediaTrack::CodecStatus::Failed);
+	}
+	return result;
 }
 
 void TranscodeEncoder::DeinitCodec()

--- a/src/projects/transcoder/transcoder_encoder.cpp
+++ b/src/projects/transcoder/transcoder_encoder.cpp
@@ -51,16 +51,17 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 	ov::String configuration = ""; 
 	std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> candidate_modules = std::make_shared<std::vector<std::shared_ptr<info::CodecCandidate>>>();
 
-	// If the track is not video, the default module is the only candidate.
-	if (cmn::IsVideoCodec(track->GetCodecId()) == false)
+	// Non-video codecs with no explicit module config always use DEFAULT.
+	// If a non-video codec (e.g. Whisper) sets <Modules>, it falls through to the normal hardware selection path.
+	if (cmn::IsVideoCodec(track->GetCodecId()) == false && track->GetCodecModules().Trim().IsEmpty() == true)
 	{
 		candidate_modules->push_back(std::make_shared<info::CodecCandidate>(track->GetCodecId(), cmn::MediaCodecModuleId::DEFAULT, 0));
 		return candidate_modules;
 	}
 
-	if(hwaccels_enable == true)
+	if (hwaccels_enable == true)
 	{
-		if(track->GetCodecModules().Trim().IsEmpty() == false)
+		if (track->GetCodecModules().Trim().IsEmpty() == false)
 		{
 			configuration = track->GetCodecModules().Trim();
 		}
@@ -93,7 +94,7 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 		desire_modules.push_back(ov::String::FormatString("%s:%d", DEFAULT_MODULE_NAME, ALL_GPU_ID));
 	}
 
-	for(auto &desire_module : desire_modules)
+	for (auto &desire_module : desire_modules)
 	{
 		// Pattern : <module_name>:<gpu_id> or <module_name>
 		ov::Regex pattern_regex = ov::Regex::CompiledRegex( "(?<module_name>[^,:\\s]+[\\w]+):?(?<gpu_id>[^,]*)");
@@ -118,12 +119,12 @@ std::shared_ptr<std::vector<std::shared_ptr<info::CodecCandidate>>> TranscodeEnc
 			continue;
 		}
 
-		if(cmn::IsSupportHWAccels(module_id) == true && hwaccels_enable == false)
+		if (cmn::IsSupportHWAccels(module_id) == true && hwaccels_enable == false)
 		{
 			logtw("HWAccels is not enabled. Ignore this codec. module(%s)", module_name.CStr());
 			continue;
 		}
-		else  if(cmn::IsSupportHWAccels(module_id) == true && hwaccels_enable == true)
+		else  if (cmn::IsSupportHWAccels(module_id) == true && hwaccels_enable == true)
 		{
 			for (int device_id = 0; device_id < TranscodeGPU::GetInstance()->GetDeviceCount(module_id); device_id++)
 			{

--- a/src/projects/transcoder/transcoder_encoder.h
+++ b/src/projects/transcoder/transcoder_encoder.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <map>
+
 #include "base/info/stream.h"
 #include "base/info/codec.h"
 #include "codec/codec_base.h"
@@ -39,6 +41,31 @@ public:
 	// Returns true if this encoder consumes input but does not produce output packets
 	// back into the transcoding pipeline (e.g. STT encoders that push data forward directly).
 	virtual bool IsInputOnly() const noexcept { return false; }
+
+	struct EncoderInfo
+	{
+		cmn::MediaCodecId       codec_id  = cmn::MediaCodecId::None;
+		cmn::MediaCodecModuleId module_id = cmn::MediaCodecModuleId::None;
+		bool                    hw_accel  = false;
+		// Codec-specific extended fields (key/value pairs).
+		// e.g. Whisper: {"model":"small", "language":"ko", "translation":"false"}
+		std::map<ov::String, ov::String> properties;
+	};
+
+	virtual EncoderInfo GetInfo() const
+	{
+		EncoderInfo info;
+		info.codec_id  = GetCodecID();
+		info.module_id = GetModuleID();
+		info.hw_accel  = IsHWAccel();
+		return info;
+	}
+
+	// Pause/resume output of this encoder.
+	// Default is no-op; override in encoders that support pausing (e.g. EncoderWhisper).
+	virtual void Pause()          {}
+	virtual void Resume()         {}
+	virtual bool IsPaused() const { return false; }
 
 	bool InitCodecInteral();
 	virtual bool InitCodec() = 0;

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -720,10 +720,8 @@ size_t TranscoderStream::CreateOutputStreams()
 	}
 
 // STT (Speech-to-Text) output streams.
-        // New config: <OutputProfiles><MediaOptions><STT><Rendition> (preferred)
-        // Legacy config: <Application><Subtitle><Rendition><Transcription> (deprecated, backward compat)
-        // Both may be present (e.g. static legacy config + webhook-injected new config).
-        // New config takes priority per subtitle label; legacy is used as fallback.
+        // Config: <OutputProfiles><MediaOptions><STT><Rendition>
+        // Legacy <Application><Subtitle><Rendition><Transcription> is deprecated and logs a warning; it is not used for STT stream creation.
         {
                 auto new_output_profile_name = ov::String::FormatString("%s#stt", _input_stream->GetName().CStr());
 

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1140,7 +1140,11 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 
 	for (auto &[output_stream, output_track, encoder_id] : _composite.GetEncoderListByDecoderId(track_id))
 	{
-		// Create Encoder
+		// Probe encoder properties before full creation so we can act on them even if Configure fails.
+		auto probe = TranscodeEncoder::Instantiate(
+			output_track->GetCodecId(), cmn::MediaCodecModuleId::DEFAULT, *output_stream);
+		const bool is_input_only = probe && probe->IsInputOnly();
+
 		if (CreateEncoder(encoder_id, output_stream, output_track) == false)
 		{
 			// Non-essential track: encoder failure is not fatal, stream continues without it.
@@ -1148,6 +1152,12 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 			{
 				logtw("%s Could not create encoder for non-essential track — disabled for this stream. Id(%d), OutputTrack(%d)", _log_prefix.CStr(),
 					  encoder_id, output_track->GetId());
+				// CodecStatus=Failed is already set. For input-only encoders, notify MediaRouter
+				// to re-check stream readiness (they never push packets into the pipeline).
+				if (is_input_only)
+				{
+					_parent->UpdateStream(output_stream);
+				}
 				continue;
 			}
 
@@ -1168,6 +1178,13 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 #endif
 
 			return false;
+		}
+
+		// Input-only encoders never push packets into the pipeline, so OutboundWorkerThread
+		// will never trigger IsStreamReady. Notify MediaRouter explicitly after init.
+		if (is_input_only)
+		{
+			_parent->UpdateStream(output_stream);
 		}
 	}
 

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -202,6 +202,72 @@ bool TranscoderStream::Stop()
 	return true;
 }
 
+bool TranscoderStream::PauseEncoders(cmn::MediaCodecId codec_id)
+{
+	bool found = false;
+	std::shared_lock<std::shared_mutex> lock(_encoder_map_mutex);
+	for (auto &[encoder_id, filter_encoder_pair] : _encoders)
+	{
+		auto &encoder = filter_encoder_pair.second;
+		if (encoder && encoder->GetCodecID() == codec_id)
+		{
+			encoder->Pause();
+			found = true;
+		}
+	}
+	return found;
+}
+
+bool TranscoderStream::ResumeEncoders(cmn::MediaCodecId codec_id)
+{
+	bool found = false;
+	std::shared_lock<std::shared_mutex> lock(_encoder_map_mutex);
+	for (auto &[encoder_id, filter_encoder_pair] : _encoders)
+	{
+		auto &encoder = filter_encoder_pair.second;
+		if (encoder && encoder->GetCodecID() == codec_id)
+		{
+			encoder->Resume();
+			found = true;
+		}
+	}
+	return found;
+}
+
+bool TranscoderStream::IsEncoderPaused(cmn::MediaCodecId codec_id)
+{
+	std::shared_lock<std::shared_mutex> lock(_encoder_map_mutex);
+	for (auto &[encoder_id, filter_encoder_pair] : _encoders)
+	{
+		auto &encoder = filter_encoder_pair.second;
+		if (encoder && encoder->GetCodecID() == codec_id)
+		{
+			return encoder->IsPaused();
+		}
+	}
+	return false;
+}
+
+ov::String TranscoderStream::GetInputStreamName() const
+{
+	return _input_stream ? _input_stream->GetName() : "";
+}
+
+std::vector<TranscodeEncoder::EncoderInfo> TranscoderStream::GetEncoderInfoList(cmn::MediaCodecId codec_id)
+{
+	std::vector<TranscodeEncoder::EncoderInfo> result;
+	std::shared_lock<std::shared_mutex> lock(_encoder_map_mutex);
+	for (auto &[encoder_id, filter_encoder_pair] : _encoders)
+	{
+		auto &encoder = filter_encoder_pair.second;
+		if (encoder && encoder->GetCodecID() == codec_id)
+		{
+			result.push_back(encoder->GetInfo());
+		}
+	}
+	return result;
+}
+
 const cfg::vhost::app::oprf::OutputProfiles *TranscoderStream::RequestWebhook()
 {
 	// Measure response time of transcode webhook
@@ -698,6 +764,7 @@ size_t TranscoderStream::CreateOutputStreams()
                         speech_to_text_profile.SetStepMs(stt_rendition.GetStepMs());
                         speech_to_text_profile.SetLengthMs(stt_rendition.GetLengthMs());
                         speech_to_text_profile.SetKeepMs(stt_rendition.GetKeepMs());
+                        speech_to_text_profile.SetSttEnabled(cfg_stt.IsEnabled());
 
                         encodes.AddSpeechToTextProfiles(speech_to_text_profile);
                         i++;

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -695,6 +695,9 @@ size_t TranscoderStream::CreateOutputStreams()
                         speech_to_text_profile.SetSourceLanguage(stt_rendition.GetSourceLanguage());
                         speech_to_text_profile.SetTranslation(stt_rendition.GetTranslation());
                         speech_to_text_profile.SetOutputTrackLabel(stt_rendition.GetOutputSubtitleLabel());
+                        speech_to_text_profile.SetStepMs(stt_rendition.GetStepMs());
+                        speech_to_text_profile.SetLengthMs(stt_rendition.GetLengthMs());
+                        speech_to_text_profile.SetKeepMs(stt_rendition.GetKeepMs());
 
                         encodes.AddSpeechToTextProfiles(speech_to_text_profile);
                         i++;

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1392,6 +1392,16 @@ bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info
 		return true;
 	}
 
+	// If the encoder paired with this filter failed to initialize (e.g. non-essential Whisper encoder),
+	// skip filter creation to avoid wasting CPU/memory on resampling that will never be consumed.
+	auto encoder_id = _composite.GetEncoderIdByFilterId(filter_id);
+	if (encoder_id.has_value() && GetEncoder(encoder_id.value()) == nullptr)
+	{
+		logtd("%s Skip filter creation because paired encoder(%d) does not exist. Filter(%d)",
+			  _log_prefix.CStr(), encoder_id.value(), filter_id);
+		return true;
+	}
+
 	auto filter = TranscodeFilter::Create(filter_id, input_stream, input_track, output_stream, output_track, bind(&TranscoderStream::OnFilteredFrame, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	if (filter == nullptr)
 	{
@@ -2061,6 +2071,12 @@ void TranscoderStream::SpreadToFilters(MediaTrackId decoder_id, std::shared_ptr<
 {
 	for (auto &filter_id : _composite.GetFilterIdsByDecoderId(decoder_id))
 	{
+		// Skip clone entirely if the filter does not exist (e.g. paired encoder failed to init).
+		if (GetFilter(filter_id) == nullptr)
+		{
+			continue;
+		}
+
 		auto frame_clone = frame->CloneFrame(); 
 		if (!frame_clone)
 		{

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -762,6 +762,7 @@ size_t TranscoderStream::CreateOutputStreams()
                         speech_to_text_profile.SetStepMs(stt_rendition.GetStepMs());
                         speech_to_text_profile.SetLengthMs(stt_rendition.GetLengthMs());
                         speech_to_text_profile.SetKeepMs(stt_rendition.GetKeepMs());
+                        speech_to_text_profile.SetModules(stt_rendition.GetModules());
                         speech_to_text_profile.SetSttEnabled(cfg_stt.IsEnabled());
 
                         encodes.AddSpeechToTextProfiles(speech_to_text_profile);

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -9,14 +9,14 @@
 
 #include "transcoder_stream.h"
 
+#include <monitoring/monitoring.h>
+
 #include "config/config_manager.h"
 #include "modules/transcode_webhook/transcode_webhook.h"
 #include "orchestrator/orchestrator.h"
-#include <monitoring/monitoring.h>
-
 #include "transcoder_application.h"
-#include "transcoder_private.h"
 #include "transcoder_modules.h"
+#include "transcoder_private.h"
 
 #define UNUSED_VARIABLE(var) (void)var;
 #define MAX_FILLER_FRAMES 100
@@ -40,7 +40,7 @@ std::shared_ptr<TranscoderStream> TranscoderStream::Create(const info::Applicati
 TranscoderStream::TranscoderStream(const info::Application &application_info, const std::shared_ptr<info::Stream> &stream, TranscodeApplication *parent)
 	: _parent(parent), _application_info(application_info), _input_stream(stream)
 {
-	_log_prefix = ov::String::FormatString("[%s(%u)]", _input_stream->GetUri().CStr(), _input_stream->GetId());
+	_log_prefix			 = ov::String::FormatString("[%s(%u)]", _input_stream->GetUri().CStr(), _input_stream->GetId());
 
 	// default output profiles configuration
 	_output_profiles_cfg = &(_application_info.GetConfig().GetOutputProfiles());
@@ -79,7 +79,7 @@ bool TranscoderStream::Start()
 
 bool TranscoderStream::Prepare(const std::shared_ptr<info::Stream> &stream)
 {
-	if(GetState() != State::PREPARING)
+	if (GetState() != State::PREPARING)
 	{
 		logte("%s Stream is not in preparing state", _log_prefix.CStr());
 		return false;
@@ -150,13 +150,13 @@ void TranscoderStream::PrepareAsync()
 
 	SetState(State::STARTED);
 	_prepare_thread_running = false;
-	
-	logti("%s stream has been prepared", _log_prefix.CStr());	
+
+	logti("%s stream has been prepared", _log_prefix.CStr());
 }
 
 bool TranscoderStream::Update(const std::shared_ptr<info::Stream> &stream)
 {
-	if(GetState() != State::STARTED)
+	if (GetState() != State::STARTED)
 	{
 		logtt("%s stream is not started", _log_prefix.CStr());
 		return false;
@@ -174,7 +174,7 @@ bool TranscoderStream::Stop()
 		logtt("%s Prepare thread joined", _log_prefix.CStr());
 	}
 
-	if(GetState() == State::STOPPED)
+	if (GetState() == State::STOPPED)
 	{
 		return true;
 	}
@@ -341,7 +341,7 @@ bool TranscoderStream::PrepareInternal()
 
 		return false;
 	}
-	else 
+	else
 	{
 		logtd("%s Components have been created successfully. %s", _log_prefix.CStr(), _composite.GetInfoString().CStr());
 	}
@@ -375,7 +375,7 @@ bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &strea
 
 		CreateDecoders();
 		pipeline_lock.unlock();
-		logti("%s stream has been updated", _log_prefix.CStr());		
+		logti("%s stream has been updated", _log_prefix.CStr());
 	}
 	else
 	{
@@ -391,7 +391,7 @@ bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &strea
 
 		CreateDecoders();
 		pipeline_lock.unlock();
-		logti("%s stream has been updated", _log_prefix.CStr());		
+		logti("%s stream has been updated", _log_prefix.CStr());
 
 		UpdateMsidOfOutputStreams(stream->GetMsid());
 		NotifyUpdateStreams();
@@ -519,10 +519,10 @@ void TranscoderStream::RemoveSpecificEncoders()
 void TranscoderStream::RemoveEncoders()
 {
 	std::unique_lock<std::shared_mutex> read_lock(_encoder_map_mutex);
-	
+
 	auto encoders = _encoders;
 	_encoders.clear();
-	
+
 	read_lock.unlock();
 
 	for (auto &[id, object] : encoders)
@@ -564,7 +564,7 @@ std::shared_ptr<info::Stream> TranscoderStream::GetOutputStreamByTrackId(MediaTr
 	for (auto &[stream_name, output_stream] : _output_streams)
 	{
 		UNUSED_VARIABLE(stream_name)
-		
+
 		if (output_stream->GetTrack(output_track_id) != nullptr)
 		{
 			return output_stream;
@@ -579,12 +579,12 @@ bool TranscoderStream::CanSeamlessTransition(const std::shared_ptr<info::Stream>
 	auto new_tracks = input_stream->GetTracks();
 
 	// Check if the number and type of original tracks are different.
-	if(CompareTracksForSeamlessTransition(new_tracks, GetStoredTracks()) == false)
+	if (CompareTracksForSeamlessTransition(new_tracks, GetStoredTracks()) == false)
 	{
 		logtw("%s The input track has changed. It does not support smooth transitions.", _log_prefix.CStr());
 		return false;
 	}
-	
+
 	return true;
 }
 
@@ -634,7 +634,7 @@ bool TranscoderStream::SendBufferedPackets()
 		}
 
 		auto media_packet = buffered_media_packet.value();
-	
+
 		ProcessPacket(std::move(media_packet));
 	}
 
@@ -690,7 +690,7 @@ size_t TranscoderStream::CreateOutputStreams()
 {
 	// Get the output profile to make the output stream
 	auto cfg_output_profile_list = GetOutputProfilesCfg()->GetOutputProfileList();
-	
+
 	for (const auto &profile : cfg_output_profile_list)
 	{
 		auto output_stream = CreateOutputStream(profile);
@@ -719,84 +719,84 @@ size_t TranscoderStream::CreateOutputStreams()
 		logti("%s Output stream has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
 	}
 
-// STT (Speech-to-Text) output streams.
-        // Config: <OutputProfiles><MediaOptions><STT><Rendition>
-        // Legacy <Application><Subtitle><Rendition><Transcription> is deprecated and logs a warning; it is not used for STT stream creation.
-        {
-                auto new_output_profile_name = ov::String::FormatString("%s#stt", _input_stream->GetName().CStr());
+	// STT (Speech-to-Text) output streams.
+	// Config: <OutputProfiles><MediaOptions><STT><Rendition>
+	// Legacy <Application><Subtitle><Rendition><Transcription> is deprecated and logs a warning; it is not used for STT stream creation.
+	{
+		auto new_output_profile_name = ov::String::FormatString("%s#stt", _input_stream->GetName().CStr());
 
-                cfg::vhost::app::oprf::OutputProfile cfg_new_output_profile;
-                cfg_new_output_profile.SetInternal(true);
-                cfg_new_output_profile.SetName(new_output_profile_name);
-                cfg_new_output_profile.SetOutputStreamName(new_output_profile_name);
+		cfg::vhost::app::oprf::OutputProfile cfg_new_output_profile;
+		cfg_new_output_profile.SetInternal(true);
+		cfg_new_output_profile.SetName(new_output_profile_name);
+		cfg_new_output_profile.SetOutputStreamName(new_output_profile_name);
 
-                cfg::vhost::app::oprf::Encodes encodes;
-                int i = 0;
+		cfg::vhost::app::oprf::Encodes encodes;
+		int i				= 0;
 
-                // 1. New config: <MediaOptions><STT>
-                const auto &cfg_stt = GetOutputProfilesCfg()->GetMediaOptions().GetStt();
-                for (const auto &stt_rendition : cfg_stt.GetRenditions())
-                {
-                        auto name = ov::String::FormatString("SpeechToText_%d", i);
-                        auto model_path = ov::GetFilePath(stt_rendition.GetModel(), cfg::ConfigManager::GetInstance()->GetConfigPath());
+		// 1. New config: <MediaOptions><STT>
+		const auto &cfg_stt = GetOutputProfilesCfg()->GetMediaOptions().GetStt();
+		for (const auto &stt_rendition : cfg_stt.GetRenditions())
+		{
+			auto name				   = ov::String::FormatString("SpeechToText_%d", i);
+			auto model_path			   = ov::GetFilePath(stt_rendition.GetModel(), cfg::ConfigManager::GetInstance()->GetConfigPath());
 
-                        auto input_audio_track = _input_stream->GetMediaTrackByOrder(cmn::MediaType::Audio, stt_rendition.GetInputAudioIndex());
-                        auto output_subtitle_track = _input_stream->GetTrackByLabel(stt_rendition.GetOutputSubtitleLabel());
+			auto input_audio_track	   = _input_stream->GetMediaTrackByOrder(cmn::MediaType::Audio, stt_rendition.GetInputAudioIndex());
+			auto output_subtitle_track = _input_stream->GetTrackByLabel(stt_rendition.GetOutputSubtitleLabel());
 
-                        if (input_audio_track == nullptr || output_subtitle_track == nullptr)
-                        {
-                                logte("Could not find input audio track or output subtitle track for STT. InputAudioIndex(%d), OutputSubtitleLabel(%s)",
-                                        stt_rendition.GetInputAudioIndex(), stt_rendition.GetOutputSubtitleLabel().CStr());
-                                i++;
-                                continue;
-                        }
+			if (input_audio_track == nullptr || output_subtitle_track == nullptr)
+			{
+				logte("Could not find input audio track or output subtitle track for STT. InputAudioIndex(%d), OutputSubtitleLabel(%s)",
+					  stt_rendition.GetInputAudioIndex(), stt_rendition.GetOutputSubtitleLabel().CStr());
+				i++;
+				continue;
+			}
 
-                        cfg::vhost::app::oprf::SpeechToTextProfile speech_to_text_profile(name,
-                                                                       stt_rendition.GetEngine(),
-                                                                       model_path,
-                                                                       input_audio_track->GetId(),
-                                                                       output_subtitle_track->GetId());
-                        speech_to_text_profile.SetSourceLanguage(stt_rendition.GetSourceLanguage());
-                        speech_to_text_profile.SetTranslation(stt_rendition.GetTranslation());
-                        speech_to_text_profile.SetOutputTrackLabel(stt_rendition.GetOutputSubtitleLabel());
-                        speech_to_text_profile.SetStepMs(stt_rendition.GetStepMs());
-                        speech_to_text_profile.SetLengthMs(stt_rendition.GetLengthMs());
-                        speech_to_text_profile.SetKeepMs(stt_rendition.GetKeepMs());
-                        speech_to_text_profile.SetModules(stt_rendition.GetModules());
-                        speech_to_text_profile.SetSttEnabled(cfg_stt.IsEnabled());
+			cfg::vhost::app::oprf::SpeechToTextProfile speech_to_text_profile(name,
+																			  stt_rendition.GetEngine(),
+																			  model_path,
+																			  input_audio_track->GetId(),
+																			  output_subtitle_track->GetId());
+			speech_to_text_profile.SetSourceLanguage(stt_rendition.GetSourceLanguage());
+			speech_to_text_profile.SetTranslation(stt_rendition.GetTranslation());
+			speech_to_text_profile.SetOutputTrackLabel(stt_rendition.GetOutputSubtitleLabel());
+			speech_to_text_profile.SetStepMs(stt_rendition.GetStepMs());
+			speech_to_text_profile.SetLengthMs(stt_rendition.GetLengthMs());
+			speech_to_text_profile.SetKeepMs(stt_rendition.GetKeepMs());
+			speech_to_text_profile.SetModules(stt_rendition.GetModules());
+			speech_to_text_profile.SetSttEnabled(cfg_stt.IsEnabled());
 
-                        encodes.AddSpeechToTextProfiles(speech_to_text_profile);
-                        i++;
-                }
+			encodes.AddSpeechToTextProfiles(speech_to_text_profile);
+			i++;
+		}
 
-                cfg_new_output_profile.SetEncodes(encodes);
+		cfg_new_output_profile.SetEncodes(encodes);
 
-                if (cfg_new_output_profile.GetEncodes().GetSpeechToTextProfileList().size() > 0)
-                {
-                        auto output_stream = CreateOutputStream(cfg_new_output_profile);
-                        if (output_stream == nullptr)
-                        {
-                                logte("%s Could not create output stream for STT. name:%s", _log_prefix.CStr(), cfg_new_output_profile.GetName().CStr());
+		if (cfg_new_output_profile.GetEncodes().GetSpeechToTextProfileList().size() > 0)
+		{
+			auto output_stream = CreateOutputStream(cfg_new_output_profile);
+			if (output_stream == nullptr)
+			{
+				logte("%s Could not create output stream for STT. name:%s", _log_prefix.CStr(), cfg_new_output_profile.GetName().CStr());
 
 #if NOTIFICATION_ENABLED
-                                TranscoderAlerts::UpdateErrorWithoutCount(
-                                        TranscoderAlerts::ErrorType::CREATION_ERROR_PROFILE,
-                                        std::make_shared<cfg::vhost::app::oprf::OutputProfile>(cfg_new_output_profile),
-                                        _input_stream,
-                                        nullptr,
-                                        nullptr,
-                                        nullptr);
+				TranscoderAlerts::UpdateErrorWithoutCount(
+					TranscoderAlerts::ErrorType::CREATION_ERROR_PROFILE,
+					std::make_shared<cfg::vhost::app::oprf::OutputProfile>(cfg_new_output_profile),
+					_input_stream,
+					nullptr,
+					nullptr,
+					nullptr);
 #endif
-                        }
-                        else
-                        {
-                                output_stream->SetInternal(true);
-                                {
-                                        std::unique_lock<std::shared_mutex> lock(_output_stream_mutex);
-                                        _output_streams.insert(std::make_pair(output_stream->GetName(), output_stream));
-                                }
+			}
+			else
+			{
+				output_stream->SetInternal(true);
+				{
+					std::unique_lock<std::shared_mutex> lock(_output_stream_mutex);
+					_output_streams.insert(std::make_pair(output_stream->GetName(), output_stream));
+				}
 
-                                logti("%s Output stream(STT) has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
+				logti("%s Output stream(STT) has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
 			}
 		}
 	}
@@ -850,7 +850,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 					if (output_track == nullptr)
 					{
 						logte("[%s] Failed to create video track. Encoding options need to be checked. InputTrack(%d)", _log_prefix.CStr(), input_track_id);
-					
+
 						return nullptr;
 					}
 
@@ -867,7 +867,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 					if (output_track == nullptr)
 					{
 						logte("[%s] Failed to create image track. Encoding options need to be checked. InputTrack(%d)", _log_prefix.CStr(), input_track_id);
-					
+
 						return nullptr;
 					}
 
@@ -909,7 +909,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 					if (output_track == nullptr)
 					{
 						logte("[%s] Failed to create data track for transcription. Encoding options need to be checked. InputTrack(%d), SpeechToTextProfile(%s)", _log_prefix.CStr(), input_track_id, profile.GetName().CStr());
-						
+
 						return nullptr;
 					}
 
@@ -920,29 +920,29 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 				}
 			}
 			break;
-			
+
 			// If there is a data type track in the input stream, it must be created equally in all output streams.
-			case cmn::MediaType::Data: 
-			case cmn::MediaType::Subtitle:{
-					// Data or Subtitle must be duplicated even if there is no profile, unless
-					if (cfg_output_profile.IsInternal() == true)
-					{
-						continue;
-					}
-			
-					// Create a output track by cloning the input track.
-					auto output_track = CreateOutputTrackDataType(input_track);
-					if (output_track == nullptr)
-					{
-						logte("[%s] Failed to create data track. Encoding options need to be checked. InputTrack(%d)", _log_prefix.CStr(), input_track_id);
-						
-						return nullptr;
-					}
+			case cmn::MediaType::Data:
+			case cmn::MediaType::Subtitle: {
+				// Data or Subtitle must be duplicated even if there is no profile, unless
+				if (cfg_output_profile.IsInternal() == true)
+				{
+					continue;
+				}
 
-					output_stream->AddTrack(output_track);
+				// Create a output track by cloning the input track.
+				auto output_track = CreateOutputTrackDataType(input_track);
+				if (output_track == nullptr)
+				{
+					logte("[%s] Failed to create data track. Encoding options need to be checked. InputTrack(%d)", _log_prefix.CStr(), input_track_id);
 
-					auto signature = ProfileToSerialize(input_track_id);
-					_composite.AddComposite(input_stream, input_track, signature, output_stream, output_track);
+					return nullptr;
+				}
+
+				output_stream->AddTrack(output_track);
+
+				auto signature = ProfileToSerialize(input_track_id);
+				_composite.AddComposite(input_stream, input_track, signature, output_stream, output_track);
 			}
 			break;
 			default: {
@@ -953,17 +953,17 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 	}
 
 	// Playlist
-	bool is_parsed = false;
+	bool is_parsed	   = false;
 	auto cfg_playlists = cfg_output_profile.GetPlaylists(&is_parsed);
 	if (is_parsed)
 	{
 		for (const auto &cfg_playlist : cfg_playlists)
 		{
-			auto playlist_info = cfg_playlist.GetPlaylistInfo();
+			auto playlist_info		 = cfg_playlist.GetPlaylistInfo();
 
 			// Create renditions with RenditionTemplate
 			auto rendition_templates = cfg_playlist.GetRenditionTemplates();
-			auto tracks = output_stream->GetTracks();
+			auto tracks				 = output_stream->GetTracks();
 
 			for (const auto &rendition_template : rendition_templates)
 			{
@@ -986,7 +986,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 						matched_video_tracks.push_back(track);
 					}
 				}
-				
+
 				if (has_audio_template)
 				{
 					// Do not separate the Audio track group. (Used as Multilingual)
@@ -1016,8 +1016,8 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 						{
 							// Make Rendition Name
 							ov::String rendition_name = MakeRenditionName(rendition_template.GetName(), playlist_info, video_track, audio_track);
-							
-							auto rendition = std::make_shared<info::Rendition>(rendition_name, video_track->GetVariantName(), audio_track->GetVariantName());
+
+							auto rendition			  = std::make_shared<info::Rendition>(rendition_name, video_track->GetVariantName(), audio_track->GetVariantName());
 							rendition->SetVideoIndexHint(video_track->GetGroupIndex());
 							rendition->SetAudioIndexHint(audio_track->GetGroupIndex());
 
@@ -1033,7 +1033,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 					{
 						// Make Rendition Name
 						ov::String rendition_name = MakeRenditionName(rendition_template.GetName(), playlist_info, video_track, nullptr);
-						auto rendition = std::make_shared<info::Rendition>(rendition_name, video_track->GetVariantName(), "");
+						auto rendition			  = std::make_shared<info::Rendition>(rendition_name, video_track->GetVariantName(), "");
 						rendition->SetVideoIndexHint(video_track->GetGroupIndex());
 
 						playlist_info->AddRendition(rendition);
@@ -1048,7 +1048,7 @@ std::shared_ptr<info::Stream> TranscoderStream::CreateOutputStream(const cfg::vh
 						// Make Rendition Name
 						ov::String rendition_name = MakeRenditionName(rendition_template.GetName(), playlist_info, nullptr, audio_track);
 
-						auto rendition = std::make_shared<info::Rendition>(rendition_name, "", audio_track->GetVariantName());
+						auto rendition			  = std::make_shared<info::Rendition>(rendition_name, "", audio_track->GetVariantName());
 						rendition->SetAudioIndexHint(audio_track->GetGroupIndex());
 
 						playlist_info->AddRendition(rendition);
@@ -1081,11 +1081,11 @@ ov::String TranscoderStream::MakeRenditionName(const ov::String &name_template, 
 	if (video_track != nullptr)
 	{
 		auto resolution = video_track->GetResolution();
-		rendition_name = rendition_name.Replace("${Width}", ov::String::FormatString("%d", resolution.width).CStr());
-		rendition_name = rendition_name.Replace("${Height}", ov::String::FormatString("%d", resolution.height).CStr());
-		rendition_name = rendition_name.Replace("${Bitrate}", ov::String::FormatString("%d", video_track->GetBitrate()).CStr());
+		rendition_name	= rendition_name.Replace("${Width}", ov::String::FormatString("%d", resolution.width).CStr());
+		rendition_name	= rendition_name.Replace("${Height}", ov::String::FormatString("%d", resolution.height).CStr());
+		rendition_name	= rendition_name.Replace("${Bitrate}", ov::String::FormatString("%d", video_track->GetBitrate()).CStr());
 		// TODO: Check if there are cases where the rendition name includes decimal points. (e.g., 29.97fps)
-		rendition_name = rendition_name.Replace("${Framerate}", ov::String::FormatString("%.0f", video_track->GetFrameRate()).CStr());
+		rendition_name	= rendition_name.Replace("${Framerate}", ov::String::FormatString("%.0f", video_track->GetFrameRate()).CStr());
 	}
 
 	if (audio_track != nullptr)
@@ -1095,7 +1095,7 @@ ov::String TranscoderStream::MakeRenditionName(const ov::String &name_template, 
 	}
 
 	// Check if the rendition name is duplicated
-	uint32_t rendition_index = 0;
+	uint32_t rendition_index		 = 0;
 	ov::String unique_rendition_name = rendition_name;
 	while (playlist_info->GetRendition(unique_rendition_name) != nullptr)
 	{
@@ -1107,7 +1107,7 @@ ov::String TranscoderStream::MakeRenditionName(const ov::String &name_template, 
 
 bool TranscoderStream::CreateDecoders()
 {
-	for(auto &[input_stream, input_track, decoder_id] : _composite.GetDecoderList())
+	for (auto &[input_stream, input_track, decoder_id] : _composite.GetDecoderList())
 	{
 		// Create Decoder
 		if (CreateDecoder(decoder_id, input_stream, input_track) == false)
@@ -1139,7 +1139,7 @@ bool TranscoderStream::CreateDecoders()
 
 bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<info::Stream> input_stream, std::shared_ptr<MediaTrack> input_track)
 {
-	if(GetDecoder(decoder_id) != nullptr)
+	if (GetDecoder(decoder_id) != nullptr)
 	{
 		logtw("%s Decoder already exists. InputTrack(%d), Decoder(%d)", _log_prefix.CStr(), input_track->GetId(), decoder_id);
 		return true;
@@ -1155,13 +1155,13 @@ bool TranscoderStream::CreateDecoder(MediaTrackId decoder_id, std::shared_ptr<in
 	// Set the thread count for the decoder.
 	input_track->SetThreadCount(GetOutputProfilesCfg()->GetDecodes().GetThreadCount());
 
-	auto hwaccels_enable = GetOutputProfilesCfg()->GetHWAccels().GetDecoder().IsEnable() ||
-						   GetOutputProfilesCfg()->IsHardwareAcceleration();  // Deprecated
+	auto hwaccels_enable  = GetOutputProfilesCfg()->GetHWAccels().GetDecoder().IsEnable() ||
+							GetOutputProfilesCfg()->IsHardwareAcceleration();  // Deprecated
 
 	auto hwaccels_modules = GetOutputProfilesCfg()->GetHWAccels().GetDecoder().GetModules();
 
 	// Get a list of available decoder candidates.
-	auto candidates = TranscodeDecoder::GetCandidates(hwaccels_enable, hwaccels_modules, input_track);
+	auto candidates		  = TranscodeDecoder::GetCandidates(hwaccels_enable, hwaccels_modules, input_track);
 	if (candidates == nullptr)
 	{
 		logte("%s Decoder candidates are not found. InputTrack(%u)", _log_prefix.CStr(), input_track->GetId());
@@ -1231,19 +1231,19 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 			}
 
 			logte("%s Could not create encoder. Id(%d)<Codec:%s,Module:%s:%d>, OutputTrack(%d)", _log_prefix.CStr(),
-				  encoder_id, cmn::GetCodecIdString(output_track->GetCodecId()), cmn::GetCodecModuleIdString(output_track->GetCodecModuleId()), output_track->GetCodecDeviceId(), output_track->GetId());	
+				  encoder_id, cmn::GetCodecIdString(output_track->GetCodecId()), cmn::GetCodecModuleIdString(output_track->GetCodecModuleId()), output_track->GetCodecDeviceId(), output_track->GetId());
 
 #if NOTIFICATION_ENABLED
-				auto output_profile_ptr = GetOutputProfileByName(output_stream->GetOutputProfileName());
-				auto output_profile		= (output_profile_ptr) ? std::make_shared<cfg::vhost::app::oprf::OutputProfile>(*output_profile_ptr) : nullptr;
+			auto output_profile_ptr = GetOutputProfileByName(output_stream->GetOutputProfileName());
+			auto output_profile		= (output_profile_ptr) ? std::make_shared<cfg::vhost::app::oprf::OutputProfile>(*output_profile_ptr) : nullptr;
 
-				TranscoderAlerts::UpdateErrorWithoutCount(
-					TranscoderAlerts::ErrorType::CREATION_ERROR_ENCODER,
-					output_profile,
-					GetInputStream(),
-					GetInputStream()->GetTrack(track_id),
-					output_stream,
-					output_track);
+			TranscoderAlerts::UpdateErrorWithoutCount(
+				TranscoderAlerts::ErrorType::CREATION_ERROR_ENCODER,
+				output_profile,
+				GetInputStream(),
+				GetInputStream()->GetTrack(track_id),
+				output_stream,
+				output_track);
 #endif
 
 			return false;
@@ -1260,20 +1260,20 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 	return true;
 }
 
-#define UPDATE_OUTPUT_TRACK_CODEC_INFO(track, encoder)                      \
-	do                                                                      \
-	{                                                                       \
-		track->SetCodecModuleId(encoder->GetModuleID());                    \
-		track->SetCodecDeviceId(encoder->GetDeviceID());                    \
-		track->SetOriginBitstream(encoder->GetBitstreamFormat());           \
-		if (track->GetMediaType() == cmn::MediaType::Video)                 \
-		{                                                                   \
-			track->SetColorspace(encoder->GetSupportVideoFormat());         \
-		}                                                                   \
-		else if (track->GetMediaType() == cmn::MediaType::Audio)            \
-		{                                                                   \
+#define UPDATE_OUTPUT_TRACK_CODEC_INFO(track, encoder)                \
+	do                                                                \
+	{                                                                 \
+		track->SetCodecModuleId(encoder->GetModuleID());              \
+		track->SetCodecDeviceId(encoder->GetDeviceID());              \
+		track->SetOriginBitstream(encoder->GetBitstreamFormat());     \
+		if (track->GetMediaType() == cmn::MediaType::Video)           \
+		{                                                             \
+			track->SetColorspace(encoder->GetSupportVideoFormat());   \
+		}                                                             \
+		else if (track->GetMediaType() == cmn::MediaType::Audio)      \
+		{                                                             \
 			track->SetSampleFormat(encoder->GetSupportAudioFormat()); \
-		}                                                                   \
+		}                                                             \
 	} while (0)
 
 bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<info::Stream> output_stream, std::shared_ptr<MediaTrack> output_track)
@@ -1304,8 +1304,8 @@ bool TranscoderStream::CreateEncoder(MediaTrackId encoder_id, std::shared_ptr<in
 	}
 
 	// Get a list of available encoder candidates(modules)
-	auto hwaccels_enable = GetOutputProfilesCfg()->GetHWAccels().GetEncoder().IsEnable() ||
-						   GetOutputProfilesCfg()->IsHardwareAcceleration();  // Deprecated
+	auto hwaccels_enable  = GetOutputProfilesCfg()->GetHWAccels().GetEncoder().IsEnable() ||
+							GetOutputProfilesCfg()->IsHardwareAcceleration();  // Deprecated
 	auto hwaccels_modules = GetOutputProfilesCfg()->GetHWAccels().GetEncoder().GetModules();
 
 	auto candidates		  = TranscodeEncoder::GetCandidates(hwaccels_enable, hwaccels_modules, output_track);
@@ -1451,7 +1451,7 @@ bool TranscoderStream::CreateFilters(std::shared_ptr<MediaFrame> buffer)
 	}
 
 	return true;
-	}
+}
 
 bool TranscoderStream::CreateFilter(MediaTrackId filter_id, std::shared_ptr<info::Stream> input_stream, std::shared_ptr<MediaTrack> input_track, std::shared_ptr<info::Stream> output_stream, std::shared_ptr<MediaTrack> output_track)
 {
@@ -1520,7 +1520,7 @@ void TranscoderStream::ChangeOutputFormat(std::shared_ptr<MediaFrame> buffer)
 	UpdateOutputTrack(buffer);
 
 	// Create an encoder. If there is an existing encoder, reuse it
-	if(CreateEncoders(buffer) == false)
+	if (CreateEncoders(buffer) == false)
 	{
 		SetState(State::ERROR);
 
@@ -1528,7 +1528,7 @@ void TranscoderStream::ChangeOutputFormat(std::shared_ptr<MediaFrame> buffer)
 	}
 
 	// Create an filter. If there is an existing filter, reuse it
-	if(CreateFilters(buffer) == false)
+	if (CreateFilters(buffer) == false)
 	{
 		SetState(State::ERROR);
 
@@ -1552,21 +1552,18 @@ void TranscoderStream::UpdateInputTrack(std::shared_ptr<MediaFrame> buffer)
 
 	switch (input_track->GetMediaType())
 	{
-		case cmn::MediaType::Video: 
-		{
+		case cmn::MediaType::Video: {
 			input_track->SetResolution(buffer->GetWidth(), buffer->GetHeight());
 			input_track->SetColorspace(buffer->GetFormat<cmn::VideoPixelFormatId>());
 		}
 		break;
-		case cmn::MediaType::Audio: 
-		{
+		case cmn::MediaType::Audio: {
 			input_track->SetSampleRate(buffer->GetSampleRate());
 			input_track->SetChannel(buffer->GetChannels());
 			input_track->SetSampleFormat(buffer->GetFormat<cmn::AudioSample::Format>());
 		}
 		break;
-		default: 
-		{
+		default: {
 			logtt("%s Unsupported media type. InputTrack(%d)", _log_prefix.CStr(), track_id);
 		}
 		break;
@@ -1676,22 +1673,21 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 {
 	switch (result)
 	{
-		case TranscodeResult::DataError:
-		{
-#if NOTIFICATION_ENABLED			
+		case TranscodeResult::DataError: {
+#if NOTIFICATION_ENABLED
 			auto input_track = GetInputTrack(decoder_id);
 			if (input_track == nullptr)
 			{
 				logte("%s Could not found input track. Decoder(%d)", _log_prefix.CStr(), decoder_id);
 				return;
 			}
-	
+
 			TranscoderAlerts::UpdateErrorCountIfNeeded(TranscoderAlerts::ErrorType::DECODING_ERROR, _input_stream, input_track, nullptr, nullptr);
-#endif			
+#endif
 		}
 		break;
 		case TranscodeResult::NoData: {
- #if FILLER_ENABLED
+#if FILLER_ENABLED
 			if (!decoded_frame)
 			{
 				return;
@@ -1700,7 +1696,7 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 			// Generate a filler frame (Part 1). * Using previously decoded frame
 			///////////////////////////////////////////////////////////////////
 			// - It is mainly used in Persistent Stream.
-			// - When the input stream is switched, decoding fails until a KeyFrame is received. 
+			// - When the input stream is switched, decoding fails until a KeyFrame is received.
 			//   If the keyframe interval is longer than the buffered length of the player, buffering occurs in the player.
 			//   Therefore, the number of frames in which decoding fails is replaced with the last decoded frame and used as a filler frame.
 			auto last_frame = GetLastDecodedFrame(decoder_id);
@@ -1722,10 +1718,10 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 				break;
 			}
 
-			double input_expr = input_track->GetTimeBase().GetExpr();
+			double input_expr  = input_track->GetTimeBase().GetExpr();
 			double filter_expr = input_track_of_filter->GetTimeBase().GetExpr();
 
-			if(last_frame->GetPts()*filter_expr >= decoded_frame->GetPts()*input_expr)
+			if (last_frame->GetPts() * filter_expr >= decoded_frame->GetPts() * input_expr)
 			{
 				break;
 			}
@@ -1744,13 +1740,13 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 
 			// Send Temporary Frame to Filter
 			SpreadToFilters(decoder_id, last_frame);
-#endif // End of Filler Frame Generation
+#endif	// End of Filler Frame Generation
 		}
 		break;
 
 		// It indicates output format is changed
 		case TranscodeResult::FormatChanged: {
-			if(!decoded_frame)
+			if (!decoded_frame)
 			{
 				return;
 			}
@@ -1773,32 +1769,32 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 				return;
 			}
 
-				int64_t last_decoded_frame_time_us = 0;
-				int64_t last_decoded_frame_duration_us = 0;
-				bool _has_last_decoded_frame_pts = false;
+			int64_t last_decoded_frame_time_us	   = 0;
+			int64_t last_decoded_frame_duration_us = 0;
+			bool _has_last_decoded_frame_pts	   = false;
+			{
+				std::shared_lock<std::shared_mutex> lock(_last_decoded_frame_mutex);
+				if (_last_decoded_frame_pts.find(decoder_id) != _last_decoded_frame_pts.end())
 				{
-					std::shared_lock<std::shared_mutex> lock(_last_decoded_frame_mutex);
-					if (_last_decoded_frame_pts.find(decoder_id) != _last_decoded_frame_pts.end())
-					{
-						last_decoded_frame_time_us = _last_decoded_frame_pts[decoder_id];
-						last_decoded_frame_duration_us = _last_decoded_frame_duration[decoder_id];
-						_has_last_decoded_frame_pts = true;
-					}
+					last_decoded_frame_time_us	   = _last_decoded_frame_pts[decoder_id];
+					last_decoded_frame_duration_us = _last_decoded_frame_duration[decoder_id];
+					_has_last_decoded_frame_pts	   = true;
 				}
-				if (_has_last_decoded_frame_pts)
-				{
+			}
+			if (_has_last_decoded_frame_pts)
+			{
 				// Decoded frame PTS to microseconds
 				int64_t curr_decoded_frame_time_us = (int64_t)((double)decoded_frame->GetPts() * input_track->GetTimeBase().GetExpr() * 1000000);
 
 				// Calculate the time difference between the last decoded frame and the current decoded frame.
-				int64_t hole_time_us = curr_decoded_frame_time_us - (last_decoded_frame_time_us + last_decoded_frame_duration_us);
-				int64_t hole_time_tb = (int64_t)(floor((double)hole_time_us / input_track->GetTimeBase().GetExpr() / 1000000));
+				int64_t hole_time_us			   = curr_decoded_frame_time_us - (last_decoded_frame_time_us + last_decoded_frame_duration_us);
+				int64_t hole_time_tb			   = (int64_t)(floor((double)hole_time_us / input_track->GetTimeBase().GetExpr() / 1000000));
 
-				int64_t duration_per_frame = -1LL;
+				int64_t duration_per_frame		   = -1LL;
 				switch (input_track->GetMediaType())
 				{
 					case cmn::MediaType::Video:
-						if(input_track->GetFrameRate() > 0 && input_track->GetTimeBase().GetTimescale() > 0)
+						if (input_track->GetFrameRate() > 0 && input_track->GetTimeBase().GetTimescale() > 0)
 						{
 							duration_per_frame = static_cast<int64_t>(input_track->GetTimeBase().GetTimescale() / input_track->GetFrameRate());
 						}
@@ -1813,9 +1809,9 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 				// If the time difference is greater than 0, it means that there is a hole between with the last frame and the current frame.
 				if (duration_per_frame > 0 && hole_time_tb >= duration_per_frame)
 				{
-					int64_t start_pts = decoded_frame->GetPts() - hole_time_tb;
-					int64_t end_pts = decoded_frame->GetPts();
-					int32_t needed_frames = hole_time_tb / duration_per_frame;
+					int64_t start_pts	   = decoded_frame->GetPts() - hole_time_tb;
+					int64_t end_pts		   = decoded_frame->GetPts();
+					int32_t needed_frames  = hole_time_tb / duration_per_frame;
 					int32_t created_filler = 0;
 
 					logtt("%s Generate filler frame because time diffrence from last frame. Type(%s), needed(%d), last_pts(%" PRId64 "), curr_pts(%" PRId64 "), hole_time(%" PRId64 "), hole_time_tb(%" PRId64 "), frame_duration(%" PRId64 "), start_pts(%" PRId64 "), end_pts(%" PRId64 ")",
@@ -1848,7 +1844,7 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 						SpreadToFilters(decoder_id, clone_frame);
 
 						// Prevent infinite loop
-						if(created_filler++ >= MAX_FILLER_FRAMES)
+						if (created_filler++ >= MAX_FILLER_FRAMES)
 						{
 							break;
 						}
@@ -1863,16 +1859,16 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 					}
 				}
 			}
-#endif // End of Filler Frame Generation	
+#endif	// End of Filler Frame Generation
 
 			[[fallthrough]];
 		}
-		
+
 		case TranscodeResult::DataReady: {
-			if(!decoded_frame)
+			if (!decoded_frame)
 			{
 				return;
-			}			
+			}
 
 			// The last decoded frame is kept and used as a filling frame in the blank section.
 			SetLastDecodedFrame(decoder_id, decoded_frame);
@@ -1890,17 +1886,17 @@ void TranscoderStream::OnDecodedFrame(TranscodeResult result, MediaTrackId decod
 
 void TranscoderStream::SetLastDecodedFrame(MediaTrackId decoder_id, std::shared_ptr<MediaFrame> &decoded_frame)
 {
-	auto input_track = GetInputTrack(decoder_id);
+	auto input_track  = GetInputTrack(decoder_id);
 
 	auto scale_factor = input_track->GetTimeBase().GetExpr() * 1000000.0;
-	auto pts = static_cast<int64_t>(decoded_frame->GetPts() * scale_factor);
-	auto duration = static_cast<int64_t>(decoded_frame->GetDuration() * scale_factor);
-	auto cloned = decoded_frame->CloneFrame();
+	auto pts		  = static_cast<int64_t>(decoded_frame->GetPts() * scale_factor);
+	auto duration	  = static_cast<int64_t>(decoded_frame->GetDuration() * scale_factor);
+	auto cloned		  = decoded_frame->CloneFrame();
 
 	std::unique_lock<std::shared_mutex> lock(_last_decoded_frame_mutex);
-	_last_decoded_frame_pts[decoder_id] = pts;
+	_last_decoded_frame_pts[decoder_id]		 = pts;
 	_last_decoded_frame_duration[decoder_id] = duration;
-	_last_decoded_frames[decoder_id] = std::move(cloned);
+	_last_decoded_frames[decoder_id]		 = std::move(cloned);
 }
 
 std::shared_ptr<MediaFrame> TranscoderStream::GetLastDecodedFrame(MediaTrackId decoder_id)
@@ -1950,7 +1946,7 @@ TranscodeResult TranscoderStream::FilterFrame(MediaTrackId filter_id, std::share
 		logtt("%s Failed to acquire pipeline lock. FilterId(%d)", _log_prefix.CStr(), filter_id);
 		return TranscodeResult::DataReady;
 	}
-	
+
 	auto filter = GetFilter(filter_id);
 	if (filter == nullptr)
 	{
@@ -2016,7 +2012,7 @@ TranscodeResult TranscoderStream::EncoderFilterFrame(std::shared_ptr<MediaFrame>
 
 	pipeline_lock.unlock();
 
-		// If there is no post-filter, it is sent directly to the encoder.
+	// If there is no post-filter, it is sent directly to the encoder.
 	OnEncoderFilterdFrame(TranscodeResult::DataReady, encoder_id.value(), std::move(frame));
 
 	return TranscodeResult::DataReady;
@@ -2024,7 +2020,6 @@ TranscodeResult TranscoderStream::EncoderFilterFrame(std::shared_ptr<MediaFrame>
 
 void TranscoderStream::OnEncoderFilterdFrame(TranscodeResult result, MediaTrackId encoder_id, std::shared_ptr<MediaFrame> filtered_frame)
 {
-
 	if (result != TranscodeResult::DataReady || !filtered_frame)
 	{
 #if NOTIFICATION_ENABLED
@@ -2073,7 +2068,7 @@ void TranscoderStream::OnEncodedPacket(TranscodeResult result, MediaTrackId enco
 {
 	if (result != TranscodeResult::DataReady)
 	{
-#if NOTIFICATION_ENABLED				
+#if NOTIFICATION_ENABLED
 		auto opts = _composite.GetInputOutputByEncoderId(encoder_id);
 		if (!opts.has_value())
 		{
@@ -2082,7 +2077,7 @@ void TranscoderStream::OnEncodedPacket(TranscodeResult result, MediaTrackId enco
 
 		auto &[input_stream, input_track, output_stream, output_track] = opts.value();
 		TranscoderAlerts::UpdateErrorCountIfNeeded(TranscoderAlerts::ErrorType::ENCODING_ERROR, _input_stream, input_track, output_stream, output_track);
-#endif		
+#endif
 		return;
 	}
 
@@ -2091,14 +2086,14 @@ void TranscoderStream::OnEncodedPacket(TranscodeResult result, MediaTrackId enco
 		return;
 	}
 
-	auto output_list = _composite.GetOutputListByEncoderId(encoder_id);
+	auto output_list   = _composite.GetOutputListByEncoderId(encoder_id);
 	int32_t used_count = output_list.size();
-	for( auto &[output_stream, output_track] : output_list)
+	for (auto &[output_stream, output_track] : output_list)
 	{
 		std::shared_ptr<MediaPacket> packet = nullptr;
-		
-		// If the packet is used in multiple tracks, it is cloned. 
-		packet = (used_count == 1) ? encoded_packet : encoded_packet->ClonePacket();
+
+		// If the packet is used in multiple tracks, it is cloned.
+		packet								= (used_count == 1) ? encoded_packet : encoded_packet->ClonePacket();
 		if (!packet)
 		{
 			logte("%s Could not clone packet. Encoder(%d)", _log_prefix.CStr(), encoder_id);
@@ -2120,7 +2115,7 @@ void TranscoderStream::UpdateMsidOfOutputStreams(uint32_t msid)
 	for (auto &[output_stream_name, output_stream] : _output_streams)
 	{
 		UNUSED_VARIABLE(output_stream_name)
-		
+
 		output_stream->SetMsid(msid);
 	}
 }
@@ -2146,7 +2141,7 @@ void TranscoderStream::SpreadToFilters(MediaTrackId decoder_id, std::shared_ptr<
 			continue;
 		}
 
-		auto frame_clone = frame->CloneFrame(); 
+		auto frame_clone = frame->CloneFrame();
 		if (!frame_clone)
 		{
 			logte("%s Failed to clone frame", _log_prefix.CStr());

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -653,92 +653,80 @@ size_t TranscoderStream::CreateOutputStreams()
 		logti("%s Output stream has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
 	}
 
-	auto cfg_media_option_subtitles = _application_info.GetConfig().GetSubtitle();
-	if (cfg_media_option_subtitles.IsEnabled() == false)
-	{
-		// Subtitle option is moved to Application level, and OutputProfiles/MediaOptions/Subtitle will be deprecated. 
-		cfg_media_option_subtitles = GetOutputProfilesCfg()->GetMediaOptions().GetSubtitle();
-	}
-	
-	cfg::vhost::app::oprf::OutputProfile cfg_new_output_profile;
-	if (cfg_media_option_subtitles.IsEnabled())
-	{
-		auto new_output_profile_name = ov::String::FormatString("TranscriptionProcess_%s", _input_stream->GetName().CStr());
-		cfg_new_output_profile.SetInternal(true);
-		cfg_new_output_profile.SetName(new_output_profile_name);
-		cfg_new_output_profile.SetOutputStreamName(new_output_profile_name);
+// STT (Speech-to-Text) output streams.
+        // New config: <OutputProfiles><MediaOptions><STT><Rendition> (preferred)
+        // Legacy config: <Application><Subtitle><Rendition><Transcription> (deprecated, backward compat)
+        // Both may be present (e.g. static legacy config + webhook-injected new config).
+        // New config takes priority per subtitle label; legacy is used as fallback.
+        {
+                auto new_output_profile_name = ov::String::FormatString("TranscriptionProcess_%s", _input_stream->GetName().CStr());
 
-		cfg::vhost::app::oprf::Encodes encodes;
-		int i = 0;
-		for (const auto &subtitle_rendition : cfg_media_option_subtitles.GetRenditions())
-		{
-			bool enabled = false;
-			auto cfg_transcription = subtitle_rendition.GetTranscription(&enabled);
-			if (enabled)
-			{
-				// Make SpeechToTextProfile
-				auto name = ov::String::FormatString("SpeechToText_%d", i);
-				auto engine = cfg_transcription.GetEngine();
-				auto model = cfg_transcription.GetModel();
-				auto model_path = ov::GetFilePath(model, cfg::ConfigManager::GetInstance()->GetConfigPath());
-				// check if the model file exists
-				if (access(model_path.CStr(), F_OK) != 0)
-				{
-					logte("The transcription model file does not exist. model(%s)", model_path.CStr());
-					continue;
-				}
+                cfg::vhost::app::oprf::OutputProfile cfg_new_output_profile;
+                cfg_new_output_profile.SetInternal(true);
+                cfg_new_output_profile.SetName(new_output_profile_name);
+                cfg_new_output_profile.SetOutputStreamName(new_output_profile_name);
 
-				auto input_audio_track = _input_stream->GetMediaTrackByOrder(cmn::MediaType::Audio, cfg_transcription.GetAudioIndexHint());
-				auto output_subtitle_track = _input_stream->GetTrackByLabel(subtitle_rendition.GetLabel());
+                cfg::vhost::app::oprf::Encodes encodes;
+                int i = 0;
 
-				if (input_audio_track == nullptr || output_subtitle_track == nullptr)
-				{
-					logte("Could not find input audio track or output subtitle track for transcription. AudioIndexHint(%d), SubtitleLabel(%s)", cfg_transcription.GetAudioIndexHint(), subtitle_rendition.GetLabel().CStr());
-					continue;
-				}
+                // 1. New config: <MediaOptions><STT>
+                const auto &cfg_stt = GetOutputProfilesCfg()->GetMediaOptions().GetStt();
+                for (const auto &stt_rendition : cfg_stt.GetRenditions())
+                {
+                        auto name = ov::String::FormatString("SpeechToText_%d", i);
+                        auto model_path = ov::GetFilePath(stt_rendition.GetModel(), cfg::ConfigManager::GetInstance()->GetConfigPath());
 
-				cfg::vhost::app::oprf::SpeechToTextProfile speech_to_text_profile(name,
-																				engine,
-																				model_path,
-																				input_audio_track->GetId(),
-																				output_subtitle_track->GetId());
-				speech_to_text_profile.SetSourceLanguage(cfg_transcription.GetSourceLanguage());
-				speech_to_text_profile.SetTranslation(cfg_transcription.GetTranslation());
-				speech_to_text_profile.SetOutputTrackLabel(subtitle_rendition.GetLabel());
+                        auto input_audio_track = _input_stream->GetMediaTrackByOrder(cmn::MediaType::Audio, stt_rendition.GetInputAudioIndex());
+                        auto output_subtitle_track = _input_stream->GetTrackByLabel(stt_rendition.GetOutputSubtitleLabel());
 
-				encodes.AddSpeechToTextProfiles(speech_to_text_profile);
-			}
+                        if (input_audio_track == nullptr || output_subtitle_track == nullptr)
+                        {
+                                logte("Could not find input audio track or output subtitle track for STT. InputAudioIndex(%d), OutputSubtitleLabel(%s)",
+                                        stt_rendition.GetInputAudioIndex(), stt_rendition.GetOutputSubtitleLabel().CStr());
+                                i++;
+                                continue;
+                        }
 
-			cfg_new_output_profile.SetEncodes(encodes);
+                        cfg::vhost::app::oprf::SpeechToTextProfile speech_to_text_profile(name,
+                                                                       stt_rendition.GetEngine(),
+                                                                       model_path,
+                                                                       input_audio_track->GetId(),
+                                                                       output_subtitle_track->GetId());
+                        speech_to_text_profile.SetSourceLanguage(stt_rendition.GetSourceLanguage());
+                        speech_to_text_profile.SetTranslation(stt_rendition.GetTranslation());
+                        speech_to_text_profile.SetOutputTrackLabel(stt_rendition.GetOutputSubtitleLabel());
 
-			i++;
-		}
+                        encodes.AddSpeechToTextProfiles(speech_to_text_profile);
+                        i++;
+                }
 
-		if (cfg_new_output_profile.GetEncodes().GetSpeechToTextProfileList().size() > 0)
-		{
-			auto output_stream = CreateOutputStream(cfg_new_output_profile);
-			if (output_stream == nullptr)
-			{
-				logte("%s Could not create output stream for transcription. name:%s", _log_prefix.CStr(), cfg_new_output_profile.GetName().CStr());
+                cfg_new_output_profile.SetEncodes(encodes);
+
+                if (cfg_new_output_profile.GetEncodes().GetSpeechToTextProfileList().size() > 0)
+                {
+                        auto output_stream = CreateOutputStream(cfg_new_output_profile);
+                        if (output_stream == nullptr)
+                        {
+                                logte("%s Could not create output stream for STT. name:%s", _log_prefix.CStr(), cfg_new_output_profile.GetName().CStr());
 
 #if NOTIFICATION_ENABLED
-				TranscoderAlerts::UpdateErrorWithoutCount(
-					TranscoderAlerts::ErrorType::CREATION_ERROR_PROFILE,
-					std::make_shared<cfg::vhost::app::oprf::OutputProfile>(cfg_new_output_profile),
-					_input_stream,
-					nullptr,
-					nullptr,
-					nullptr);
+                                TranscoderAlerts::UpdateErrorWithoutCount(
+                                        TranscoderAlerts::ErrorType::CREATION_ERROR_PROFILE,
+                                        std::make_shared<cfg::vhost::app::oprf::OutputProfile>(cfg_new_output_profile),
+                                        _input_stream,
+                                        nullptr,
+                                        nullptr,
+                                        nullptr);
 #endif
-			}
-			else
-			{
-				{
-					std::unique_lock<std::shared_mutex> lock(_output_stream_mutex);
-					_output_streams.insert(std::make_pair(output_stream->GetName(), output_stream));
-				}
+                        }
+                        else
+                        {
+                                {
+                                        std::unique_lock<std::shared_mutex> lock(_output_stream_mutex);
+                                        _output_streams.insert(std::make_pair(output_stream->GetName(), output_stream));
+                                }
 
-				logti("%s Output stream(transcription) has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
+                                logti("%s Output stream(STT) has been created. [%s(%u)]", _log_prefix.CStr(), output_stream->GetUri().CStr(), output_stream->GetId());
 			}
 		}
 	}
@@ -1154,6 +1142,15 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 		// Create Encoder
 		if (CreateEncoder(encoder_id, output_stream, output_track) == false)
 		{
+			// Whisper (STT) encoder failure is non-fatal: GPU OOM or resource exhaustion
+			// should not bring down the whole stream. Log a warning and skip.
+			if (output_track->GetCodecId() == cmn::MediaCodecId::Whisper)
+			{
+				logtw("%s Could not create Whisper encoder — STT disabled for this stream. Id(%d), OutputTrack(%d)", _log_prefix.CStr(),
+					  encoder_id, output_track->GetId());
+				continue;
+			}
+
 			logte("%s Could not create encoder. Id(%d)<Codec:%s,Module:%s:%d>, OutputTrack(%d)", _log_prefix.CStr(),
 				  encoder_id, cmn::GetCodecIdString(output_track->GetCodecId()), cmn::GetCodecModuleIdString(output_track->GetCodecModuleId()), output_track->GetCodecDeviceId(), output_track->GetId());	
 

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -721,6 +721,7 @@ size_t TranscoderStream::CreateOutputStreams()
                         }
                         else
                         {
+                                output_stream->SetInternal(true);
                                 {
                                         std::unique_lock<std::shared_mutex> lock(_output_stream_mutex);
                                         _output_streams.insert(std::make_pair(output_stream->GetName(), output_stream));

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -659,7 +659,7 @@ size_t TranscoderStream::CreateOutputStreams()
         // Both may be present (e.g. static legacy config + webhook-injected new config).
         // New config takes priority per subtitle label; legacy is used as fallback.
         {
-                auto new_output_profile_name = ov::String::FormatString("TranscriptionProcess_%s", _input_stream->GetName().CStr());
+                auto new_output_profile_name = ov::String::FormatString("%s#stt", _input_stream->GetName().CStr());
 
                 cfg::vhost::app::oprf::OutputProfile cfg_new_output_profile;
                 cfg_new_output_profile.SetInternal(true);
@@ -1143,11 +1143,10 @@ bool TranscoderStream::CreateEncoders(std::shared_ptr<MediaFrame> buffer)
 		// Create Encoder
 		if (CreateEncoder(encoder_id, output_stream, output_track) == false)
 		{
-			// Whisper (STT) encoder failure is non-fatal: GPU OOM or resource exhaustion
-			// should not bring down the whole stream. Log a warning and skip.
-			if (output_track->GetCodecId() == cmn::MediaCodecId::Whisper)
+			// Non-essential track: encoder failure is not fatal, stream continues without it.
+			if (output_track->IsEssentialTrack() == false)
 			{
-				logtw("%s Could not create Whisper encoder — STT disabled for this stream. Id(%d), OutputTrack(%d)", _log_prefix.CStr(),
+				logtw("%s Could not create encoder for non-essential track — disabled for this stream. Id(%d), OutputTrack(%d)", _log_prefix.CStr(),
 					  encoder_id, output_track->GetId());
 				continue;
 			}

--- a/src/projects/transcoder/transcoder_stream.h
+++ b/src/projects/transcoder/transcoder_stream.h
@@ -50,6 +50,12 @@ public:
 	bool Update(const std::shared_ptr<info::Stream> &stream);
 	bool Push(std::shared_ptr<MediaPacket> packet);
 
+	bool PauseEncoders(cmn::MediaCodecId codec_id);
+	bool ResumeEncoders(cmn::MediaCodecId codec_id);
+	bool IsEncoderPaused(cmn::MediaCodecId codec_id);
+	ov::String GetInputStreamName() const;
+	std::vector<TranscodeEncoder::EncoderInfo> GetEncoderInfoList(cmn::MediaCodecId codec_id);
+
 	// Notify event to mediarouter
 	void NotifyCreateStreams();
 	void NotifyDeleteStreams();

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -615,6 +615,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetStepMs(profile.GetStepMs());
 	output_track->SetLengthMs(profile.GetLengthMs());
 	output_track->SetKeepMs(profile.GetKeepMs());
+	output_track->SetSttEnabled(profile.IsSttEnabled());
 
 	output_track->SetExtraInfo(ov::String::FormatString(
 		"Engine(%s) Model(%s) AudioInput(%d) Language(%s)",

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -602,6 +602,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetLanguage(profile.GetSourceLanguage());
 	
 	output_track->SetCodecId(cmn::MediaCodecId::Whisper);
+	output_track->SetCodecModules(profile.GetModules());
 	
 	output_track->SetOriginBitstream(input_track->GetOriginBitstream());
 	output_track->SetTimeBase(input_track->GetTimeBase());

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -597,8 +597,8 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 
 	output_track->SetMediaType(cmn::MediaType::Subtitle);
 	output_track->SetId(NewTrackId());
-	output_track->SetVariantName(ov::String::FormatString("SpeechToText_%d", output_track->GetId()));
-	output_track->SetPublicName(ov::String::FormatString("SpeechToText_%d", output_track->GetId()));
+	output_track->SetVariantName(profile.GetOutputTrackLabel());
+	output_track->SetPublicName(profile.GetOutputTrackLabel());
 	output_track->SetLanguage(profile.GetSourceLanguage());
 	
 	output_track->SetCodecId(cmn::MediaCodecId::Whisper);
@@ -612,6 +612,16 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetSourceLanguage(profile.GetSourceLanguage());
 	output_track->SetTranslation(profile.ShouldTranslate());
 	output_track->SetOutputLabel(profile.GetOutputTrackLabel());
+
+	output_track->SetExtraInfo(ov::String::FormatString(
+		"Engine(%s) Model(%s) AudioInput(%d) Language(%s)",
+		profile.GetEngine().CStr(),
+		profile.GetModel().CStr(),
+		input_track->GetId(),
+		profile.GetSourceLanguage().CStr()));
+
+	// STT track is non-essential: encoder failure is not fatal and the stream continues without it.
+	output_track->SetEssentialTrack(false);
 
 	if (profile.GetEngine().LowerCaseString() == "whisper")
 	{

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -612,6 +612,9 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetSourceLanguage(profile.GetSourceLanguage());
 	output_track->SetTranslation(profile.ShouldTranslate());
 	output_track->SetOutputLabel(profile.GetOutputTrackLabel());
+	output_track->SetStepMs(profile.GetStepMs());
+	output_track->SetLengthMs(profile.GetLengthMs());
+	output_track->SetKeepMs(profile.GetKeepMs());
 
 	output_track->SetExtraInfo(ov::String::FormatString(
 		"Engine(%s) Model(%s) AudioInput(%d) Language(%s)",

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -1,0 +1,235 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#include <algorithm>
+#include <sys/stat.h>
+
+#ifdef HWACCELS_NVIDIA_ENABLED
+#include <cuda_runtime.h>
+#endif
+
+#include "transcoder_whisper_model_registry.h"
+#include "transcoder_private.h"
+
+bool WhisperModelRegistry::Preload(const std::vector<ov::String> &model_paths)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	// Sort by file size descending so larger models are loaded first.
+	// This maximizes GPU utilization: the biggest model claims GPU memory first,
+	// and smaller models fill whatever remains (or fall back to CPU).
+	auto sorted_paths = model_paths;
+	std::sort(sorted_paths.begin(), sorted_paths.end(), [](const ov::String &a, const ov::String &b) {
+		struct stat sa{}, sb{};
+		off_t size_a = (::stat(a.CStr(), &sa) == 0) ? sa.st_size : 0;
+		off_t size_b = (::stat(b.CStr(), &sb) == 0) ? sb.st_size : 0;
+		return size_a > size_b;  // descending
+	});
+
+	for (const auto &path : sorted_paths)
+	{
+		LoadModel(path);
+	}
+
+	return true;
+}
+
+// Caller must hold _mutex.
+void WhisperModelRegistry::LoadModel(const ov::String &path)
+{
+	const std::string key = path.CStr();
+
+	if (_models.count(key) > 0)
+	{
+		logtw("Whisper model already loaded, skipping duplicate. path=%s", path.CStr());
+		return;
+	}
+
+	// Whisper requires a GPU for real-time live transcription.
+	// CPU inference is too slow (several times slower than real-time) and is not supported.
+#ifndef HWACCELS_NVIDIA_ENABLED
+	logte("Whisper requires NVIDIA GPU support. Rebuild with OME_HWACCEL_NVIDIA=ON. path=%s", path.CStr());
+	return;
+#endif
+
+	struct whisper_context_params cparams = whisper_context_default_params();
+	cparams.flash_attn = true;
+
+	// Check free GPU memory before calling whisper_init_from_file_with_params().
+	// ggml calls abort() on CUDA OOM instead of returning an error, so we must
+	// pre-flight check. Required: model file size * 2 (weights + kv cache + compute buffers).
+#ifdef HWACCELS_NVIDIA_ENABLED
+	{
+		struct stat model_stat{};
+		size_t model_file_bytes = 0;
+		if (::stat(path.CStr(), &model_stat) == 0)
+		{
+			model_file_bytes = static_cast<size_t>(model_stat.st_size);
+		}
+
+		size_t required_bytes = model_file_bytes * 2;
+		size_t free_mem = 0, total_mem = 0;
+		if (cudaMemGetInfo(&free_mem, &total_mem) != cudaSuccess)
+		{
+			logte("cudaMemGetInfo failed — cannot load Whisper model. path=%s", path.CStr());
+			return;
+		}
+
+		if (free_mem < required_bytes)
+		{
+			logte("Not enough GPU memory for Whisper model (free=%.1f MiB, required≈%.1f MiB). path=%s",
+				static_cast<double>(free_mem) / (1024.0 * 1024.0),
+				static_cast<double>(required_bytes) / (1024.0 * 1024.0),
+				path.CStr());
+			return;
+		}
+
+		logti("Whisper GPU init: free=%.1f MiB, required≈%.1f MiB. path=%s",
+			static_cast<double>(free_mem) / (1024.0 * 1024.0),
+			static_cast<double>(required_bytes) / (1024.0 * 1024.0),
+			path.CStr());
+	}
+#endif
+
+	cparams.use_gpu = true;
+
+	// libcublas lazy-initializes its global state in two phases without thread safety.
+	// Phase 1: whisper_init_from_file_with_params() → cublasCreate().
+	// Phase 2: first GEMM call → pthread_rwlock_init (triggered by warmup below).
+	// All loads happen sequentially under _mutex, so races are prevented.
+	auto raw_ctx = whisper_init_from_file_with_params(path.CStr(), cparams);
+	if (raw_ctx == nullptr)
+	{
+		logte("Failed to load Whisper model. path=%s", path.CStr());
+		return;
+	}
+
+	// Wrap in shared_ptr with whisper_free as custom deleter.
+	auto ctx = std::shared_ptr<whisper_context>(raw_ctx, [](whisper_context *c) {
+		whisper_free(c);
+	});
+
+	// Warmup: GPU only — force phase-2 libcublas init (first GEMM call) by running
+	// a full inference pass on 1 second of silence via a temporary state.
+	// Also measures GPU memory consumed by one state for later OOM prevention.
+	// Warmup: force phase-2 libcublas init (first GEMM call) by running a full inference
+	// pass on 1 second of silence. Also measures GPU memory consumed by one state
+	// for OOM pre-checks in NewState().
+#ifdef HWACCELS_NVIDIA_ENABLED
+	{
+		size_t free_before = 0, free_after = 0, total = 0;
+		cudaMemGetInfo(&free_before, &total);
+		auto warmup_state = whisper_init_state(ctx.get());
+		if (warmup_state != nullptr)
+		{
+			cudaMemGetInfo(&free_after, &total);
+			size_t state_cost = (free_before > free_after) ? (free_before - free_after) : 0;
+			_state_memory_bytes[key] = state_cost;
+			logti("Whisper state memory cost: %.1f MiB per instance. path=%s",
+				static_cast<double>(state_cost) / (1024.0 * 1024.0), path.CStr());
+
+			std::vector<float> silence(WHISPER_SAMPLE_RATE, 0.0f);
+			whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+			wparams.print_progress   = false;
+			wparams.print_special    = false;
+			wparams.print_realtime   = false;
+			wparams.print_timestamps = false;
+			wparams.n_threads        = 1;
+			wparams.language         = "en";
+			wparams.no_context       = true;
+			whisper_full_with_state(ctx.get(), warmup_state, wparams, silence.data(), static_cast<int>(silence.size()));
+			whisper_free_state(warmup_state);
+		}
+	}
+#endif
+
+	_models[key] = std::move(ctx);
+	logti("Whisper model loaded successfully. path=%s", path.CStr());
+}
+
+void WhisperModelRegistry::Uninitialize()
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+	_models.clear();
+	_state_memory_bytes.clear();
+	logti("Whisper model registry cleared.");
+}
+
+std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov::String &model_path)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	const std::string key = model_path.CStr();
+
+	auto it = _models.find(key);
+	if (it != _models.end())
+	{
+		return it->second;
+	}
+
+	// Model not preloaded — load on-demand and cache it for future callers.
+	logti("Whisper model not preloaded, loading on-demand. path=%s", model_path.CStr());
+	LoadModel(model_path);
+
+	it = _models.find(key);
+	if (it == _models.end())
+	{
+		// Loading failed (error already logged inside _LoadModel).
+		return nullptr;
+	}
+
+	return it->second;
+}
+
+whisper_state *WhisperModelRegistry::NewState(const ov::String &model_path)
+{
+	std::lock_guard<std::mutex> lock(_mutex);
+
+	const std::string key = model_path.CStr();
+
+	auto model_it = _models.find(key);
+	if (model_it == _models.end())
+	{
+		logte("Cannot allocate whisper state: model not loaded. path=%s", model_path.CStr());
+		return nullptr;
+	}
+
+#ifdef HWACCELS_NVIDIA_ENABLED
+	// Check GPU memory before calling whisper_init_state to prevent ggml crash.
+	// The mutex ensures serialize check+alloc across all encoder threads.
+	auto mem_it = _state_memory_bytes.find(key);
+	if (mem_it != _state_memory_bytes.end() && mem_it->second > 0)
+	{
+		size_t required = mem_it->second;
+		size_t free_mem = 0, total_mem = 0;
+		if (cudaMemGetInfo(&free_mem, &total_mem) == cudaSuccess && free_mem < required)
+		{
+			logte("Not enough GPU memory to create Whisper state (required=%.1f MiB, free=%.1f MiB). path=%s",
+				  static_cast<double>(required) / (1024.0 * 1024.0),
+				  static_cast<double>(free_mem) / (1024.0 * 1024.0),
+				  model_path.CStr());
+			return nullptr;
+		}
+	}
+#endif
+
+	auto *state = whisper_init_state(model_it->second.get());
+	if (state == nullptr)
+	{
+		logte("whisper_init_state failed. path=%s", model_path.CStr());
+	}
+	return state;
+}
+
+void WhisperModelRegistry::DeleteState(whisper_state *state)
+{
+	if (state != nullptr)
+	{
+		whisper_free_state(state);
+	}
+}

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -16,7 +16,7 @@
 #include "transcoder_whisper_model_registry.h"
 #include "transcoder_private.h"
 
-bool WhisperModelRegistry::Preload(const std::vector<ov::String> &model_paths)
+bool WhisperModelRegistry::Preload(const std::vector<std::pair<ov::String, std::vector<int32_t>>> &models)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 
@@ -32,36 +32,55 @@ bool WhisperModelRegistry::Preload(const std::vector<ov::String> &model_paths)
 	return false;
 #endif // HWACCELS_NVIDIA_ENABLED
 
-	// Sort by file size descending so larger models are loaded first.
-	// This maximizes GPU utilization: the biggest model claims GPU memory first,
-	// and smaller models fill whatever remains.
-	auto sorted_paths = model_paths;
-	std::sort(sorted_paths.begin(), sorted_paths.end(), [](const ov::String &a, const ov::String &b) {
+	// Sort models by file size descending within each device so the largest model
+	// claims GPU memory first, leaving smaller models to fill whatever remains.
+	auto sorted_models = models;
+	std::sort(sorted_models.begin(), sorted_models.end(), [](const auto &a, const auto &b) {
 		struct stat sa{}, sb{};
-		off_t size_a = (::stat(a.CStr(), &sa) == 0) ? sa.st_size : 0;
-		off_t size_b = (::stat(b.CStr(), &sb) == 0) ? sb.st_size : 0;
+		off_t size_a = (::stat(a.first.CStr(), &sa) == 0) ? sa.st_size : 0;
+		off_t size_b = (::stat(b.first.CStr(), &sb) == 0) ? sb.st_size : 0;
 		return size_a > size_b;  // descending
 	});
 
-	for (const auto &path : sorted_paths)
+	for (const auto &[path, device_ids] : sorted_models)
 	{
-		LoadModel(path);
+#ifdef HWACCELS_NVIDIA_ENABLED
+		if (device_ids.empty())
+		{
+			// Empty list = "all" — load on every available CUDA device.
+			for (int32_t dev = 0; dev < device_count; ++dev)
+			{
+				LoadModel(path, dev);
+			}
+		}
+		else
+		{
+			for (int32_t dev : device_ids)
+			{
+				if (dev < 0 || dev >= device_count)
+				{
+					logtw("Whisper preload: CUDA device %d does not exist (device_count=%d), skipping. path=%s", dev, device_count, path.CStr());
+					continue;
+				}
+				LoadModel(path, dev);
+			}
+		}
+#endif
 	}
 
 	return true;
 }
 
 // Caller must hold _mutex.
-void WhisperModelRegistry::LoadModel(const ov::String &path)
+void WhisperModelRegistry::LoadModel(const ov::String &path, int32_t cuda_device_id)
 {
-	const std::string key = path.CStr();
+	const std::string key = ov::String::FormatString("%s@%d", path.CStr(), cuda_device_id).CStr();
 
 	if (_models.count(key) > 0)
 	{
-		logtw("Whisper model already loaded, skipping duplicate. path=%s", path.CStr());
+		logtw("Whisper model already loaded on device %d, skipping duplicate. path=%s", cuda_device_id, path.CStr());
 		return;
 	}
-
 	// Whisper requires a GPU for real-time live transcription.
 	// CPU inference is too slow (several times slower than real-time) and is not supported.
 #ifndef HWACCELS_NVIDIA_ENABLED
@@ -77,6 +96,8 @@ void WhisperModelRegistry::LoadModel(const ov::String &path)
 	// pre-flight check. Required: model file size * 2 (weights + kv cache + compute buffers).
 #ifdef HWACCELS_NVIDIA_ENABLED
 	{
+		cudaSetDevice(cuda_device_id);
+
 		struct stat model_stat{};
 		size_t model_file_bytes = 0;
 		if (::stat(path.CStr(), &model_stat) == 0)
@@ -89,20 +110,22 @@ void WhisperModelRegistry::LoadModel(const ov::String &path)
 		cudaError_t cuda_err = cudaMemGetInfo(&free_mem, &total_mem);
 		if (cuda_err != cudaSuccess)
 		{
-			logte("Failed to query GPU memory for Whisper model (CUDA: %s). path=%s", cudaGetErrorString(cuda_err), path.CStr());
+			logte("Failed to query GPU memory for Whisper model on device %d (CUDA: %s). path=%s", cuda_device_id, cudaGetErrorString(cuda_err), path.CStr());
 			return;
 		}
 
 		if (free_mem < required_bytes)
 		{
-			logte("Not enough GPU memory for Whisper model (free=%.1f MiB, required≈%.1f MiB). path=%s",
+			logte("Not enough GPU memory for Whisper model on device %d (free=%.1f MiB, required≈%.1f MiB). path=%s",
+				cuda_device_id,
 				static_cast<double>(free_mem) / (1024.0 * 1024.0),
 				static_cast<double>(required_bytes) / (1024.0 * 1024.0),
 				path.CStr());
 			return;
 		}
 
-		logti("Whisper GPU init: free=%.1f MiB, required≈%.1f MiB. path=%s",
+		logti("Whisper GPU init on device %d: free=%.1f MiB, required≈%.1f MiB. path=%s",
+			cuda_device_id,
 			static_cast<double>(free_mem) / (1024.0 * 1024.0),
 			static_cast<double>(required_bytes) / (1024.0 * 1024.0),
 			path.CStr());
@@ -110,6 +133,7 @@ void WhisperModelRegistry::LoadModel(const ov::String &path)
 #endif
 
 	cparams.use_gpu = true;
+	cparams.gpu_device = cuda_device_id;
 
 	// libcublas lazy-initializes its global state in two phases without thread safety.
 	// Phase 1: whisper_init_from_file_with_params() → cublasCreate().
@@ -162,7 +186,7 @@ void WhisperModelRegistry::LoadModel(const ov::String &path)
 #endif
 
 	_models[key] = std::move(ctx);
-	logti("Whisper model loaded successfully. path=%s", path.CStr());
+	logti("Whisper model loaded successfully on device %d. path=%s", cuda_device_id, path.CStr());
 }
 
 void WhisperModelRegistry::Uninitialize()
@@ -173,11 +197,11 @@ void WhisperModelRegistry::Uninitialize()
 	logti("Whisper model registry cleared.");
 }
 
-std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov::String &model_path)
+std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov::String &model_path, int32_t cuda_device_id)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 
-	const std::string key = model_path.CStr();
+	const std::string key = ov::String::FormatString("%s@%d", model_path.CStr(), cuda_device_id).CStr();
 
 	auto it = _models.find(key);
 	if (it != _models.end())
@@ -186,35 +210,36 @@ std::shared_ptr<whisper_context> WhisperModelRegistry::GetModelContext(const ov:
 	}
 
 	// Model not preloaded — load on-demand and cache it for future callers.
-	logti("Whisper model not preloaded, loading on-demand. path=%s", model_path.CStr());
-	LoadModel(model_path);
+	logti("Whisper model not preloaded on device %d, loading on-demand. path=%s", cuda_device_id, model_path.CStr());
+	LoadModel(model_path, cuda_device_id);
 
 	it = _models.find(key);
 	if (it == _models.end())
 	{
-		// Loading failed (error already logged inside _LoadModel).
+		// Loading failed (error already logged inside LoadModel).
 		return nullptr;
 	}
 
 	return it->second;
 }
 
-whisper_state *WhisperModelRegistry::NewState(const ov::String &model_path)
+whisper_state *WhisperModelRegistry::NewState(const ov::String &model_path, int32_t cuda_device_id)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 
-	const std::string key = model_path.CStr();
+	const std::string key = ov::String::FormatString("%s@%d", model_path.CStr(), cuda_device_id).CStr();
 
 	auto model_it = _models.find(key);
 	if (model_it == _models.end())
 	{
-		logte("Cannot allocate whisper state: model not loaded. path=%s", model_path.CStr());
+		logte("Cannot allocate whisper state: model not loaded on device %d. path=%s", cuda_device_id, model_path.CStr());
 		return nullptr;
 	}
 
 #ifdef HWACCELS_NVIDIA_ENABLED
 	// Check GPU memory before calling whisper_init_state to prevent ggml crash.
 	// The mutex ensures serialize check+alloc across all encoder threads.
+	cudaSetDevice(cuda_device_id);
 	auto mem_it = _state_memory_bytes.find(key);
 	if (mem_it != _state_memory_bytes.end() && mem_it->second > 0)
 	{
@@ -222,7 +247,8 @@ whisper_state *WhisperModelRegistry::NewState(const ov::String &model_path)
 		size_t free_mem = 0, total_mem = 0;
 		if (cudaMemGetInfo(&free_mem, &total_mem) == cudaSuccess && free_mem < required)
 		{
-			logte("Not enough GPU memory to create Whisper state (required=%.1f MiB, free=%.1f MiB). path=%s",
+			logte("Not enough GPU memory on device %d to create Whisper state (required=%.1f MiB, free=%.1f MiB). path=%s",
+				  cuda_device_id,
 				  static_cast<double>(required) / (1024.0 * 1024.0),
 				  static_cast<double>(free_mem) / (1024.0 * 1024.0),
 				  model_path.CStr());

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -34,7 +34,7 @@ bool WhisperModelRegistry::Preload(const std::vector<ov::String> &model_paths)
 
 	// Sort by file size descending so larger models are loaded first.
 	// This maximizes GPU utilization: the biggest model claims GPU memory first,
-	// and smaller models fill whatever remains (or fall back to CPU).
+	// and smaller models fill whatever remains.
 	auto sorted_paths = model_paths;
 	std::sort(sorted_paths.begin(), sorted_paths.end(), [](const ov::String &a, const ov::String &b) {
 		struct stat sa{}, sb{};

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -20,6 +20,18 @@ bool WhisperModelRegistry::Preload(const std::vector<ov::String> &model_paths)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 
+#ifdef HWACCELS_NVIDIA_ENABLED
+	int device_count = 0;
+	if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0)
+	{
+		logtw("Whisper STT requires an NVIDIA GPU, but no NVIDIA device is available. Whisper models will not be loaded.");
+		return false;
+	}
+#else // HWACCELS_NVIDIA_ENABLED
+	logtw("Whisper requires NVIDIA GPU support (rebuild with OME_HWACCEL_NVIDIA=ON). Whisper models will not be loaded.");
+	return false;
+#endif // HWACCELS_NVIDIA_ENABLED
+
 	// Sort by file size descending so larger models are loaded first.
 	// This maximizes GPU utilization: the biggest model claims GPU memory first,
 	// and smaller models fill whatever remains (or fall back to CPU).
@@ -74,9 +86,10 @@ void WhisperModelRegistry::LoadModel(const ov::String &path)
 
 		size_t required_bytes = model_file_bytes * 2;
 		size_t free_mem = 0, total_mem = 0;
-		if (cudaMemGetInfo(&free_mem, &total_mem) != cudaSuccess)
+		cudaError_t cuda_err = cudaMemGetInfo(&free_mem, &total_mem);
+		if (cuda_err != cudaSuccess)
 		{
-			logte("cudaMemGetInfo failed — cannot load Whisper model. path=%s", path.CStr());
+			logte("Failed to query GPU memory for Whisper model (CUDA: %s). path=%s", cudaGetErrorString(cuda_err), path.CStr());
 			return;
 		}
 

--- a/src/projects/transcoder/transcoder_whisper_model_registry.cpp
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.cpp
@@ -47,7 +47,7 @@ bool WhisperModelRegistry::Preload(const std::vector<std::pair<ov::String, std::
 #ifdef HWACCELS_NVIDIA_ENABLED
 		if (device_ids.empty())
 		{
-			// Empty list = "all" — load on every available CUDA device.
+			// "all" — load on every available CUDA device.
 			for (int32_t dev = 0; dev < device_count; ++dev)
 			{
 				LoadModel(path, dev);

--- a/src/projects/transcoder/transcoder_whisper_model_registry.h
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.h
@@ -21,28 +21,29 @@
 class WhisperModelRegistry : public ov::Singleton<WhisperModelRegistry>
 {
 public:
-	// Eagerly load the given model paths. Optional — call at server start to preload.
-	// model_paths may be absolute or already-resolved paths.
-	bool Preload(const std::vector<ov::String> &model_paths);
+// Eagerly load the given models. Optional — call at server start to preload.
+        // Each entry is a (resolved_path, cuda_device_ids) pair.
+        // An empty device_ids list means "load on all available CUDA devices".
+        bool Preload(const std::vector<std::pair<ov::String, std::vector<int32_t>>> &models);
 
 	// Release all loaded models. Called at server stop.
 	void Uninitialize();
 
-	// Return a shared_ptr to the whisper_context for the given model path.
-	// If the model is not yet loaded it will be loaded on-demand and cached.
-	std::shared_ptr<whisper_context> GetModelContext(const ov::String &model_path);
+// Return a shared_ptr to the whisper_context for the given model path and CUDA device.
+        // If the model is not yet loaded on that device it will be loaded on-demand and cached.
+        std::shared_ptr<whisper_context> GetModelContext(const ov::String &model_path, int32_t cuda_device_id = 0);
 
-	// Allocate a per-encoder whisper_state for the given model.
-	// Checks GPU memory availability before allocation to prevent ggml crash.
-	// Returns nullptr if the model is not loaded or GPU memory is insufficient.
-	whisper_state *NewState(const ov::String &model_path);
+        // Allocate a per-encoder whisper_state for the given model and CUDA device.
+        // Checks GPU memory availability before allocation to prevent ggml crash.
+        // Returns nullptr if the model is not loaded or GPU memory is insufficient.
+        whisper_state *NewState(const ov::String &model_path, int32_t cuda_device_id = 0);
 
-	// Free a whisper_state previously returned by NewState.
-	void DeleteState(whisper_state *state);
+        // Free a whisper_state previously returned by NewState.
+        void DeleteState(whisper_state *state);
 
 private:
-	// Load a single model and insert it into _models. Caller must hold _mutex.
-	void LoadModel(const ov::String &model_path);
+        // Load a single model on the specified CUDA device and cache it. Caller must hold _mutex.
+        void LoadModel(const ov::String &model_path, int32_t cuda_device_id = 0);
 
 	std::mutex _mutex;
 	std::unordered_map<std::string, std::shared_ptr<whisper_context>> _models;

--- a/src/projects/transcoder/transcoder_whisper_model_registry.h
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.h
@@ -1,0 +1,52 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Getroot
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <whisper.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <base/ovlibrary/ovlibrary.h>
+
+class WhisperModelRegistry : public ov::Singleton<WhisperModelRegistry>
+{
+public:
+	// Eagerly load the given model paths. Optional — call at server start to preload.
+	// model_paths may be absolute or already-resolved paths.
+	bool Preload(const std::vector<ov::String> &model_paths);
+
+	// Release all loaded models. Called at server stop.
+	void Uninitialize();
+
+	// Return a shared_ptr to the whisper_context for the given model path.
+	// If the model is not yet loaded it will be loaded on-demand and cached.
+	std::shared_ptr<whisper_context> GetModelContext(const ov::String &model_path);
+
+	// Allocate a per-encoder whisper_state for the given model.
+	// Checks GPU memory availability before allocation to prevent ggml crash.
+	// Returns nullptr if the model is not loaded or GPU memory is insufficient.
+	whisper_state *NewState(const ov::String &model_path);
+
+	// Free a whisper_state previously returned by NewState.
+	void DeleteState(whisper_state *state);
+
+private:
+	// Load a single model and insert it into _models. Caller must hold _mutex.
+	void LoadModel(const ov::String &model_path);
+
+	std::mutex _mutex;
+	std::unordered_map<std::string, std::shared_ptr<whisper_context>> _models;
+	// GPU memory (bytes) consumed by one whisper_state for each model.
+	// Populated during GPU warmup; 0 means CPU model (no pre-check needed).
+	std::unordered_map<std::string, size_t> _state_memory_bytes;
+};

--- a/src/projects/transcoder/transcoder_whisper_model_registry.h
+++ b/src/projects/transcoder/transcoder_whisper_model_registry.h
@@ -23,7 +23,8 @@ class WhisperModelRegistry : public ov::Singleton<WhisperModelRegistry>
 public:
 // Eagerly load the given models. Optional — call at server start to preload.
         // Each entry is a (resolved_path, cuda_device_ids) pair.
-        // An empty device_ids list means "load on all available CUDA devices".
+        // An empty device_ids list means "all available CUDA devices" (from <Devices>all</Devices>).
+        // A single-element list {0} means the default (omitted <Devices>).
         bool Preload(const std::vector<std::pair<ov::String, std::vector<int32_t>>> &models);
 
 	// Release all loaded models. Called at server stop.


### PR DESCRIPTION
## Overview

Redesigns the STT subsystem to decouple speech-to-text configuration from subtitle rendition definitions, adds a Whisper model registry for shared GPU model management, and improves robustness when NVIDIA hardware is unavailable.

## Breaking Changes

- `<Subtitles><Rendition><Transcription>` has been removed. STT is now configured under `<OutputProfiles><MediaOptions><STT>`. See the updated documentation for migration details.
- CPU inference is no longer supported. An NVIDIA GPU is now required for Whisper STT.

## Key Changes

**Configuration restructure**
- STT config moved to `<OutputProfiles><MediaOptions><STT><Rendition>` — separates subtitle track definitions from transcription logic
- `<Modules><Whisper><PreloadModel>` added to Server.xml for preloading Whisper models into GPU memory at startup
- Using deprecated `<Transcription>` now logs a warning instead of crashing OME on startup

**Whisper model registry**
- Shared `WhisperModelRegistry` loads each model once and shares it across encoder instances, avoiding redundant GPU memory allocation
- Pre-flight GPU memory check before model load to prevent `abort()` from ggml on CUDA OOM
- `cudaGetDeviceCount` check in `Preload()` and `Configure()` for early exit when no NVIDIA device is available

**Transcoder improvements**
- `MediaTrack` extended with `CodecStatus`, `ExtraInfo`, and `IsEssentialTrack` for STT track lifecycle tracking
- `CreateFilter()` skips filter creation when the paired encoder failed
- `SpreadToFilters()` skips `CloneFrame()` when no filter is registered for a decoder output
- STT processing streams are marked as internal and hidden from Publishers (HLS, WebRTC, etc.), preventing clients from subscribing to them directly

**API**
- GET Stream API response now includes detailed track info (codec status, extra info, essential flag)

**Build / Docs**
- CUDA architecture 61 (Pascal) added to `prerequisites.sh` to match `InstallPrerequisites.cmake`
- `realtime-speech-to-text.md` updated to reflect the new configuration structure

## Whisper sliding-window tuning parameters

Added `StepMs`, `LengthMs`, and `KeepMs` as optional fields under `<STT><Rendition>`. When omitted, the updated defaults below are used.

- `StepMs` (default: 2000): Amount of new audio (ms) to collect before running inference. Directly affects subtitle latency and must exceed the model's inference time.
- `LengthMs` (default: 10000): Total audio window size (ms) passed to Whisper per inference call. Larger values improve context-aware accuracy.
- `KeepMs` (default: 1500): Audio overlap (ms) retained from the previous window after a context reset. Mitigates quality degradation immediately following a reset.

The previous defaults (`LengthMs=8000`, `KeepMs=100`) caused the minimum window after a reset to be only 2.1 s. With the new defaults, that rises to 3.5 s.

```xml
<STT>
    <Rendition>
        <Engine>whisper</Engine>
        <Model>whisper_model/ggml-small.bin</Model>
        <Modules>nv:0</Modules>
        <OutputSubtitleLabel>Korean</OutputSubtitleLabel>
        <SourceLanguage>auto</SourceLanguage>
        <StepMs>2000</StepMs>
        <LengthMs>10000</LengthMs>
        <KeepMs>1500</KeepMs>
    </Rendition>
</STT>
```

## Runtime STT Control API

Added REST API endpoints to pause and resume STT inference at runtime without restarting the server.

- `POST :enableStt` — Resume STT inference for the stream
- `POST :disableStt` — Pause STT inference (audio frames are dropped, freeing GPU resources)
- `POST :sttStatus` — Get current enabled state and active rendition list

Full API reference: `docs/rest-api/v1/virtualhost/application/stream/stt-control.md`

## Multi-GPU Distribution

Added `<Modules>` to `<STT><Rendition>` and `<Devices>` to `<PreloadModel>` so Whisper instances can be distributed across multiple GPUs.

- `<Modules>nv:0</Modules>` on each STT rendition selects the GPU (same format as `<Video><Modules>`)
- `<PreloadModel><Devices>0,1</Devices>` controls which GPUs to preload a model onto at startup. If omitted, defaults to device 0. Set to `all` to load on every available GPU.
- The model registry keys models as `path@device_id`, so the same model file loaded on different GPUs is managed as separate cached contexts.

```xml
<Modules>
    <Whisper>
        <PreloadModel>
            <Path>whisper_model/ggml-small.bin</Path>
            <Devices>0,1</Devices>
        </PreloadModel>
    </Whisper>
</Modules>

<STT>
    <Rendition>
        <Engine>whisper</Engine>
        <Model>whisper_model/ggml-small.bin</Model>
        <Modules>nv:0</Modules>
        <OutputSubtitleLabel>Korean</OutputSubtitleLabel>
        <SourceLanguage>auto</SourceLanguage>
    </Rendition>
    <Rendition>
        <Engine>whisper</Engine>
        <Model>whisper_model/ggml-small.bin</Model>
        <Modules>nv:1</Modules>
        <OutputSubtitleLabel>English</OutputSubtitleLabel>
        <SourceLanguage>auto</SourceLanguage>
        <Translation>true</Translation>
    </Rendition>
</STT>
```
