### PR TITLE
feat: support per-RID Oven-Capabilities for simulcast streams

### DIFF
--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -280,7 +280,7 @@ namespace pvd
 				//   MID="video0", RID="low"  → key = "video0:low"
 				//   no MID,       RID="high" → key = "high"
 				auto mid = answer_media_desc->GetMid();
-				auto key = mid.has_value()
+				auto key = (mid.has_value() && !mid->IsEmpty())
 							? (mid.value() + ":" + rid_attr->GetId())
 							: rid_attr->GetId();
 				_simulcast_track_map[key] = track->GetId();

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -9,6 +9,7 @@
 
 #include "webrtc_stream.h"
 
+#include "base/ovlibrary/converter.h"
 #include "base/ovlibrary/random.h"
 #include "modules/rtp_rtcp/rtcp_info/sender_report.h"
 #include "webrtc_application.h"

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -271,7 +271,7 @@ namespace pvd
 			
 			if (has_rid_extension)
 			{
-				// Key: "mid:rid" when MID extension is present to disambiguate across m= sections
+				// Key: "mid:rid" when the SDP a=mid identifier is available to disambiguate across m= sections
 				// that reuse the same RID values; otherwise just "rid".
 				// RID values are [a-zA-Z0-9\-_]+ and MID tokens contain no ':', so ':' is a safe separator.
 				//
@@ -280,7 +280,7 @@ namespace pvd
 				//   MID="video0", RID="low"  → key = "video0:low"
 				//   no MID,       RID="high" → key = "high"
 				auto mid = answer_media_desc->GetMid();
-				auto key = (has_mid_extension && mid.has_value())
+				auto key = mid.has_value()
 							? (mid.value() + ":" + rid_attr->GetId())
 							: rid_attr->GetId();
 				_simulcast_track_map[key] = track->GetId();

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -440,15 +440,18 @@ namespace pvd
 
 				if (field == "max_width")
 				{
-					rid_max_width[rid_id] = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) rid_max_width[rid_id] = v;
 				}
 				else if (field == "max_height")
 				{
-					rid_max_height[rid_id] = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) rid_max_height[rid_id] = v;
 				}
 				else if (field == "max_fps")
 				{
-					rid_max_fps[rid_id] = std::atof(value.CStr());
+					auto v = ov::Converter::ToDouble(value.CStr());
+					if (v > 0) rid_max_fps[rid_id] = v;
 				}
 			}
 			else if (key_lower.HasPrefix("mid:"))
@@ -467,15 +470,18 @@ namespace pvd
 
 				if (field == "max_width")
 				{
-					rid_max_width[mid_rid_key] = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) rid_max_width[mid_rid_key] = v;
 				}
 				else if (field == "max_height")
 				{
-					rid_max_height[mid_rid_key] = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) rid_max_height[mid_rid_key] = v;
 				}
 				else if (field == "max_fps")
 				{
-					rid_max_fps[mid_rid_key] = std::atof(value.CStr());
+					auto v = ov::Converter::ToDouble(value.CStr());
+					if (v > 0) rid_max_fps[mid_rid_key] = v;
 				}
 			}
 			else
@@ -483,15 +489,18 @@ namespace pvd
 				// Plain format: applied to the first video track
 				if (key_lower == "max_width")
 				{
-					plain_max_width = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) plain_max_width = v;
 				}
 				else if (key_lower == "max_height")
 				{
-					plain_max_height = std::atoi(value.CStr());
+					auto v = ov::Converter::ToInt32(value.CStr());
+					if (v > 0) plain_max_height = v;
 				}
 				else if (key_lower == "max_fps")
 				{
-					plain_max_fps = std::atof(value.CStr());
+					auto v = ov::Converter::ToDouble(value.CStr());
+					if (v > 0) plain_max_fps = v;
 				}
 			}
 		}

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -271,9 +271,22 @@ namespace pvd
 			
 			if (has_rid_extension)
 			{
-				// Store RID to track ID mapping for Oven-Capabilities per-RID support
-				// rid_attr->GetId() is guaranteed non-empty: the SDP parser requires [a-zA-Z0-9\-_]+ (1+ chars)
-				_rid_to_track_id[rid_attr->GetId()] = track->GetId();
+				// Key: "mid:rid" when MID extension is present to disambiguate across m= sections
+				// that reuse the same RID values; otherwise just "rid".
+				// RID values are [a-zA-Z0-9\-_]+ and MID tokens contain no ':', so ':' is a safe separator.
+				//
+				// Examples:
+				//   MID="video0", RID="high" → key = "video0:high"
+				//   MID="video0", RID="low"  → key = "video0:low"
+				//   no MID,       RID="high" → key = "high"
+				auto mid = answer_media_desc->GetMid();
+				auto key = (has_mid_extension && mid.has_value())
+							? (mid.value() + ":" + rid_attr->GetId())
+							: rid_attr->GetId();
+				_simulcast_track_map[key] = track->GetId();
+				logti("%s - RID mapped: key=\"%s\" → track_id(%u) [mid_ext=%s, rid=\"%s\"]",
+					GetName().CStr(), key.CStr(), track->GetId(),
+					has_mid_extension ? "yes" : "no", rid_attr->GetId().CStr());
 			}
 		}
 
@@ -370,8 +383,20 @@ namespace pvd
 		// 1. Plain format (applied to the first video track only):
 		//    max_width=1920, max_height=1080, max_fps=30
 		//
+		//    capabilities = "max_width=1920, max_height=1080, max_fps=30"
+		//
 		// 2. RID format (applied per RID to the corresponding simulcast track):
-		//    rid:0:max_width=1280, rid:0:max_height=720, rid:0:max_fps=30, rid:1:max_width=640, rid:1:max_height=360, rid:1:max_fps=30
+		//    rid:high:max_width=1280, rid:high:max_height=720, rid:high:max_fps=30, rid:low:max_width=640, rid:low:max_height=360
+		//
+		//    capabilities = "rid:high:max_width=1280, rid:high:max_height=720, rid:high:max_fps=30, rid:low:max_width=640, rid:low:max_height=360"
+		//
+		// 3. MID+RID format (disambiguates RIDs across multiple m= sections):
+		//    mid:<mid_id>:rid:<rid_id>:<field>=<value>
+		//
+		//    capabilities = "mid:0:rid:high:max_width=1280, mid:0:rid:high:max_height=720, mid:0:rid:high:max_fps=30, mid:0:rid:low:max_width=640, mid:0:rid:low:max_height=360"
+		//
+		//    Internally keyed by "mid:rid" in _simulcast_track_map (e.g. "0:high" → track_id),
+		//    so the same maps (rid_max_*) cover both RID-only and MID+RID formats.
 		//
 		// If plain format params are present in a simulcast stream, they are applied to the first video track (backward compatibility).
 
@@ -402,7 +427,7 @@ namespace pvd
 			if (key_lower.HasPrefix("rid:"))
 			{
 				// RID format: rid:<rid_id>:<field>
-				// rid_id preserves original case to match _rid_to_track_id keys from SDP
+				// rid_id preserves original case to match _simulcast_track_map keys from SDP
 				auto parts = ov::String::Split(key.CStr(), ":");
 				if (parts.size() != 3)
 				{
@@ -423,6 +448,33 @@ namespace pvd
 				else if (field == "max_fps")
 				{
 					rid_max_fps[rid_id] = std::atof(value.CStr());
+				}
+			}
+			else if (key_lower.HasPrefix("mid:"))
+			{
+				// MID+RID format: mid:<mid_id>:rid:<rid_id>:<field>
+				// e.g. "mid:0:rid:high:max_width" → mid_rid_key = "0:high", field = "max_width"
+				auto parts = ov::String::Split(key.CStr(), ":");
+				if (parts.size() != 5 || parts[2].LowerCaseString() != "rid")
+				{
+					continue;
+				}
+
+				// Build the same "mid:rid" composite key used in _simulcast_track_map
+				auto mid_rid_key = parts[1] + ":" + parts[3];
+				auto field = parts[4].LowerCaseString();
+
+				if (field == "max_width")
+				{
+					rid_max_width[mid_rid_key] = std::atoi(value.CStr());
+				}
+				else if (field == "max_height")
+				{
+					rid_max_height[mid_rid_key] = std::atoi(value.CStr());
+				}
+				else if (field == "max_fps")
+				{
+					rid_max_fps[mid_rid_key] = std::atof(value.CStr());
 				}
 			}
 			else
@@ -467,12 +519,31 @@ namespace pvd
 			}
 		}
 
-		// Apply RID params to the corresponding simulcast track (_rid_to_track_id is empty for unicast, so this loop is a no-op)
-		for (const auto &[rid_id, track_id] : _rid_to_track_id)
+		// Apply RID params to the corresponding simulcast track (_simulcast_track_map is empty for unicast, so this loop is a no-op)
+		for (const auto &[key, track_id] : _simulcast_track_map)
 		{
-			auto it_width  = rid_max_width.find(rid_id);
-			auto it_height = rid_max_height.find(rid_id);
-			auto it_fps    = rid_max_fps.find(rid_id);
+			// _simulcast_track_map key is "mid:rid" (MID present) or "rid" (no MID).
+			// rid_max_* maps may be keyed by:
+			//   - "mid:rid" composite key (format 3: mid:0:rid:high:max_width=...)
+			//   - "rid" only             (format 2: rid:high:max_width=...)
+			//
+			// Try the full key first (handles format 3 and no-MID format 2).
+			// Fall back to the RID-only suffix (last ':'-token) to handle the common case
+			// where the sender uses RID-only format but the SDP contains a MID extension,
+			// making the internal key "mid:rid" (e.g. "0:high") while the header says "rid:high".
+			//
+			// Examples:
+			//   key="0:high", rid_max_* has "0:high" → direct hit  (format 3)
+			//   key="0:high", rid_max_* has "high"   → fallback hit (format 2 + MID present)
+			//   key="high",   rid_max_* has "high"   → direct hit  (format 2, no MID)
+			const auto rid_suffix = ov::String(ov::String::Split(key.CStr(), ":").back());
+
+			auto it_width  = rid_max_width.find(key);
+			if (it_width  == rid_max_width.end())  it_width  = rid_max_width.find(rid_suffix);
+			auto it_height = rid_max_height.find(key);
+			if (it_height == rid_max_height.end()) it_height = rid_max_height.find(rid_suffix);
+			auto it_fps    = rid_max_fps.find(key);
+			if (it_fps    == rid_max_fps.end())    it_fps    = rid_max_fps.find(rid_suffix);
 
 			if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
 			{
@@ -482,7 +553,7 @@ namespace pvd
 					track->SetResolution(it_width->second, it_height->second);
 
 					auto max_resolution = track->GetMaxResolution();
-					logtt("%s - Set max resolution for rid(%s): %s", GetName().CStr(), rid_id.CStr(), max_resolution.ToString().CStr());
+					logtt("%s - Set max resolution for key(%s): %s", GetName().CStr(), key.CStr(), max_resolution.ToString().CStr());
 				}
 			}
 
@@ -492,7 +563,7 @@ namespace pvd
 				if (track != nullptr)
 				{
 					track->SetMaxFrameRate(it_fps->second);
-					logtt("%s - Set max fps for rid(%s): %.2f", GetName().CStr(), rid_id.CStr(), track->GetMaxFrameRate());
+					logtt("%s - Set max fps for key(%s): %.2f", GetName().CStr(), key.CStr(), track->GetMaxFrameRate());
 				}
 			}
 		}

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -284,8 +284,9 @@ namespace pvd
 							? (mid.value() + ":" + rid_attr->GetId())
 							: rid_attr->GetId();
 				_simulcast_track_map[key] = track->GetId();
-				logti("%s - RID mapped: key=\"%s\" → track_id(%u) [mid_ext=%s, rid=\"%s\"]",
-					GetName().CStr(), key.CStr(), track->GetId(),
+
+				logti("[%s(%u)] Simulcast track mapped - key(%s), track_id(%u), mid_ext(%s), rid(%s)",
+					GetName().CStr(), GetId(), key.CStr(), track->GetId(),
 					has_mid_extension ? "yes" : "no", rid_attr->GetId().CStr());
 			}
 		}
@@ -545,22 +546,18 @@ namespace pvd
 			auto it_fps    = rid_max_fps.find(key);
 			if (it_fps    == rid_max_fps.end())    it_fps    = rid_max_fps.find(rid_suffix);
 
-			if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
+			auto track = GetTrack(track_id);
+			if (track != nullptr)
 			{
-				auto track = GetTrack(track_id);
-				if (track != nullptr)
+				if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
 				{
 					track->SetResolution(it_width->second, it_height->second);
 
 					auto max_resolution = track->GetMaxResolution();
 					logtt("%s - Set max resolution for key(%s): %s", GetName().CStr(), key.CStr(), max_resolution.ToString().CStr());
 				}
-			}
 
-			if (it_fps != rid_max_fps.end())
-			{
-				auto track = GetTrack(track_id);
-				if (track != nullptr)
+				if (it_fps != rid_max_fps.end())
 				{
 					track->SetMaxFrameRate(it_fps->second);
 					logtt("%s - Set max fps for key(%s): %.2f", GetName().CStr(), key.CStr(), track->GetMaxFrameRate());

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -268,6 +268,13 @@ namespace pvd
 		if (rid_attr != nullptr)
 		{
 			has_rid_extension = answer_media_desc->FindExtmapItem("urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id", rid_extension_id, rid_extension_uri);
+			
+			if (has_rid_extension)
+			{
+				// Store RID to track ID mapping for Oven-Capabilities per-RID support
+				// rid_attr->GetId() is guaranteed non-empty: the SDP parser requires [a-zA-Z0-9\-_]+ (1+ chars)
+				_rid_to_track_id[rid_attr->GetId()] = track->GetId();
+			}
 		}
 
 		// Add Rtp Receiver
@@ -358,62 +365,141 @@ namespace pvd
 	{
 		_oven_capabilities = capabilities;
 
-		// 26.01.08
-		// Oven-Capabilities: max_width=1920, max_height=1080, max_fps=30
+		// Oven-Capabilities format:
+		// - For Unicast (no RID extension): max_width=1920, max_height=1080, max_fps=30
+		// - For Simulcast (with RID extension): rid:0:max_width=1280, rid:0:max_height=720, rid:0:max_fps=30, rid:1:max_width=640, rid:1:max_height=360, rid:1:max_fps=30
 
-		// Parse and apply capabilities
 		logtt("%s - Set Oven-Capabilities: %s", GetName().CStr(), capabilities.CStr());
 
 		auto params = ov::String::Split(capabilities.CStr(), ",");
 
-		std::optional<int> max_width;
-		std::optional<int> max_height;
-		std::optional<double> max_fps;
-
-		for (const auto &param : params)
+		// If _rid_to_track_id is not empty, it means the stream has simulcast layers 
+		// and Oven-Capabilities should be parsed per RID. Otherwise, parse as unicast stream level parameters.
+		if (_rid_to_track_id.empty())
 		{
-			auto key_value = ov::String::Split(param.CStr(), "=");
-			if (key_value.size() != 2)
+			// Unicast: parse max_width, max_height, max_fps only
+			std::optional<int> max_width;
+			std::optional<int> max_height;
+			std::optional<double> max_fps;
+
+			for (const auto &param : params)
 			{
-				continue;
+				auto key_value = ov::String::Split(param.CStr(), "=");
+				if (key_value.size() != 2)
+				{
+					continue;
+				}
+
+				auto key   = key_value[0].Trim().LowerCaseString();
+				auto value = key_value[1].Trim();
+
+				if (key == "max_width")
+				{
+					max_width = std::atoi(value.CStr());
+				}
+				else if (key == "max_height")
+				{
+					max_height = std::atoi(value.CStr());
+				}
+				else if (key == "max_fps")
+				{
+					max_fps = std::atof(value.CStr());
+				}
 			}
 
-			auto key = key_value[0].Trim().LowerCaseString();
-			auto value = key_value[1].Trim();
-			if (key == "max_width")
-			{
-				max_width = std::atoi(value.CStr());
-			}
-			else if (key == "max_height")
-			{
-				max_height = std::atoi(value.CStr());
-			}
-			else if (key == "max_fps")
-			{
-				max_fps = std::atof(value.CStr());
-			}
-		}
-
-		if (max_width.has_value() && max_height.has_value())
-		{
 			auto first_video_track = GetFirstTrackByType(cmn::MediaType::Video);
 			if (first_video_track != nullptr)
 			{
-				first_video_track->SetResolution(max_width.value(), max_height.value());
+				if (max_width.has_value() && max_height.has_value())
+				{
+					first_video_track->SetResolution(max_width.value(), max_height.value());
 
-				auto max_resolution = first_video_track->GetMaxResolution();
-				logtt("%s - Set max resolution: %s", GetName().CStr(), max_resolution.ToString().CStr());
+					auto max_resolution = first_video_track->GetMaxResolution();
+					logtt("%s - Set max resolution: %s", GetName().CStr(), max_resolution.ToString().CStr());
+				}
+
+				if (max_fps.has_value())
+				{
+					first_video_track->SetMaxFrameRate(max_fps.value());
+
+					logtt("%s - Set max fps: %.2f", GetName().CStr(), first_video_track->GetMaxFrameRate());
+				}
 			}
 		}
-
-		if (max_fps.has_value())
+		else
 		{
-			auto first_video_track = GetFirstTrackByType(cmn::MediaType::Video);
-			if (first_video_track != nullptr)
-			{
-				first_video_track->SetMaxFrameRate(max_fps.value());
+			// Simulcast: parse rid:<rid_id>:<field> only
+			std::map<ov::String, int> rid_max_width;
+			std::map<ov::String, int> rid_max_height;
+			std::map<ov::String, double> rid_max_fps;
 
-				logtt("%s - Set max fps: %.2f", GetName().CStr(), first_video_track->GetMaxFrameRate());
+			for (const auto &param : params)
+			{
+				auto key_value = ov::String::Split(param.CStr(), "=");
+				if (key_value.size() != 2)
+				{
+					continue;
+				}
+
+				auto key = key_value[0].Trim();
+				auto value = key_value[1].Trim();
+
+				auto key_lower = key.LowerCaseString();
+				if (key_lower.HasPrefix("rid:") == false)
+				{
+					continue;
+				}
+
+				auto parts = ov::String::Split(key.CStr(), ":");
+				if (parts.size() != 3)
+				{
+					continue;
+				}
+
+				// rid_id preserves original case to match _rid_to_track_id keys from SDP
+				const auto &rid_id = parts[1];
+				auto field = parts[2].LowerCaseString();
+
+				if (field == "max_width")
+				{
+					rid_max_width[rid_id] = std::atoi(value.CStr());
+				}
+				else if (field == "max_height")
+				{
+					rid_max_height[rid_id] = std::atoi(value.CStr());
+				}
+				else if (field == "max_fps")
+				{
+					rid_max_fps[rid_id] = std::atof(value.CStr());
+				}
+			}
+
+			for (const auto &[rid_id, track_id] : _rid_to_track_id)
+			{
+				auto track = GetTrack(track_id);
+				if (track == nullptr)
+				{
+					continue;
+				}
+
+				auto it_width  = rid_max_width.find(rid_id);
+				auto it_height = rid_max_height.find(rid_id);
+				auto it_fps    = rid_max_fps.find(rid_id);
+
+				if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
+				{
+					track->SetResolution(it_width->second, it_height->second);
+
+					auto max_resolution = track->GetMaxResolution();
+					logtt("%s - Set max resolution for rid(%s): %s", GetName().CStr(), rid_id.CStr(), max_resolution.ToString().CStr());
+				}
+
+				if (it_fps != rid_max_fps.end())
+				{
+					track->SetMaxFrameRate(it_fps->second);
+
+					logtt("%s - Set max fps for rid(%s): %.2f", GetName().CStr(), rid_id.CStr(), track->GetMaxFrameRate());
+				}
 			}
 		}
 	}

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -365,98 +365,50 @@ namespace pvd
 	{
 		_oven_capabilities = capabilities;
 
-		// Oven-Capabilities format:
-		// - For Unicast (no RID extension): max_width=1920, max_height=1080, max_fps=30
-		// - For Simulcast (with RID extension): rid:0:max_width=1280, rid:0:max_height=720, rid:0:max_fps=30, rid:1:max_width=640, rid:1:max_height=360, rid:1:max_fps=30
+		// Oven-Capabilities header format:
+		//
+		// 1. Plain format (applied to the first video track only):
+		//    max_width=1920, max_height=1080, max_fps=30
+		//
+		// 2. RID format (applied per RID to the corresponding simulcast track):
+		//    rid:0:max_width=1280, rid:0:max_height=720, rid:0:max_fps=30, rid:1:max_width=640, rid:1:max_height=360, rid:1:max_fps=30
+		//
+		// If plain format params are present in a simulcast stream, they are applied to the first video track (backward compatibility).
 
 		logtt("%s - Set Oven-Capabilities: %s", GetName().CStr(), capabilities.CStr());
 
 		auto params = ov::String::Split(capabilities.CStr(), ",");
 
-		// If _rid_to_track_id is not empty, it means the stream has simulcast layers 
-		// and Oven-Capabilities should be parsed per RID. Otherwise, parse as unicast stream level parameters.
-		if (_rid_to_track_id.empty())
+		std::optional<int> plain_max_width;
+		std::optional<int> plain_max_height;
+		std::optional<double> plain_max_fps;
+
+		std::map<ov::String, int> rid_max_width;
+		std::map<ov::String, int> rid_max_height;
+		std::map<ov::String, double> rid_max_fps;
+
+		for (const auto &param : params)
 		{
-			// Unicast: parse max_width, max_height, max_fps only
-			std::optional<int> max_width;
-			std::optional<int> max_height;
-			std::optional<double> max_fps;
-
-			for (const auto &param : params)
+			auto key_value = ov::String::Split(param.CStr(), "=");
+			if (key_value.size() != 2)
 			{
-				auto key_value = ov::String::Split(param.CStr(), "=");
-				if (key_value.size() != 2)
-				{
-					continue;
-				}
-
-				auto key   = key_value[0].Trim().LowerCaseString();
-				auto value = key_value[1].Trim();
-
-				if (key == "max_width")
-				{
-					max_width = std::atoi(value.CStr());
-				}
-				else if (key == "max_height")
-				{
-					max_height = std::atoi(value.CStr());
-				}
-				else if (key == "max_fps")
-				{
-					max_fps = std::atof(value.CStr());
-				}
+				continue;
 			}
 
-			auto first_video_track = GetFirstTrackByType(cmn::MediaType::Video);
-			if (first_video_track != nullptr)
+			auto key   = key_value[0].Trim();
+			auto value = key_value[1].Trim();
+
+			auto key_lower = key.LowerCaseString();
+			if (key_lower.HasPrefix("rid:"))
 			{
-				if (max_width.has_value() && max_height.has_value())
-				{
-					first_video_track->SetResolution(max_width.value(), max_height.value());
-
-					auto max_resolution = first_video_track->GetMaxResolution();
-					logtt("%s - Set max resolution: %s", GetName().CStr(), max_resolution.ToString().CStr());
-				}
-
-				if (max_fps.has_value())
-				{
-					first_video_track->SetMaxFrameRate(max_fps.value());
-
-					logtt("%s - Set max fps: %.2f", GetName().CStr(), first_video_track->GetMaxFrameRate());
-				}
-			}
-		}
-		else
-		{
-			// Simulcast: parse rid:<rid_id>:<field> only
-			std::map<ov::String, int> rid_max_width;
-			std::map<ov::String, int> rid_max_height;
-			std::map<ov::String, double> rid_max_fps;
-
-			for (const auto &param : params)
-			{
-				auto key_value = ov::String::Split(param.CStr(), "=");
-				if (key_value.size() != 2)
-				{
-					continue;
-				}
-
-				auto key = key_value[0].Trim();
-				auto value = key_value[1].Trim();
-
-				auto key_lower = key.LowerCaseString();
-				if (key_lower.HasPrefix("rid:") == false)
-				{
-					continue;
-				}
-
+				// RID format: rid:<rid_id>:<field>
+				// rid_id preserves original case to match _rid_to_track_id keys from SDP
 				auto parts = ov::String::Split(key.CStr(), ":");
 				if (parts.size() != 3)
 				{
 					continue;
 				}
 
-				// rid_id preserves original case to match _rid_to_track_id keys from SDP
 				const auto &rid_id = parts[1];
 				auto field = parts[2].LowerCaseString();
 
@@ -473,31 +425,73 @@ namespace pvd
 					rid_max_fps[rid_id] = std::atof(value.CStr());
 				}
 			}
+			else
+			{
+				// Plain format: applied to the first video track
+				if (key_lower == "max_width")
+				{
+					plain_max_width = std::atoi(value.CStr());
+				}
+				else if (key_lower == "max_height")
+				{
+					plain_max_height = std::atoi(value.CStr());
+				}
+				else if (key_lower == "max_fps")
+				{
+					plain_max_fps = std::atof(value.CStr());
+				}
+			}
+		}
 
-			for (const auto &[rid_id, track_id] : _rid_to_track_id)
+		// Apply plain params to the first video track
+		if (plain_max_width.has_value() && plain_max_height.has_value())
+		{
+			auto first_video_track = GetFirstTrackByType(cmn::MediaType::Video);
+			if (first_video_track != nullptr)
+			{
+				first_video_track->SetResolution(plain_max_width.value(), plain_max_height.value());
+
+				auto max_resolution = first_video_track->GetMaxResolution();
+				logtt("%s - Set max resolution: %s", GetName().CStr(), max_resolution.ToString().CStr());
+			}
+		}
+
+		if (plain_max_fps.has_value())
+		{
+			auto first_video_track = GetFirstTrackByType(cmn::MediaType::Video);
+			if (first_video_track != nullptr)
+			{
+				first_video_track->SetMaxFrameRate(plain_max_fps.value());
+
+				logtt("%s - Set max fps: %.2f", GetName().CStr(), first_video_track->GetMaxFrameRate());
+			}
+		}
+
+		// Apply RID params to the corresponding simulcast track (_rid_to_track_id is empty for unicast, so this loop is a no-op)
+		for (const auto &[rid_id, track_id] : _rid_to_track_id)
+		{
+			auto it_width  = rid_max_width.find(rid_id);
+			auto it_height = rid_max_height.find(rid_id);
+			auto it_fps    = rid_max_fps.find(rid_id);
+
+			if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
 			{
 				auto track = GetTrack(track_id);
-				if (track == nullptr)
-				{
-					continue;
-				}
-
-				auto it_width  = rid_max_width.find(rid_id);
-				auto it_height = rid_max_height.find(rid_id);
-				auto it_fps    = rid_max_fps.find(rid_id);
-
-				if (it_width != rid_max_width.end() && it_height != rid_max_height.end())
+				if (track != nullptr)
 				{
 					track->SetResolution(it_width->second, it_height->second);
 
 					auto max_resolution = track->GetMaxResolution();
 					logtt("%s - Set max resolution for rid(%s): %s", GetName().CStr(), rid_id.CStr(), max_resolution.ToString().CStr());
 				}
+			}
 
-				if (it_fps != rid_max_fps.end())
+			if (it_fps != rid_max_fps.end())
+			{
+				auto track = GetTrack(track_id);
+				if (track != nullptr)
 				{
 					track->SetMaxFrameRate(it_fps->second);
-
 					logtt("%s - Set max fps for rid(%s): %.2f", GetName().CStr(), rid_id.CStr(), track->GetMaxFrameRate());
 				}
 			}

--- a/src/projects/providers/webrtc/webrtc_stream.h
+++ b/src/projects/providers/webrtc/webrtc_stream.h
@@ -132,8 +132,8 @@ namespace pvd
 		std::map<uint32_t, bool> _sent_sequence_header;
 
 		// RID to track ID mapping
-		// Key: "mid:rid" when MID extension is present (disambiguates across m= sections with reused RIDs),
-		// or just "rid" when MID is unavailable. Each key is unique, so a single track ID per entry suffices.
+		// Key: "mid:rid" when the SDP a=mid identifier is available (disambiguates across m= sections with reused RIDs),
+		// or just "rid" when no SDP MID is available. Each key is unique, so a single track ID per entry suffices.
 		std::map<ov::String, uint32_t> _simulcast_track_map;
 
 		ov::String _oven_capabilities;

--- a/src/projects/providers/webrtc/webrtc_stream.h
+++ b/src/projects/providers/webrtc/webrtc_stream.h
@@ -131,6 +131,9 @@ namespace pvd
 		std::map<uint32_t, std::shared_ptr<ov::Data>> _h26x_extradata_nalu;
 		std::map<uint32_t, bool> _sent_sequence_header;
 
+		// RID to track ID mapping
+		std::map<ov::String, uint32_t> _rid_to_track_id;
+
 		ov::String _oven_capabilities;
 
 		session_id_t _ice_session_id = 0;

--- a/src/projects/providers/webrtc/webrtc_stream.h
+++ b/src/projects/providers/webrtc/webrtc_stream.h
@@ -132,7 +132,9 @@ namespace pvd
 		std::map<uint32_t, bool> _sent_sequence_header;
 
 		// RID to track ID mapping
-		std::map<ov::String, uint32_t> _rid_to_track_id;
+		// Key: "mid:rid" when MID extension is present (disambiguates across m= sections with reused RIDs),
+		// or just "rid" when MID is unavailable. Each key is unique, so a single track ID per entry suffices.
+		std::map<ov::String, uint32_t> _simulcast_track_map;
 
 		ov::String _oven_capabilities;
 


### PR DESCRIPTION
## Summary

Extend `Oven-Capabilities` header parsing in the WebRTC provider to support per-RID resolution/fps constraints for simulcast streams, while preserving backward compatibility with the plain format.

## Motivation

Previously `SetOvenCapabilities()` applied `max_width`, `max_height`, and `max_fps` to the first video track only. This was sufficient for unicast, but simulcast streams have multiple tracks (one per RID) that each need independent constraints.

## Oven-Capabilities Format

| Mode | Format | Example |
|---|---|---|
| Plain | `key=value, ...` | `max_width=1920, max_height=1080, max_fps=30` |
| RID | `rid:<id>:<key>=value, ...` | `rid:high:max_width=1280, rid:high:max_height=720, rid:low:max_width=640, rid:low:max_height=360` |

- **Plain format** — `max_width=`, `max_height=`, `max_fps=` are always applied to the first video track. Works for both unicast and simulcast (backward compatibility).

## Testing

- Available at https://demo.ovenplayer.com/demo_input.html