### PR TITLE
fix: resolve data races in provider stream

### DIFF
--- a/src/projects/base/provider/push_provider/stream.cpp
+++ b/src/projects/base/provider/push_provider/stream.cpp
@@ -15,6 +15,16 @@
 
 namespace pvd
 {
+	namespace
+	{
+		int64_t SteadyNowMs()
+		{
+			return std::chrono::duration_cast<std::chrono::milliseconds>(
+					   std::chrono::steady_clock::now().time_since_epoch())
+				.count();
+		}
+	}  // namespace
+
 	PushStream::PushStream(StreamSourceType source_type, ov::String channel_name, uint32_t channel_id, const std::shared_ptr<PushProvider> &provider)
 		: PushStream(source_type, channel_id, provider)
 	{
@@ -73,7 +83,7 @@ namespace pvd
 
 	void PushStream::UpdateLastReceivedTime()
 	{
-		_last_received_time_ms = ov::Time::GetTimestampInMs();
+		_last_received_time_ms = SteadyNowMs();
 	}
 
 	void PushStream::SetPacketSilenceTimeoutMs(time_t timeout_ms)
@@ -94,7 +104,7 @@ namespace pvd
 			return -1;
 		}
 
-		return static_cast<time_t>(ov::Time::GetTimestampInMs() - last_received_time_ms);
+		return static_cast<time_t>(SteadyNowMs() - last_received_time_ms);
 	}
 
 	bool PushStream::PublishChannel(const info::VHostAppName &vhost_app_name)
@@ -108,7 +118,7 @@ namespace pvd
 		
 		_is_published = GetProvider()->PublishChannel(GetChannelId(), vhost_app_name, GetSharedPtrAs<PushStream>());
 
-		_last_received_time_ms = ov::Time::GetTimestampInMs();
+		_last_received_time_ms = SteadyNowMs();
 
 		return _is_published;
 	}
@@ -145,4 +155,4 @@ namespace pvd
 
 		return true;
 	}
-}
+}  // namespace pvd

--- a/src/projects/base/provider/push_provider/stream.cpp
+++ b/src/projects/base/provider/push_provider/stream.cpp
@@ -73,7 +73,7 @@ namespace pvd
 
 	void PushStream::UpdateLastReceivedTime()
 	{
-		_packet_silence_timer.Update();
+		_last_received_time_ms = ov::Time::GetTimestampInMs();
 	}
 
 	void PushStream::SetPacketSilenceTimeoutMs(time_t timeout_ms)
@@ -88,7 +88,13 @@ namespace pvd
 
 	time_t PushStream::GetElapsedMsSinceLastReceived()
 	{
-		return _packet_silence_timer.Elapsed();
+		auto last_received_time_ms = _last_received_time_ms.load();
+		if (last_received_time_ms < 0)
+		{
+			return -1;
+		}
+
+		return static_cast<time_t>(ov::Time::GetTimestampInMs() - last_received_time_ms);
 	}
 
 	bool PushStream::PublishChannel(const info::VHostAppName &vhost_app_name)
@@ -102,7 +108,7 @@ namespace pvd
 		
 		_is_published = GetProvider()->PublishChannel(GetChannelId(), vhost_app_name, GetSharedPtrAs<PushStream>());
 
-		_packet_silence_timer.Start();
+		_last_received_time_ms = ov::Time::GetTimestampInMs();
 
 		return _is_published;
 	}

--- a/src/projects/base/provider/push_provider/stream.h
+++ b/src/projects/base/provider/push_provider/stream.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <base/ovlibrary/stop_watch.h>
 #include "base/provider/stream.h"
 
 namespace pvd
@@ -85,7 +84,7 @@ namespace pvd
 		// Published?
 		bool			_is_published = false;
 		// Time elapsed since the last OnDataReceived function was called
-		ov::StopWatch _packet_silence_timer;
+		std::atomic<int64_t> _last_received_time_ms = -1;
 		std::atomic<time_t> _packet_silence_timeout_ms = 0;
 
 		std::atomic<uint32_t> _attemps_publish_count   = 0;

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -79,6 +79,8 @@ namespace pvd
 	// Consider the reconnection time and add it to the base timestamp
 	void Stream::UpdateReconnectTimeToBasetime()
 	{
+		std::scoped_lock lock(_source_stream_timestamp_mutex);
+
 		auto last_pkt_received_time_us = _last_pkt_received_time_us.load();
 		if (last_pkt_received_time_us >= 0)
 		{
@@ -375,6 +377,8 @@ namespace pvd
 
 	void Stream::ResetSourceStreamTimestamp()
 	{
+		std::scoped_lock lock(_source_stream_timestamp_mutex);
+
 		// Set the last timestamp of the highest value of all tracks
 		// In this algorithm, the timestamp of A or V jumps for synchronization.
 		// But after testing with a variety of players, this is better.
@@ -387,9 +391,10 @@ namespace pvd
 				continue;
 			}
 
-			int64_t last_duration = _last_duration_us_map.find(track_id) != _last_duration_us_map.end() ? _last_duration_us_map[track_id] : 0;
-			last_timestamp = std::max<int64_t>(timestamp + last_duration, last_timestamp);
-		}	
+			const auto last_duration_it = _last_duration_us_map.find(track_id);
+			int64_t last_duration		= (last_duration_it != _last_duration_us_map.end()) ? last_duration_it->second : 0;
+			last_timestamp				= std::max<int64_t>(timestamp + last_duration, last_timestamp);
+		}
 
 		if (last_timestamp != std::numeric_limits<int64_t>::min())
 		{
@@ -511,6 +516,8 @@ namespace pvd
 		// instead of dividing in `track_scale`, `num_tb` is multiplied in `us_scale`.
 		const auto us_scale					 = AV_TIME_BASE * num_tb;
 		const auto &track_scale				 = den_tb;	// An alias of `den_tb` for clarity
+
+		std::scoped_lock lock(_source_stream_timestamp_mutex);
 
 		// 1. Get the start timestamp and base timebase of this stream.
 		if (_start_timestamp_us == -1LL)
@@ -636,9 +643,12 @@ namespace pvd
 		}
 
 		int64_t base_timestamp = 0;
-		if (_base_timestamp_us != -1)
 		{
-			base_timestamp = _base_timestamp_us;
+			std::scoped_lock lock(_source_stream_timestamp_mutex);
+			if (_base_timestamp_us != -1)
+			{
+				base_timestamp = _base_timestamp_us;
+			}
 		}
 
 		auto base_timestamp_tb = (base_timestamp * track->GetTimeBase().GetTimescale() / 1000000);
@@ -649,6 +659,8 @@ namespace pvd
 	// This is a method of generating a PTS with an increment value (delta) when it cannot be used as a PTS because the start value of the timestamp is random like the RTP timestamp.
 	int64_t Stream::AdjustTimestampByDelta(uint32_t track_id, int64_t timestamp, int64_t max_timestamp)
 	{
+		std::scoped_lock lock(_source_stream_timestamp_mutex);
+
 		int64_t curr_timestamp;
 
 		if (_last_timestamp_us_map.find(track_id) == _last_timestamp_us_map.end())
@@ -670,8 +682,6 @@ namespace pvd
 
 	int64_t Stream::GetDeltaTimestamp(uint32_t track_id, int64_t timestamp, int64_t max_timestamp)
 	{
-		auto track = GetTrack(track_id);
-
 		// First timestamp
 		if (_source_timestamp_map.find(track_id) == _source_timestamp_map.end())
 		{

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -79,9 +79,12 @@ namespace pvd
 	// Consider the reconnection time and add it to the base timestamp
 	void Stream::UpdateReconnectTimeToBasetime()
 	{
-		if (_last_pkt_received_time != std::chrono::time_point<std::chrono::system_clock>::min())
+		auto last_pkt_received_time_us = _last_pkt_received_time_us.load();
+		if (last_pkt_received_time_us >= 0)
 		{
-			auto reconnection_time_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - _last_pkt_received_time).count();
+			auto current_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count();
+			auto reconnection_time_us = current_time_us - last_pkt_received_time_us;
 
 			logti("Time taken to reconnect is %" PRId64 " milliseconds. add to the basetime", reconnection_time_us/1000);
 
@@ -339,7 +342,8 @@ namespace pvd
 		// Statistics
 		MonitorInstance->IncreaseBytesIn(*GetSharedPtrAs<info::Stream>(), packet->GetDataLength());
 
-		_last_pkt_received_time = std::chrono::system_clock::now();
+		_last_pkt_received_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::system_clock::now().time_since_epoch()).count();
 
 		auto master_clock_track = GetMediaTrackByOrder(cmn::MediaType::Video, 0);
 		if (master_clock_track == nullptr)

--- a/src/projects/base/provider/stream.h
+++ b/src/projects/base/provider/stream.h
@@ -42,7 +42,7 @@ namespace pvd
 			PUSH
 		};
 
-		State GetState() const {return _state;};
+		State GetState() const {return _state;}
 
 		void SetApplication(const std::shared_ptr<pvd::Application> &application)
 		{
@@ -152,7 +152,7 @@ namespace pvd
 
 		std::chrono::time_point<std::chrono::system_clock>	_last_pkt_received_time = std::chrono::time_point<std::chrono::system_clock>::min();
 
-		State 	_state = State::IDLE;
+		std::atomic<State> _state{State::IDLE};
 
 		std::shared_ptr<ov::Url> _requested_url = nullptr;
 		std::shared_ptr<ov::Url> _final_url = nullptr;

--- a/src/projects/base/provider/stream.h
+++ b/src/projects/base/provider/stream.h
@@ -150,7 +150,8 @@ namespace pvd
 
 		int64_t								_start_timestamp_us = -1LL; // Make first timestamp to zero
 
-		std::chrono::time_point<std::chrono::system_clock>	_last_pkt_received_time = std::chrono::time_point<std::chrono::system_clock>::min();
+		// `-1` means no media packet has been received yet.
+		std::atomic<int64_t> _last_pkt_received_time_us{-1};
 
 		std::atomic<State> _state{State::IDLE};
 

--- a/src/projects/base/provider/stream.h
+++ b/src/projects/base/provider/stream.h
@@ -163,6 +163,7 @@ namespace pvd
 		LipSyncClock 						_rtp_lip_sync_clock;
 		ov::StopWatch						_first_rtp_received_time;
 
+		mutable std::mutex _source_stream_timestamp_mutex;
 		mutable std::mutex _timestamp_mutex;
 		int64_t _last_media_timestamp_ms = -1LL;
 		ov::StopWatch _elapsed_from_last_media_timestamp;

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -158,7 +158,11 @@ namespace pvd
 
 	bool MpegTsProvider::Stop()
 	{
-		auto stream_port_map = std::move(_stream_port_map);
+		decltype(_stream_port_map) stream_port_map;
+		{
+			std::scoped_lock lock(_stream_port_map_lock);
+			stream_port_map = std::move(_stream_port_map);
+		}
 
 		for (const auto &x : stream_port_map)
 		{


### PR DESCRIPTION
### Summary
Fixes data races in `pvd::Stream` and related classes.

### Changes

**`pvd::PushStream` - silence timer race**
- Replace `ov::StopWatch _packet_silence_timer` with `std::atomic<int64_t> _last_received_time_ms`
- Remove non-atomic access in `UpdateLastReceivedTime()`, `GetElapsedMsSinceLastReceived()`, and `PublishChannel()`
- Use `steady_clock` instead of `system_clock` for elapsed time measurement to avoid NTP jump impact

**`pvd::Stream` - state race**
- Replace `State _state` with `std::atomic<State>` to eliminate race between `StreamMotor` and `WhiteElephantStreamCollector` threads

**`pvd::Stream` - last packet received time race**
- Replace `std::chrono::time_point _last_pkt_received_time` with `std::atomic<int64_t> _last_pkt_received_time_us`

**`pvd::Stream` - timestamp state race**
- Introduce `_source_stream_timestamp_mutex` to protect timestamp state
- Guard `AdjustTimestampByBase()`, `AdjustTimestampByDelta()`, `ResetSourceStreamTimestamp()`, `UpdateReconnectTimeToBasetime()`, and `GetBaseTimestamp()` under the new mutex

**`MpegTsProvider::Stop()` - unlocked map move**
- Acquire `_stream_port_map_lock` before moving `_stream_port_map` to prevent concurrent access during stop
