### PR TITLE
fix: prevent IsSendable() warning spam and delayed ICE session cleanup on disconnect

### DIFF
--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -551,7 +551,23 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 	std::shared_ptr<IceSession> ice_session = FindIceSession(session_id);
 	if (ice_session == nullptr || ice_session->GetState() != IceConnectionState::Connected)
 	{
-		logtt("IcePort::Send - Could not find session: %d", session_id);
+		logtt("IcePort::Send - Could not find session: %u", session_id);
+		return false;
+	}
+
+	// The underlying socket may already be closed (e.g. by GC) before OnDisconnected callback arrives.
+	// Check socket state to avoid sending data to a closed socket.
+	auto remote = ice_session->GetConnectedSocket();
+	if (remote == nullptr)
+	{
+		logte("IcePort::Send - Could not find connected remote socket: %u", session_id);
+		return false;
+	}
+
+	auto socket_state = remote->GetState();
+	// Do not use != Connected: UDP uses a shared Listening socket, which is never Connected.
+	if (socket_state == ov::SocketState::Disconnected || socket_state == ov::SocketState::Closed)
+	{
 		return false;
 	}
 
@@ -575,13 +591,6 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 
 	if (send_data == nullptr)
 	{
-		return false;
-	}
-
-	auto remote = ice_session->GetConnectedSocket();
-	if (remote == nullptr)
-	{
-		logte("IcePort::Send - Could not find connected remote socket: %d", session_id);
 		return false;
 	}
 
@@ -609,15 +618,39 @@ void IcePort::OnConnected(const std::shared_ptr<ov::Socket> &remote)
 void IcePort::OnDisconnected(const std::shared_ptr<ov::Socket> &remote, PhysicalPortDisconnectReason reason, const std::shared_ptr<const ov::Error> &error)
 {
 	// called when TURN client disconnected from the turn server with TCP
-	std::lock_guard<std::shared_mutex> lock_guard(_demultiplexers_lock);
-
-	auto it = _demultiplexers.find(remote->GetNativeHandle());
-	if (it != _demultiplexers.end())
 	{
-		_demultiplexers.erase(remote->GetNativeHandle());
+		std::lock_guard<std::shared_mutex> lock_guard(_demultiplexers_lock);
+
+		auto it = _demultiplexers.find(remote->GetNativeHandle());
+		if (it != _demultiplexers.end())
+		{
+			_demultiplexers.erase(remote->GetNativeHandle());
+		}
 	}
 
 	logti("Turn client has disconnected : %s", remote->ToString().CStr());
+
+	// Find all IceSessions whose connected socket matches the disconnected socket,
+	// and mark them as Disconnecting so that IcePort::Send() stops immediately.
+	// DisconnectSession() must be called outside the lock to avoid deadlock.
+	std::vector<session_id_t> sessions_to_disconnect;
+	{
+		std::shared_lock<std::shared_mutex> lock_guard(_ice_sessions_with_id_lock);
+		for (const auto &[session_id, ice_session] : _ice_seesions_with_id)
+		{
+			auto connected_socket = ice_session->GetConnectedSocket();
+			if (connected_socket != nullptr && connected_socket->GetNativeHandle() == remote->GetNativeHandle())
+			{
+				sessions_to_disconnect.push_back(session_id);
+			}
+		}
+	}
+
+	for (const auto session_id : sessions_to_disconnect)
+	{
+		logti("Disconnecting IceSession(%u) due to TCP socket disconnect", session_id);
+		DisconnectSession(session_id);
+	}
 }
 
 void IcePort::OnDataReceived(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddress &address, const std::shared_ptr<const ov::Data> &data)

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -566,7 +566,7 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 
 	auto socket_state = remote->GetState();
 	// Do not use != Connected: UDP uses a shared Listening socket, which is never Connected.
-	if (socket_state == ov::SocketState::Disconnected || socket_state == ov::SocketState::Closed)
+	if (socket_state == ov::SocketState::Disconnected || socket_state == ov::SocketState::Closed || socket_state == ov::SocketState::Error)
 	{
 		return false;
 	}

--- a/src/projects/publishers/webrtc/rtc_bandwidth_estimator.cpp
+++ b/src/projects/publishers/webrtc/rtc_bandwidth_estimator.cpp
@@ -170,7 +170,7 @@ bool RtcBandwidthEstimator::ProcessTransportCc()
 			if (item.wide_sequence_number != feedback.wide_seq_no ||
 				item.sent_time.time_since_epoch().count() == 0)
 			{
-				logtw("Cannot find RTP history for wide_seq_no(%u)", feedback.wide_seq_no);
+				logtd("Cannot find RTP history for wide_seq_no(%u)", feedback.wide_seq_no);
 				continue;
 			}
 


### PR DESCRIPTION
## Problem
When a slow WebRTC/TCP viewer connects and its send buffer backs up, the TCP socket eventually gets disconnected by the OS. However, the ICE session remains in Connected state, causing the server to keep sending packets to the dead socket. This floods the logs with IsSendable(): Invalid state: Disconnected warnings.

The Cannot find RTP history warnings are also caused by slow clients. Because the client is too slow to consume packets, by the time Transport-CC feedback arrives, the RTP history ring buffer (8192 entries) has already wrapped around and the original entries have been overwritten.

Fixes #2066

## Root Cause
OnDisconnected() only cleaned up the TCP demultiplexer but did not disconnect the associated ICE sessions. The sessions stayed in Connected state until natural expiry, and every outgoing RTP packet triggered a warning log.