### PR TITLE
fix: keep OutputTrack quality even when input stream is updated

### DIFF
--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1583,7 +1583,7 @@ void TranscoderStream::UpdateOutputTrack(std::shared_ptr<MediaFrame> buffer)
 
 		if (output_track->IsBypass())
 		{
-			UpdateOutputTrackPassthrough(output_track, buffer);
+			UpdateOutputTrackPassthrough(output_track, input_track, buffer);
 		}
 		else
 		{

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -369,6 +369,9 @@ bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &strea
 
 		// Restrict transcoding while all decoders/filters/encoders are being generated
 		std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
+
+		UpdatePassthroughOutputTracks(stream);
+
 		RemoveDecoders();
 		RemoveFilters();
 		RemoveSpecificEncoders();
@@ -385,6 +388,9 @@ bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &strea
 
 		// Restrict transcoding while all decoders/filters/encoders are being generated
 		std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
+		
+		UpdatePassthroughOutputTracks(stream);
+
 		RemoveDecoders();
 		RemoveFilters();
 		RemoveEncoders();
@@ -1583,11 +1589,31 @@ void TranscoderStream::UpdateOutputTrack(std::shared_ptr<MediaFrame> buffer)
 
 		if (output_track->IsBypass())
 		{
-			UpdateOutputTrackPassthrough(output_track, input_track, buffer);
+			logtw("%s Invalid output track. Bypass track cannot be connected to decoder. OutputTrack(%d)", _log_prefix.CStr(), output_track->GetId());
+\
+			continue;
 		}
-		else
+
+		UpdateOutputTrackByDecodedFrame(output_track, input_track, buffer);
+	}
+}
+
+void TranscoderStream::UpdatePassthroughOutputTracks(const std::shared_ptr<info::Stream> &stream)
+{
+	for (auto it : stream->GetTracks())
+	{
+		for (auto &[input_stream, input_track, output_stream, output_track] : _composite.GetBypassOutputListByInputTrackId(it.first))
 		{
-			UpdateOutputTrackByDecodedFrame(output_track, input_track, buffer);
+			UNUSED_VARIABLE(input_stream);
+			UNUSED_VARIABLE(input_track);
+			UNUSED_VARIABLE(output_stream);
+
+			if (output_track->IsBypass() == false)
+			{
+				logtw("%s Invalid output track. Only bypass track can be updated. OutputTrack(%d)", _log_prefix.CStr(), output_track->GetId());
+			}
+
+			UpdateOutputTrackPassthrough(output_track, input_track);
 		}
 	}
 }

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -362,22 +362,27 @@ bool TranscoderStream::PrepareInternal()
 bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &stream)
 {
 	logtd("%s Trying to update a stream", _log_prefix.CStr());
+
 	if (CanSeamlessTransition(stream) == true)
 	{
 		logtt("%s This stream support seamless transitions", _log_prefix.CStr());
+
 		FlushBuffers();
 
-		// Restrict transcoding while all decoders/filters/encoders are being generated
-		std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
+		{
+			// Restrict transcoding while all decoders/filters/encoders are being generated
+			std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
 
-		UpdatePassthroughOutputTracks(stream);
+			// For tracks created as bypass, update the track data to match the input track.
+			UpdatePassthroughOutputTracks(stream);
 
-		RemoveDecoders();
-		RemoveFilters();
-		RemoveSpecificEncoders();
+			RemoveDecoders();
+			RemoveFilters();
+			RemoveSpecificEncoders();
 
-		CreateDecoders();
-		pipeline_lock.unlock();
+			CreateDecoders();
+		}
+
 		logti("%s stream has been updated", _log_prefix.CStr());
 	}
 	else
@@ -385,21 +390,25 @@ bool TranscoderStream::UpdateInternal(const std::shared_ptr<info::Stream> &strea
 		logtw("%s This stream does not support seamless transitions. Renewing all", _log_prefix.CStr());
 
 		FlushBuffers();
+	
+		{
+			// Restrict transcoding while all decoders/filters/encoders are being generated			
+			std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
 
-		// Restrict transcoding while all decoders/filters/encoders are being generated
-		std::unique_lock<std::shared_mutex> pipeline_lock(_pipeline_mutex);
-		
-		UpdatePassthroughOutputTracks(stream);
+			// When the entire stream is changed, update the MSID.
+			UpdateMsidOfOutputStreams(stream->GetMsid());
+			// For tracks created as bypass, update the track data to match the input track.
+			UpdatePassthroughOutputTracks(stream);
 
-		RemoveDecoders();
-		RemoveFilters();
-		RemoveEncoders();
+			RemoveDecoders();
+			RemoveFilters();
+			RemoveEncoders();
 
-		CreateDecoders();
-		pipeline_lock.unlock();
+			CreateDecoders();
+		}
+
 		logti("%s stream has been updated", _log_prefix.CStr());
 
-		UpdateMsidOfOutputStreams(stream->GetMsid());
 		NotifyUpdateStreams();
 
 		StoreTracks(stream);

--- a/src/projects/transcoder/transcoder_stream.cpp
+++ b/src/projects/transcoder/transcoder_stream.cpp
@@ -1590,7 +1590,6 @@ void TranscoderStream::UpdateOutputTrack(std::shared_ptr<MediaFrame> buffer)
 		if (output_track->IsBypass())
 		{
 			logtw("%s Invalid output track. Bypass track cannot be connected to decoder. OutputTrack(%d)", _log_prefix.CStr(), output_track->GetId());
-\
 			continue;
 		}
 
@@ -1611,6 +1610,7 @@ void TranscoderStream::UpdatePassthroughOutputTracks(const std::shared_ptr<info:
 			if (output_track->IsBypass() == false)
 			{
 				logtw("%s Invalid output track. Only bypass track can be updated. OutputTrack(%d)", _log_prefix.CStr(), output_track->GetId());
+				continue;
 			}
 
 			UpdateOutputTrackPassthrough(output_track, input_track);

--- a/src/projects/transcoder/transcoder_stream.h
+++ b/src/projects/transcoder/transcoder_stream.h
@@ -226,6 +226,7 @@ private:
 	void ChangeOutputFormat(std::shared_ptr<MediaFrame> buffer);
 	void UpdateInputTrack(std::shared_ptr<MediaFrame> buffer);
 	void UpdateOutputTrack(std::shared_ptr<MediaFrame> buffer);
+	void UpdatePassthroughOutputTracks(const std::shared_ptr<info::Stream> &stream);
 	void UpdateMsidOfOutputStreams(uint32_t msid);
 	bool CanSeamlessTransition(const std::shared_ptr<info::Stream> &stream);
 	void FlushBuffers();

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(
 		output_track->SetFrameRateByConfig(profile.GetFramerate());
 		output_track->SetKeyFrameIntervalByConfig(profile.GetKeyFrameInterval());
 		output_track->SetKeyFrameIntervalTypeByConfig(cmn::GetKeyFrameIntervalTypeByName(profile.GetKeyFrameIntervalType()));
-		ApplySkipFrames(profile.GetSkipFrames(), input_track, output_track);
+		output_track->SetSkipFramesByConfig(profile.GetSkipFrames());
 		output_track->SetLookaheadByConfig(profile.GetLookahead());
 		output_track->SetExtraEncoderOptionsByConfig(profile.GetExtraOptions());
 		output_track->SetCodecModules(profile.GetModules());
@@ -222,6 +222,8 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(
 				output_track->SetCodecModules(cmn::GetCodecModuleIdString(module_id));
 			}
 		}
+
+		ApplySkipFrames(input_track, output_track);
 	}
 
 	return output_track;
@@ -337,8 +339,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetResolutionByConfig(resolution);
 	output_track->SetResolution(resolution);
 	output_track->SetFrameRateByConfig(profile.GetFramerate());
-
-	ApplySkipFrames(profile.GetSkipFrames(), input_track, output_track);
+	output_track->SetSkipFramesByConfig(profile.GetSkipFrames());
 
 	// Github Issue : #1417
 	// Set any value for quick validation of the output track.
@@ -346,6 +347,8 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	// The bitrate of an image doesn’t mean much anyway.
 	output_track->SetBitrateByConfig(0);
 	output_track->SetBitrateByMeasured(1000000);
+
+	ApplySkipFrames(input_track, output_track);
 
 	return output_track;
 }
@@ -645,7 +648,7 @@ double TranscoderStreamInternal::MeasurementToRecommendFramerate(double framerat
 }
 
 // Update the output track information based on the input track and the decoded frame from the decoded frame (bypass)
-void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
+void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track)
 {
 	output_track->SetCodecId(input_track->GetCodecId());
 	output_track->SetCodecModules(input_track->GetCodecModules());
@@ -660,14 +663,14 @@ void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_pt
 
 	if (output_track->GetMediaType() == cmn::MediaType::Video)
 	{
-		output_track->SetResolution(buffer->GetWidth(), buffer->GetHeight());
-		output_track->SetColorspace(buffer->GetFormat<cmn::VideoPixelFormatId>());
+		output_track->SetResolution(input_track->GetResolution());
+		output_track->SetColorspace(input_track->GetColorspace());
 	}
 	else if (output_track->GetMediaType() == cmn::MediaType::Audio)
 	{
-		output_track->SetSampleRate(buffer->GetSampleRate());
-		output_track->SetSampleFormat(buffer->GetFormat<cmn::AudioSample::Format>());
-		output_track->SetChannel(buffer->GetChannels());
+		output_track->SetSampleRate(input_track->GetSampleRate());
+		output_track->SetSampleFormat(input_track->GetSample().GetFormat());
+		output_track->SetChannel(input_track->GetChannel());
 	}
 }
 
@@ -748,7 +751,7 @@ void TranscoderStreamInternal::UpdateOutputVideoTrackByDecodedFrame(const std::s
 			new_output_resolution.height = height;
 		}
 
-		new_output_resolution = ApplyResolutionAlignment(new_output_resolution);
+		new_output_resolution = GetAlignmentResolution(new_output_resolution);
 
 		output_track->SetResolution(new_output_resolution);
 
@@ -1060,7 +1063,7 @@ void TranscoderStreamInternal::GetCountByEncodingType(
 
 // To be compatible with all hardware. The encoding resolution must be a multiple
 // In particular, Xilinx Media Accelerator must have a resolution specified in multiples of 4.
-cmn::Resolution TranscoderStreamInternal::ApplyResolutionAlignment(const cmn::Resolution &resolution)
+cmn::Resolution TranscoderStreamInternal::GetAlignmentResolution(const cmn::Resolution &resolution)
 {
 	auto aligned = resolution;
 
@@ -1087,14 +1090,13 @@ cmn::Resolution TranscoderStreamInternal::ApplyResolutionAlignment(const cmn::Re
 	return aligned;
 }
 
-void TranscoderStreamInternal::ApplySkipFrames(int32_t skip_frames, const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track)
+void TranscoderStreamInternal::ApplySkipFrames(const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track)
 {
+	int32_t skip_frames = output_track->GetSkipFramesByConfig();
 	if (skip_frames < 0)
 	{
 		return;
 	}
-
-	output_track->SetSkipFramesByConfig(skip_frames);
 
 	// When skipFrames is enabled, the user-set framerate is ignored, and the input framerate is adjusted by applying skipFrames.
 	constexpr double precision	   = 100.0;

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -223,7 +223,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(
 			}
 		}
 
-		ApplySkipFrames(input_track, output_track);
+		ApplySkipFrames(output_track, input_track);
 	}
 
 	return output_track;
@@ -348,7 +348,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetBitrateByConfig(0);
 	output_track->SetBitrateByMeasured(1000000);
 
-	ApplySkipFrames(input_track, output_track);
+	ApplySkipFrames(output_track, input_track);
 
 	return output_track;
 }
@@ -1090,7 +1090,7 @@ cmn::Resolution TranscoderStreamInternal::GetAlignmentResolution(const cmn::Reso
 	return aligned;
 }
 
-void TranscoderStreamInternal::ApplySkipFrames(const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track)
+void TranscoderStreamInternal::ApplySkipFrames(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track)
 {
 	int32_t skip_frames = output_track->GetSkipFramesByConfig();
 	if (skip_frames < 0)

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -57,7 +57,7 @@ ov::String TranscoderStreamInternal::ProfileToSerialize(const uint32_t track_id,
 
 	if(profile.GetExtraOptions().IsEmpty() == false)
 	{
-		unique_profile_name += ov::String::FormatString(":%lu", profile.GetExtraOptions().Hash());
+		unique_profile_name += ov::String::FormatString(":%zu", profile.GetExtraOptions().Hash());
 	}
 
 	return unique_profile_name;
@@ -282,6 +282,7 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 		output_track->SetBitrateByConfig(profile.GetBitrate());
 		output_track->SetCodecModules(profile.GetModules());
 		output_track->SetChannelLayout(profile.GetChannel() == 1 ? cmn::AudioChannel::Layout::LayoutMono : cmn::AudioChannel::Layout::LayoutStereo);
+		// Sample Format will be decided by the encoder
 		output_track->SetSampleFormat(cmn::AudioSample::Format::None);
 		output_track->SetSampleRate(profile.GetSamplerate());
 		if (output_track->GetCodecId() == cmn::MediaCodecId::Opus)
@@ -297,9 +298,6 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 		{
 			output_track->SetTimeBase(1, output_track->GetSampleRate());
 		}
-
-		// Sample Format will be decided by the encoder
-		output_track->SetSampleFormat(cmn::AudioSample::Format::None);
 	}
 
 	return output_track;
@@ -834,6 +832,11 @@ void TranscoderStreamInternal::UpdateOutputVideoTrackByDecodedFrame(const std::s
 	{
 		// If the bitrate is not set, it is set based on the input video bitrate.
 		auto new_output_bitrate = input_track->GetBitrateByConfig();
+		if(new_output_bitrate <= 0)
+		{
+			// If the input bitrate is not set, it is set based on the measured bitrate.
+			new_output_bitrate = input_track->GetBitrateByMeasured();
+		}
 
 		output_track->SetBitrateByConfig(new_output_bitrate);
 
@@ -922,6 +925,11 @@ void TranscoderStreamInternal::UpdateOutputAudioTrackByDecodedFrame(const std::s
 	{
 		// If the bitrate is not set, it is set based on the input video bitrate.
 		auto new_output_bitrate = input_track->GetBitrateByConfig();
+		if(new_output_bitrate <= 0)
+		{
+			// If the input bitrate is not set, it is set based on the measured bitrate.
+			new_output_bitrate = input_track->GetBitrateByMeasured();
+		}
 
 		output_track->SetBitrateByConfig(new_output_bitrate);
 

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -55,6 +55,11 @@ ov::String TranscoderStreamInternal::ProfileToSerialize(const uint32_t track_id,
 		unique_profile_name += ov::String::FormatString(":%s", profile.GetModules().CStr());
 	}
 
+	if(profile.GetExtraOptions().IsEmpty() == false)
+	{
+		unique_profile_name += ov::String::FormatString(":%lu", profile.GetExtraOptions().Hash());
+	}
+
 	return unique_profile_name;
 }
 
@@ -146,165 +151,69 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(
 		return nullptr;
 	}
 
-	bool is_parsed;
-	profile.IsBypass(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetBypassByConfig(profile.IsBypass());
-	}
-
-	profile.GetBitrateString(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetBitrateByConfig(profile.GetBitrate());
-	}
-
-	std::optional<int> width;
-	std::optional<int> height;
-
-	profile.GetWidth(&is_parsed);
-	if (is_parsed == true)
-	{
-		width = profile.GetWidth();
-	}
-
-	profile.GetHeight(&is_parsed);
-	if (is_parsed == true)
-	{
-		height = profile.GetHeight();
-	}
-
-	if (width.has_value() && height.has_value())
-	{
-		output_track->SetResolutionByConfig(width.value(), height.value());
-	}
-	else if (width.has_value())
-	{
-		auto resolution = output_track->GetResolutionByConfig();
-		output_track->SetResolutionByConfig(width.value(), resolution.height);
-	}
-	else if (height.has_value())
-	{
-		auto resolution = output_track->GetResolutionByConfig();
-		output_track->SetResolutionByConfig(resolution.width, height.value());
-	}
-
-	profile.GetFramerate(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetFrameRateByConfig(profile.GetFramerate());
-	}
-
-	profile.GetKeyFrameInterval(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetKeyFrameIntervalByConfig(profile.GetKeyFrameInterval());
-	}
-
-	profile.GetKeyFrameIntervalType(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetKeyFrameIntervalTypeByConfig(cmn::GetKeyFrameIntervalTypeByName(profile.GetKeyFrameIntervalType()));
-	}
-
-	// If SkipFrames is enabled, it affects the output track's framerate and keyframe interval.
-	profile.GetSkipFrames(&is_parsed);
-	if (is_parsed == true)
-	{
-		auto skip_frames = profile.GetSkipFrames();
-
-		// Set ouput framerate according to the skip frames.
-		if (skip_frames >= 0)
-		{
-			output_track->SetSkipFramesByConfig(skip_frames);
-
-			// Adjust the framerate according to the skip frames. 
-			// When skipFrames is enabled, the user-set framerate is ignored, and the input framerate is adjusted by applying skipFrames.
-			// Round adjusted_frame_rate to 2 decimal places
-			auto adjusted_frame_rate = ::round(input_track->GetFrameRate() / (skip_frames + 1) * 100.0) / 100.0;
-
-			logtt("Adjust the output framerate %.02f -> %.02f according to the skip frames %d",
-				  input_track->GetFrameRate(),
-				  adjusted_frame_rate,
-				  skip_frames);
-			output_track->SetFrameRateByConfig(adjusted_frame_rate);
-
-#if 0 // This feature needs more consideration. It may confuse to users.
-			// Set keyframe interval according to the skip frames.
-			//  If the keyframe interval is not set, it will be automatically adjusted by the encoder.
-			if (output_track->GetKeyFrameIntervalByConfig() > 0)
-			{
-				auto adjusted_key_frame_interval = ::round(output_track->GetKeyFrameIntervalByConfig() / (skip_frames + 1));
-				logtt("Adjust the output key_frame_interval %.02f -> %.02f according to the skip frames %d",
-					  output_track->GetKeyFrameIntervalByConfig(),
-					  adjusted_key_frame_interval,
-					  skip_frames);
-
-				output_track->SetKeyFrameIntervalByConfig(adjusted_key_frame_interval);
-			}
-#endif
-		}
-	}
-
-	profile.GetLookahead(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetLookaheadByConfig(profile.GetLookahead());
-	}
-
-	profile.GetExtraOptions(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetExtraEncoderOptionsByConfig(profile.GetExtraOptions());
-	}
-
-
-
-
+	output_track->SetBypassByConfig(profile.IsBypass());
 	output_track->SetMediaType(cmn::MediaType::Video);
 	output_track->SetId(NewTrackId());
 	output_track->SetPublicName(input_track->GetPublicName());
-	// If the user does not specify, the default value generated in config/items/virtual_hosts/applications/output_profiles/encodes/encodes.h will be used.
-	output_track->SetVariantName(profile.GetName());	
+	output_track->SetVariantName(profile.GetName());
 	output_track->SetLanguage(input_track->GetLanguage());
 	output_track->SetCharacteristics(input_track->GetCharacteristics());
 	output_track->SetOriginBitstream(input_track->GetOriginBitstream());
 
-	bool need_bypass = IsMatchesBypassCondition(input_track, profile);
-	if (need_bypass == true)
+	bool is_bypass = IsMatchesBypassCondition(input_track, profile);
+	if (is_bypass == true)
 	{
 		output_track->SetBypass(true);
 
 		output_track->SetCodecId(input_track->GetCodecId());
 		output_track->SetCodecModules(input_track->GetCodecModules());
 		output_track->SetCodecModuleId(input_track->GetCodecModuleId());
+		output_track->SetResolution(input_track->GetResolution());
 		output_track->SetMaxResolution(input_track->GetMaxResolution());
 		output_track->SetMaxFrameRate(input_track->GetMaxFrameRate());
-		output_track->SetResolution(input_track->GetResolution());
 		output_track->SetTimeBase(input_track->GetTimeBase());
+		output_track->SetDecoderConfigurationRecord(input_track->GetDecoderConfigurationRecord());
 	}
 	else
 	{
 		output_track->SetBypass(false);
 
 		auto codec_id = cmn::GetCodecIdByName(profile.GetCodec());
+		if (cmn::IsVideoCodec(codec_id) == false)
+		{
+			logtw("%s codec is not supported video codec", profile.GetCodec().CStr());
+			return nullptr;
+		}
 
 		output_track->SetCodecId(codec_id);
-		output_track->SetCodecModules(profile.GetModules());
-		output_track->SetResolution(profile.GetWidth(), profile.GetHeight());
 		output_track->SetTimeBase(GetDefaultTimebaseByCodecId(codec_id));
+
+		cmn::Resolution resolution;
+		resolution.width  = profile.GetWidth();
+		resolution.height = profile.GetHeight();
+		output_track->SetResolutionByConfig(resolution);
+		output_track->SetResolution(resolution);
+
 		output_track->SetPreset(profile.GetPreset());
 		output_track->SetThreadCount(profile.GetThreadCount());
 		output_track->SetBFrames(profile.GetBFrames());
 		output_track->SetProfile(profile.GetProfile());
+		output_track->SetBitrateByConfig(profile.GetBitrate());
+		output_track->SetFrameRateByConfig(profile.GetFramerate());
+		output_track->SetKeyFrameIntervalByConfig(profile.GetKeyFrameInterval());
+		output_track->SetKeyFrameIntervalTypeByConfig(cmn::GetKeyFrameIntervalTypeByName(profile.GetKeyFrameIntervalType()));
+		ApplySkipFrames(profile.GetSkipFrames(), input_track, output_track);
+		output_track->SetLookaheadByConfig(profile.GetLookahead());
+		output_track->SetExtraEncoderOptionsByConfig(profile.GetExtraOptions());
+		output_track->SetCodecModules(profile.GetModules());
 
-		// Used when the encoding profile codec name includes the module name.
+		// Used when the encoding profile codec name includes the module name. This specification will soon be deprecated.
 		// ex) <Codec>h264_nvenc</Codec>
 		// ex) <Codec>h264_openh264</Codec>
 		auto module_id = cmn::GetCodecModuleIdByName(profile.GetCodec());
-		if(module_id != cmn::MediaCodecModuleId::None)
+		if (module_id != cmn::MediaCodecModuleId::None)
 		{
-			if(output_track->GetCodecModules().IsEmpty() == false)
+			if (output_track->GetCodecModules().IsEmpty() == false)
 			{
 				output_track->SetCodecModules(ov::String::FormatString("%s,%s", cmn::GetCodecModuleIdString(module_id), output_track->GetCodecModules().CStr()));
 			}
@@ -313,26 +222,6 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(
 				output_track->SetCodecModules(cmn::GetCodecModuleIdString(module_id));
 			}
 		}
-	}
-
-	//  If the framerate is not set, it is set to the same value as the input.
-	if(output_track->GetFrameRateByConfig() == 0)
-	{
-		output_track->SetFrameRateByConfig(input_track->GetFrameRateByConfig());
-		output_track->SetFrameRateByMeasured(input_track->GetFrameRateByMeasured());
-	}
-
-	//  If the bitrate is not set, it is set to the same value as the input.
-	if(output_track->GetBitrateByConfig() == 0)
-	{
-		output_track->SetBitrateByConfig(input_track->GetBitrateByConfig());
-		output_track->SetBitrateByMeasured(input_track->GetBitrateByMeasured());
-	}
-
-	if (cmn::IsVideoCodec(output_track->GetCodecId()) == false)
-	{
-		logtw("%s codec is not supported video codec", profile.GetCodec().CStr());
-		return nullptr;
 	}
 
 	return output_track;
@@ -353,28 +242,23 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 		output_track->SetBypassByConfig(profile.IsBypass());
 	}
 
-	profile.GetBitrateString(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetBitrateByConfig(profile.GetBitrate());
-	}
-
 	output_track->SetMediaType(cmn::MediaType::Audio);
 	output_track->SetId(NewTrackId());
-	
+
 	ov::String public_name = ov::String::FormatString("%s_%d", input_track->GetPublicName().CStr(), output_track->GetId());
 	output_track->SetPublicName(public_name);
-	// If the user does not specify, the default value generated in config/items/virtual_hosts/applications/output_profiles/encodes/encodes.h will be used.
-	output_track->SetVariantName(profile.GetName());	
+	output_track->SetVariantName(profile.GetName());
 	output_track->SetLanguage(input_track->GetLanguage());
 	output_track->SetCharacteristics(input_track->GetCharacteristics());
 	output_track->SetOriginBitstream(input_track->GetOriginBitstream());
 
-	bool need_bypass = IsMatchesBypassCondition(input_track, profile);
-	if (need_bypass == true)
+	bool is_bypass = IsMatchesBypassCondition(input_track, profile);
+	if (is_bypass == true)
 	{
 		output_track->SetBypass(true);
+
 		output_track->SetCodecId(input_track->GetCodecId());
+		output_track->SetBitrateByConfig(input_track->GetBitrateByConfig());
 		output_track->SetCodecModules(input_track->GetCodecModules());
 		output_track->SetCodecModuleId(input_track->GetCodecModuleId());
 		output_track->SetChannel(input_track->GetChannel());
@@ -386,13 +270,20 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	else
 	{
 		output_track->SetBypass(false);
-		output_track->SetCodecId(cmn::GetCodecIdByName(profile.GetCodec()));
+
+		auto codec_id = cmn::GetCodecIdByName(profile.GetCodec());
+		if (cmn::IsAudioCodec(codec_id) == false)
+		{
+			logtw("%s codec is not supported audio codec", profile.GetCodec().CStr());
+			return nullptr;
+		}
+
+		output_track->SetCodecId(codec_id);
+		output_track->SetBitrateByConfig(profile.GetBitrate());
 		output_track->SetCodecModules(profile.GetModules());
 		output_track->SetChannelLayout(profile.GetChannel() == 1 ? cmn::AudioChannel::Layout::LayoutMono : cmn::AudioChannel::Layout::LayoutStereo);
-		output_track->SetSampleFormat(input_track->GetSample().GetFormat());	// The sample format will change by the decoder event.
+		output_track->SetSampleFormat(cmn::AudioSample::Format::None);
 		output_track->SetSampleRate(profile.GetSamplerate());
-
-		// Samplerate
 		if (output_track->GetCodecId() == cmn::MediaCodecId::Opus)
 		{
 			if (output_track->GetSampleRate() != 48000)
@@ -402,28 +293,13 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 			}
 		}
 
-		// Timebase
-		if (output_track->GetSampleRate() == 0)
-		{
-			output_track->SetTimeBase(GetDefaultTimebaseByCodecId(output_track->GetCodecId()));
-		}
-		else
+		if (output_track->GetSampleRate() > 0)
 		{
 			output_track->SetTimeBase(1, output_track->GetSampleRate());
 		}
-	}
 
-	//  If the bitrate is not set, it is set to the same value as the input.
-	if(output_track->GetBitrateByConfig() == 0)
-	{
-		output_track->SetBitrateByConfig(input_track->GetBitrateByConfig());
-		output_track->SetBitrateByMeasured(input_track->GetBitrateByMeasured());
-	}
-
-	if (cmn::IsAudioCodec(output_track->GetCodecId()) == false)
-	{
-		logtw("%s codec is not supported audio codec", profile.GetCodec().CStr());
-		return nullptr;
+		// Sample Format will be decided by the encoder
+		output_track->SetSampleFormat(cmn::AudioSample::Format::None);
 	}
 
 	return output_track;
@@ -437,86 +313,8 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 		return nullptr;
 	}
 
-	bool is_parsed;
-
-	std::optional<int> width;
-	std::optional<int> height;
-
-	profile.GetWidth(&is_parsed);
-	if (is_parsed == true)
-	{
-		width = profile.GetWidth();
-	}
-
-	profile.GetHeight(&is_parsed);
-	if (is_parsed == true)
-	{
-		height = profile.GetHeight();
-	}
-
-	if (width.has_value() && height.has_value())
-	{
-		output_track->SetResolutionByConfig(width.value(), height.value());
-	}
-	else if (width.has_value())
-	{
-		auto resolution = output_track->GetResolutionByConfig();
-		output_track->SetResolutionByConfig(width.value(), resolution.height);
-	}
-	else if (height.has_value())
-	{
-		auto resolution = output_track->GetResolutionByConfig();
-		output_track->SetResolutionByConfig(resolution.width, height.value());
-	}
-
-	profile.GetFramerate(&is_parsed);
-	if (is_parsed == true)
-	{
-		output_track->SetFrameRateByConfig(profile.GetFramerate());
-	}
-
-	// If SkipFrames is enabled, it affects the output track's framerate and keyframe interval.
-	profile.GetSkipFrames(&is_parsed);
-	if (is_parsed == true)
-	{
-		auto skip_frames = profile.GetSkipFrames();
-
-		// Set ouput framerate according to the skip frames.
-		if (skip_frames >= 0)
-		{
-			output_track->SetSkipFramesByConfig(skip_frames);
-
-			// Adjust the framerate according to the skip frames. 
-			// When skipFrames is enabled, the user-set framerate is ignored, and the input framerate is adjusted by applying skipFrames.
-			// Round adjusted_frame_rate to 2 decimal places
-			auto adjusted_frame_rate = ::round(input_track->GetFrameRate() / (skip_frames + 1) * 100.0) / 100.0;
-
-			logtt("Adjust the output framerate %.02f -> %.02f according to the skip frames %d",
-				  input_track->GetFrameRate(),
-				  adjusted_frame_rate,
-				  skip_frames);
-			output_track->SetFrameRateByConfig(adjusted_frame_rate);
-
-#if 0 // This feature needs more consideration. It may confuse to users.
-			// Set keyframe interval according to the skip frames.
-			//  If the keyframe interval is not set, it will be automatically adjusted by the encoder.
-			if (output_track->GetKeyFrameIntervalByConfig() > 0)
-			{
-				auto adjusted_key_frame_interval = ::round(output_track->GetKeyFrameIntervalByConfig() / (skip_frames + 1));
-				logtt("Adjust the output key_frame_interval %.02f -> %.02f according to the skip frames %d",
-					  output_track->GetKeyFrameIntervalByConfig(),
-					  adjusted_key_frame_interval,
-					  skip_frames);
-
-				output_track->SetKeyFrameIntervalByConfig(adjusted_key_frame_interval);
-			}
-#endif
-		}
-	}
-
 	output_track->SetPublicName(input_track->GetPublicName());
-	// If the user does not specify, the default value generated in config/items/virtual_hosts/applications/output_profiles/encodes/encodes.h will be used.
-	output_track->SetVariantName(profile.GetName());	
+	output_track->SetVariantName(profile.GetName());
 	output_track->SetLanguage(input_track->GetLanguage());
 	output_track->SetCharacteristics(input_track->GetCharacteristics());
 	output_track->SetOriginBitstream(input_track->GetOriginBitstream());
@@ -524,34 +322,32 @@ std::shared_ptr<MediaTrack> TranscoderStreamInternal::CreateOutputTrack(const st
 	output_track->SetMediaType(cmn::MediaType::Video);
 	output_track->SetId(NewTrackId());
 	output_track->SetBypass(false);
-	output_track->SetCodecId(cmn::GetCodecIdByName(profile.GetCodec()));
-	output_track->SetCodecModules(profile.GetModules());
-	output_track->SetResolution(profile.GetWidth(), profile.GetHeight());
-	output_track->SetTimeBase(GetDefaultTimebaseByCodecId(output_track->GetCodecId()));
 
-	// Github Issue : #1417
-	// Set any value for quick validation of the output track. 
-	// If the validation of OutputTrack is delayed, the Stream Prepare event occurs late in Publisher.
-	// The bitrate of an image doesn’t mean much anyway.
-	output_track->SetBitrateByConfig(0);
-	output_track->SetBitrateByMeasured(1000000);
-	
-	//  If the framerate is not set, it is set to the same value as the input.
-	if(output_track->GetFrameRateByConfig() == 0)
-	{
-		output_track->SetFrameRateByMeasured(input_track->GetFrameRate());
-	}
-	else
-	{
-		output_track->SetFrameRateByMeasured(output_track->GetFrameRateByConfig());
-	}
-	
-
-	if (cmn::IsImageCodec(output_track->GetCodecId()) == false)
+	auto codec_id = cmn::GetCodecIdByName(profile.GetCodec());
+	if (cmn::IsImageCodec(codec_id) == false)
 	{
 		logtw("%s codec is not supported image codec", profile.GetCodec().CStr());
 		return nullptr;
 	}
+	output_track->SetCodecId(codec_id);
+	output_track->SetTimeBase(GetDefaultTimebaseByCodecId(codec_id));
+	output_track->SetCodecModules(profile.GetModules());
+
+	cmn::Resolution resolution;
+	resolution.width  = profile.GetWidth();
+	resolution.height = profile.GetHeight();
+	output_track->SetResolutionByConfig(resolution);
+	output_track->SetResolution(resolution);
+	output_track->SetFrameRateByConfig(profile.GetFramerate());
+
+	ApplySkipFrames(profile.GetSkipFrames(), input_track, output_track);
+
+	// Github Issue : #1417
+	// Set any value for quick validation of the output track.
+	// If the validation of OutputTrack is delayed, the Stream Prepare event occurs late in Publisher.
+	// The bitrate of an image doesn’t mean much anyway.
+	output_track->SetBitrateByConfig(0);
+	output_track->SetBitrateByMeasured(1000000);
 
 	return output_track;
 }
@@ -850,8 +646,20 @@ double TranscoderStreamInternal::MeasurementToRecommendFramerate(double framerat
 	return ::floor(recommend_framerate);
 }
 
-void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, std::shared_ptr<MediaFrame> buffer)
+// Update the output track information based on the input track and the decoded frame from the decoded frame (bypass)
+void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
 {
+	output_track->SetCodecId(input_track->GetCodecId());
+	output_track->SetCodecModules(input_track->GetCodecModules());
+	output_track->SetCodecModuleId(input_track->GetCodecModuleId());
+
+	output_track->SetFrameRateByConfig(input_track->GetFrameRateByConfig());
+	output_track->SetFrameRateByMeasured(input_track->GetFrameRateByMeasured());
+	output_track->SetBitrateByMeasured(input_track->GetBitrateByMeasured());
+	output_track->SetBitrateByConfig(input_track->GetBitrateByConfig());
+	output_track->SetTimeBase(input_track->GetTimeBase());
+	output_track->SetDecoderConfigurationRecord(input_track->GetDecoderConfigurationRecord());
+
 	if (output_track->GetMediaType() == cmn::MediaType::Video)
 	{
 		output_track->SetResolution(buffer->GetWidth(), buffer->GetHeight());
@@ -865,79 +673,260 @@ void TranscoderStreamInternal::UpdateOutputTrackPassthrough(const std::shared_pt
 	}
 }
 
+// Update the output track information based on the decoded frame from the decoder before creating the encoder. (encoding)
+// If the user has not specified it, the output specification is automatically determined.
+// Once determined for the first time, the specification is maintained until the stream ends.
 void TranscoderStreamInternal::UpdateOutputTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
 {
 	if (output_track->GetMediaType() == cmn::MediaType::Video)
 	{
-		float aspect_ratio = (float)buffer->GetWidth() / (float)buffer->GetHeight();
-
-		// Keep the original video resolution
-		auto output_resolution = output_track->GetResolution();
-		if (output_resolution.width == 0 && output_resolution.height == 0)
-		{
-			output_resolution.width = buffer->GetWidth();
-			output_resolution.height = buffer->GetHeight();
-			output_track->SetResolution(output_resolution);
-		}
-		// Width is automatically calculated as the original video ratio
-		else if (output_resolution.width == 0 && output_resolution.height != 0)
-		{
-			int32_t width = (int32_t)((float)output_resolution.height * aspect_ratio);
-			width = (width % 2 == 0) ? width : width + 1;
-
-			output_resolution.width = width;
-			output_track->SetResolution(output_resolution);
-		}
-		// Heigh is automatically calculated as the original video ratio
-		else if (output_resolution.width != 0 && output_resolution.height == 0)
-		{
-			int32_t height = (int32_t)((float)output_resolution.width / aspect_ratio);
-			height = (height % 2 == 0) ? height : height + 1;
-
-			output_resolution.height = height;
-			output_track->SetResolution(output_resolution);
-		}
-
-		// Set framerate of the output track
-		if (output_track->GetFrameRateByConfig() == 0.0f)
-		{
-			output_track->SetFrameRateByMeasured(input_track->GetFrameRateByMeasured());
-		}
-
-		// To be compatible with all hardware. The encoding resolution must be a multiple of 4
-		// In particular, Xilinx Media Accelerator must have a resolution specified in multiples of 4.
-		if (output_resolution.width % 4 != 0)
-		{
-			int32_t new_width = (output_resolution.width / 4 + 1) * 4;
-
-			logtd("The width of the output track is not a multiple of 4. change the width to %d -> %d", output_resolution.width, new_width);
-
-			output_resolution.width = new_width;
-			output_track->SetResolution(output_resolution);
-		}
-
-		if (output_resolution.height % 4 != 0)
-		{
-			int32_t new_height = (output_resolution.height / 4 + 1) * 4;
-
-			logtd("The height of the output track is not a multiple of 4. change the height to %d -> %d", output_resolution.height, new_height);
-
-			output_resolution.height = new_height;
-			output_track->SetResolution(output_resolution);
-		}
+		UpdateOutputVideoTrackByDecodedFrame(output_track, input_track, buffer);
 	}
 	else if (output_track->GetMediaType() == cmn::MediaType::Audio)
 	{
-		if (output_track->GetSampleRate() == 0)
+		UpdateOutputAudioTrackByDecodedFrame(output_track, input_track, buffer);
+	}
+	else
+	{
+		// Not need to update for other media types.
+	}
+}
+
+void TranscoderStreamInternal::UpdateOutputVideoTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
+{
+	const int32_t src_width	 = buffer->GetWidth();
+	const int32_t src_height = buffer->GetHeight();
+
+	if (src_width <= 0 || src_height <= 0)
+	{
+		logte("Invalid decoded frame size: %dx%d", src_width, src_height);
+		return;
+	}
+
+	logtt("Input Resolution: %dx%d(conf) %dx%d(max), Output Resolution: %dx%d(conf) %dx%d(max)",
+		  input_track->GetResolution().width, input_track->GetResolution().height,
+		  input_track->GetMaxResolution().width, input_track->GetMaxResolution().height,
+		  output_track->GetResolution().width, output_track->GetResolution().height,
+		  output_track->GetMaxResolution().width, output_track->GetMaxResolution().height);
+
+	// Update Output resolution
+	auto output_resolution = output_track->GetResolution();
+	if (output_resolution.width > 0 && output_resolution.height > 0 &&
+		output_resolution.width % 4 == 0 && output_resolution.height % 4 == 0)
+	{
+		// The output resolution is already set. It should be maintained until the stream end.
+		logtt("Resolution is not changed. %dx%d", output_resolution.width, output_resolution.height);
+	}
+	else
+	{
+		// If the output resolution is not set, it is set based on the original video resolution.
+		auto new_output_resolution = output_resolution;
+
+		if (output_resolution.width == 0 && output_resolution.height == 0)
 		{
-			output_track->SetSampleRate(buffer->GetSampleRate());
-			output_track->SetTimeBase(1, buffer->GetSampleRate());
+			// Used the original video resolution
+			new_output_resolution.width	 = buffer->GetWidth();
+			new_output_resolution.height = buffer->GetHeight();
+		}
+		else if (output_resolution.width == 0 && output_resolution.height != 0)
+		{
+			// Width is automatically calculated as the original video ratio
+			const float aspect_ratio	= static_cast<float>(src_width) / static_cast<float>(src_height);
+			const double scaled_width	= static_cast<double>(output_resolution.height) * static_cast<double>(aspect_ratio);
+			int32_t width				= static_cast<int32_t>(std::lround(scaled_width));
+
+			width						= (width % 2 == 0) ? width : width + 1;
+
+			new_output_resolution.width = width;
+		}
+		else if (output_resolution.width != 0 && output_resolution.height == 0)
+		{
+			// Height is automatically calculated as the original video ratio
+			const float aspect_ratio	 = static_cast<float>(src_width) / static_cast<float>(src_height);
+			const double scaled_height	 = static_cast<double>(output_resolution.width) / static_cast<double>(aspect_ratio);
+			int32_t height				 = static_cast<int32_t>(std::lround(scaled_height));
+			height						 = (height % 2 == 0) ? height : height + 1;
+
+			new_output_resolution.height = height;
 		}
 
-		if (output_track->GetChannel().GetLayout() == cmn::AudioChannel::Layout::LayoutUnknown)
+		new_output_resolution = ApplyResolutionAlignment(new_output_resolution);
+
+		output_track->SetResolution(new_output_resolution);
+
+		logtd("Id(%d), Resolution is changed %dx%d -> %dx%d",
+			  output_track->GetId(), output_resolution.width, output_resolution.height,
+			  new_output_resolution.width, new_output_resolution.height);
+	}
+
+	logtt("Input Timebase: %d/%d, Output Timebase: %d/%d",
+		  input_track->GetTimeBase().GetNum(), input_track->GetTimeBase().GetDen(),
+		  output_track->GetTimeBase().GetNum(), output_track->GetTimeBase().GetDen());
+
+	// Update timebase of the output track
+	auto output_timebase = output_track->GetTimeBase();
+	if (output_timebase.GetNum() != 0 && output_timebase.GetDen() != 0)
+	{
+		// The timebase is already set. It should be maintained until the stream end.
+		logtt("Timebase is not changed. %d/%d", output_timebase.GetNum(), output_timebase.GetDen());
+	}
+	else
+	{
+		// If the timebase is not set, it is set default timebase based on the codec.
+		auto new_output_timebase = GetDefaultTimebaseByCodecId(output_track->GetCodecId());
+
+		output_track->SetTimeBase(new_output_timebase);
+
+		logtd("Id(%d), Timebase is changed. %d/%d -> %d/%d",
+			  output_track->GetId(), output_timebase.GetNum(), output_timebase.GetDen(),
+			  new_output_timebase.GetNum(), new_output_timebase.GetDen());
+	}
+
+	// Update framerate of the output track
+	logtt("Input Framerate: %.02f(conf) %.02f(measure) %.02f(max), Output Framerate: %.02f(conf) %.02f(measure) %.02f(max)",
+		  input_track->GetFrameRateByConfig(), input_track->GetFrameRateByMeasured(), input_track->GetMaxFrameRate(),
+		  output_track->GetFrameRateByConfig(), output_track->GetFrameRateByMeasured(), output_track->GetMaxFrameRate());
+
+	auto output_framerate = output_track->GetFrameRateByConfig();
+	if (output_framerate > 0.0f)
+	{
+		// The framerate is already set. It should be maintained until the stream end.
+		logtt("Framerate is not changed.  %.2f", output_framerate);
+	}
+	else
+	{
+		// If the framerate is not set, it is set based on the input video framerate.
+		double new_output_framerate;
+		if (input_track->GetFrameRateByConfig() > 0.0f)
 		{
-			output_track->SetChannel(buffer->GetChannels());
+			new_output_framerate = input_track->GetFrameRateByConfig();
 		}
+		else if (buffer->GetDuration() > 0)
+		{
+			new_output_framerate = 1.0f / (input_track->GetTimeBase().GetExpr() * buffer->GetDuration());
+		}
+		else if (input_track->GetFrameRateByMeasured() > 0.0f)
+		{
+			new_output_framerate = input_track->GetFrameRateByMeasured();
+		}
+		else
+		{
+			new_output_framerate = 1.0f;
+		}
+
+		output_track->SetFrameRateByConfig(new_output_framerate);
+
+		logtd("Id(%d), Framerate is changed. %.2f -> %.2f",
+			  output_track->GetId(), output_framerate, new_output_framerate);
+	}
+
+	// Update Output bitrate
+	logtt("Input Bitrate: %d(conf) %d(measure), Output Bitrate: %d(conf) %d(measure)",
+		  input_track->GetBitrateByConfig(), input_track->GetBitrateByMeasured(), output_track->GetBitrateByConfig(), output_track->GetBitrateByMeasured());
+
+	auto output_bitrate = output_track->GetBitrateByConfig();
+	if (output_bitrate > 0)
+	{
+		// The bitrate is already set. It should be maintained until the stream end.
+		logtt("Bitrate is not changed. %d", output_bitrate);
+	}
+	else
+	{
+		// If the bitrate is not set, it is set based on the input video bitrate.
+		auto new_output_bitrate = input_track->GetBitrateByConfig();
+
+		output_track->SetBitrateByConfig(new_output_bitrate);
+
+		logtd("Id(%d), Bitrate is changed. %d -> %d", output_track->GetId(), output_bitrate, new_output_bitrate);
+	}
+}
+
+void TranscoderStreamInternal::UpdateOutputAudioTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
+{
+	if (buffer->GetSampleRate() <= 0 || buffer->GetChannels().GetLayout() == cmn::AudioChannel::Layout::LayoutUnknown)
+	{
+		logte("Invalid decoded frame sample rate: %d", buffer->GetSampleRate());
+		return;
+	}
+
+	// Update sample rate of the output track
+	logtt("Input SampleRate: %d, Output SampleRate: %d",
+		  input_track->GetSampleRate(), output_track->GetSampleRate());
+
+	auto output_samplerate = output_track->GetSampleRate();
+	if (output_samplerate > 0)
+	{
+		logtt("SampleRate is not changed. %d", output_samplerate);
+	}
+	else
+	{
+		auto new_output_samplerate = buffer->GetSampleRate();
+
+		logtd("Id(%d), SampleRate is changed. %d -> %d",
+			  output_track->GetId(), output_samplerate, new_output_samplerate);
+
+		output_track->SetSampleRate(new_output_samplerate);
+	}
+
+	// Update timebase of the output track
+	logtt("Input Timebase: %d/%d, Output Timebase: %d/%d",
+		  input_track->GetTimeBase().GetNum(), input_track->GetTimeBase().GetDen(), output_track->GetTimeBase().GetNum(), output_track->GetTimeBase().GetDen());
+
+	auto output_timebase = output_track->GetTimeBase();
+	if (output_timebase.GetNum() != 0 && output_timebase.GetDen() != 0)
+	{
+		logtt("Timebase is not changed. %d/%d", output_timebase.GetNum(), output_timebase.GetDen());
+	}
+	else
+	{
+		cmn::Timebase new_output_timebase;
+
+		new_output_timebase.Set(1, buffer->GetSampleRate());
+
+		output_track->SetTimeBase(new_output_timebase);
+
+		logtd("Id(%d), Timebase is changed. %d/%d -> %d/%d",
+			  output_track->GetId(), output_timebase.GetNum(), output_timebase.GetDen(), new_output_timebase.GetNum(), new_output_timebase.GetDen());
+	}
+
+	// Update channel layout of the output track
+	logtt("Input Channel Layout: %s, Output Channel Layout: %s",
+		  cmn::AudioChannel::GetLayoutName(input_track->GetChannel().GetLayout()), cmn::AudioChannel::GetLayoutName(output_track->GetChannel().GetLayout()));
+
+	if (output_track->GetChannel().GetLayout() != cmn::AudioChannel::Layout::LayoutUnknown)
+	{
+		logtt("Id(%d), Channel layout is not changed. %s",
+			  output_track->GetId(), cmn::AudioChannel::GetLayoutName(output_track->GetChannel().GetLayout()));
+	}
+	else
+	{
+		logtd("Id(%d), Channel layout is changed. %s -> %s",
+			  output_track->GetId(),
+			  cmn::AudioChannel::GetLayoutName(output_track->GetChannel().GetLayout()),
+			  cmn::AudioChannel::GetLayoutName(buffer->GetChannels().GetLayout()));
+
+		output_track->SetChannel(buffer->GetChannels());
+	}
+
+	// Update Output bitrate
+	logtt("Input Bitrate: %d(conf) %d(measure), Output Bitrate: %d(conf) %d(measure)",
+		  input_track->GetBitrateByConfig(), input_track->GetBitrateByMeasured(), output_track->GetBitrateByConfig(), output_track->GetBitrateByMeasured());
+
+	auto output_bitrate = output_track->GetBitrateByConfig();
+	if (output_bitrate > 0)
+	{
+		// The bitrate is already set. It should be maintained until the stream end.
+		logtt("Bitrate is not changed. %d", output_bitrate);
+	}
+	else
+	{
+		// If the bitrate is not set, it is set based on the input video bitrate.
+		auto new_output_bitrate = input_track->GetBitrateByConfig();
+
+		output_track->SetBitrateByConfig(new_output_bitrate);
+
+		logtd("Id(%d), Bitrate is changed. %d -> %d",
+			  output_track->GetId(), output_bitrate, new_output_bitrate);
 	}
 }
 
@@ -1053,4 +1042,51 @@ void TranscoderStreamInternal::GetCountByEncodingType(
 			}
 		}
 	}
+}
+
+// To be compatible with all hardware. The encoding resolution must be a multiple
+// In particular, Xilinx Media Accelerator must have a resolution specified in multiples of 4.
+cmn::Resolution TranscoderStreamInternal::ApplyResolutionAlignment(const cmn::Resolution &resolution)
+{
+	auto aligned = resolution;
+
+	if (aligned.width % 4 != 0)
+	{
+		int32_t new_width = (aligned.width / 4 + 1) * 4;
+
+		logtw("The width of the output track is not a multiple of 4. change the width to %d -> %d",
+			  aligned.width, new_width);
+
+		aligned.width = new_width;
+	}
+
+	if (aligned.height % 4 != 0)
+	{
+		int32_t new_height = (aligned.height / 4 + 1) * 4;
+
+		logtw("The height of the output track is not a multiple of 4. change the height to %d -> %d",
+			  aligned.height, new_height);
+
+		aligned.height = new_height;
+	}
+
+	return aligned;
+}
+
+void TranscoderStreamInternal::ApplySkipFrames(int32_t skip_frames, const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track)
+{
+	if (skip_frames < 0)
+	{
+		return;
+	}
+
+	output_track->SetSkipFramesByConfig(skip_frames);
+
+	// When skipFrames is enabled, the user-set framerate is ignored, and the input framerate is adjusted by applying skipFrames.
+	constexpr double precision	   = 100.0;
+	auto adjusted_output_framerate = std::round(input_track->GetFrameRate() / (skip_frames + 1.0) * precision) / precision;
+
+	output_track->SetFrameRateByConfig(adjusted_output_framerate);
+
+	logtd("Adjust the output framerate %.02f -> %.02f according to the skip frames %d", input_track->GetFrameRate(), adjusted_output_framerate, skip_frames);
 }

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -686,7 +686,7 @@ void TranscoderStreamInternal::UpdateOutputTrackByDecodedFrame(const std::shared
 	}
 	else
 	{
-		// Not need to update for other media types.
+		// No update is needed for other media types.
 	}
 }
 
@@ -846,11 +846,17 @@ void TranscoderStreamInternal::UpdateOutputVideoTrackByDecodedFrame(const std::s
 
 void TranscoderStreamInternal::UpdateOutputAudioTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer)
 {
-	if (buffer->GetSampleRate() <= 0 || buffer->GetChannels().GetLayout() == cmn::AudioChannel::Layout::LayoutUnknown)
-	{
-		logte("Invalid decoded frame sample rate: %d", buffer->GetSampleRate());
-		return;
-	}
+ 	if (buffer->GetSampleRate() <= 0)
+ 	{
+ 		logte("Invalid decoded frame sample rate: %d", buffer->GetSampleRate());
+ 		return;
+ 	}
+	
+ 	if (buffer->GetChannels().GetLayout() == cmn::AudioChannel::Layout::LayoutUnknown)
+ 	{
+ 		logte("Invalid decoded frame channel layout: %d", static_cast<int>(buffer->GetChannels().GetLayout()));
+ 		return;
+ 	}
 
 	// Update sample rate of the output track
 	logtt("Input SampleRate: %d, Output SampleRate: %d",
@@ -923,7 +929,7 @@ void TranscoderStreamInternal::UpdateOutputAudioTrackByDecodedFrame(const std::s
 	}
 	else
 	{
-		// If the bitrate is not set, it is set based on the input video bitrate.
+		// If the bitrate is not set, it is set based on the input audio bitrate.
 		auto new_output_bitrate = input_track->GetBitrateByConfig();
 		if(new_output_bitrate <= 0)
 		{

--- a/src/projects/transcoder/transcoder_stream_internal.h
+++ b/src/projects/transcoder/transcoder_stream_internal.h
@@ -48,7 +48,7 @@ public:
 
 	static double MeasurementToRecommendFramerate(double framerate);
 
-	void UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
+	void UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track);
 	void UpdateOutputTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
 
 private:
@@ -56,10 +56,10 @@ private:
 	void UpdateOutputAudioTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
 
 	// Optimized resolution for a specific encoder.
-	static cmn::Resolution ApplyResolutionAlignment(const cmn::Resolution &resolution);
+	static cmn::Resolution GetAlignmentResolution(const cmn::Resolution &resolution);
 
 	// If SkipFrames is enabled, adjust the output framerate.
-	static void ApplySkipFrames(int32_t skip_frames, const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track);	
+	static void ApplySkipFrames(const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track);	
 
 public:
 	// This is used to check if only keyframes can be decoded.

--- a/src/projects/transcoder/transcoder_stream_internal.h
+++ b/src/projects/transcoder/transcoder_stream_internal.h
@@ -46,13 +46,22 @@ public:
 	bool IsMatchesBypassCondition(const std::shared_ptr<MediaTrack> &input_track, const cfg::vhost::app::oprf::VideoProfile &profile);
 	bool IsMatchesBypassCondition(const std::shared_ptr<MediaTrack> &input_track, const cfg::vhost::app::oprf::AudioProfile &profile);
 
-	double GetProperFramerate(const std::shared_ptr<MediaTrack> &ref_track);
 	static double MeasurementToRecommendFramerate(double framerate);
 
-	void UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, std::shared_ptr<MediaFrame> buffer);
+	void UpdateOutputTrackPassthrough(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
 	void UpdateOutputTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
 
+private:
+	void UpdateOutputVideoTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
+	void UpdateOutputAudioTrackByDecodedFrame(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track, std::shared_ptr<MediaFrame> buffer);
 
+	// Optimized resolution for a specific encoder.
+	static cmn::Resolution ApplyResolutionAlignment(const cmn::Resolution &resolution);
+
+	// If SkipFrames is enabled, adjust the output framerate.
+	static void ApplySkipFrames(int32_t skip_frames, const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track);	
+
+public:
 	// This is used to check if only keyframes can be decoded.
 	// If the output profile has only image encoding options, keyframes can be decoded to use the CPU efficiently.
 	bool IsKeyframeOnlyDecodable(const std::map<ov::String, std::shared_ptr<info::Stream>> &streams);

--- a/src/projects/transcoder/transcoder_stream_internal.h
+++ b/src/projects/transcoder/transcoder_stream_internal.h
@@ -59,7 +59,7 @@ private:
 	static cmn::Resolution GetAlignmentResolution(const cmn::Resolution &resolution);
 
 	// If SkipFrames is enabled, adjust the output framerate.
-	static void ApplySkipFrames(const std::shared_ptr<MediaTrack> &input_track, const std::shared_ptr<MediaTrack> &output_track);	
+	static void ApplySkipFrames(const std::shared_ptr<MediaTrack> &output_track, const std::shared_ptr<MediaTrack> &input_track);	
 
 public:
 	// This is used to check if only keyframes can be decoded.


### PR DESCRIPTION
### Summary

Improved OutputTrack quality retention behavior when the source stream is updated, along with minor refactoring.

### Key Changes
#### 1. Default Parameter Handling
- OutputTrack now uses parameters defined in the Config as default values during create output track. so, removed previous logic that selected default values based on whether Config parsing was performed.

#### 2. Output Track Initialization
- If no user-defined settings are provided, parameters are automatically derived from decoded frame information:
  - Resolution, Timebase, Framerate, Bitrate, Samplerate, Channel

#### 3. Behavior on Input Stream Update
- **Encoding mode**
  - OutputTrack keeps its initial quality even if the input stream quality change.

- **Bypass mode**
  - OutputTrack updates to match the changed input stream quality