### PR TITLE
fix: fixed incorrect libdir in hiredis.pc caused by the LIBRARY_PATH env

### DIFF
--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -367,7 +367,7 @@ make ${_J} && sudo make install && rm -rf ${TEMP_PATH}/x264
 set(_install_nvcc_hdr "
 mkdir -p ${TEMP_PATH}/nvcc-hdr && cd ${TEMP_PATH}/nvcc-hdr &&
 curl -sSLf ${NVCC_HDR_SOURCE_URL} | tar -xz --strip-components=1 &&
-make PREFIX="${PREFIX}" LIBDIR=lib install
+sudo make PREFIX="${PREFIX}" LIBDIR=lib install
 ")
 
 # ---- FFmpeg ----

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -367,7 +367,7 @@ make ${_J} && sudo make install && rm -rf ${TEMP_PATH}/x264
 set(_install_nvcc_hdr "
 mkdir -p ${TEMP_PATH}/nvcc-hdr && cd ${TEMP_PATH}/nvcc-hdr &&
 curl -sSLf ${NVCC_HDR_SOURCE_URL} | tar -xz --strip-components=1 &&
-sed -i 's|PREFIX.*=\\(.*\\)|PREFIX = ${PREFIX}|g' Makefile && sudo make install
+make PREFIX="${PREFIX}" LIBDIR=lib install
 ")
 
 # ---- FFmpeg ----

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -507,7 +507,7 @@ make ${_J} && sudo make install && rm -rf ${TEMP_PATH}/pcre2
 set(_install_hiredis "
 mkdir -p ${TEMP_PATH}/hiredis && cd ${TEMP_PATH}/hiredis &&
 curl -sSLf ${HIREDIS_SOURCE_URL} | tar -xz --strip-components=1 &&
-make ${_J} PREFIX=${PREFIX} && sudo make install PREFIX=${PREFIX} && rm -rf ${TEMP_PATH}/hiredis
+make ${_J} PREFIX=${PREFIX} LIBRARY_PATH=lib && sudo make install PREFIX=${PREFIX} LIBRARY_PATH=lib && rm -rf ${TEMP_PATH}/hiredis
 ")
 
 # ---- spdlog ----

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -222,8 +222,7 @@ install_nvcc_hdr() {
         mkdir -p ${DIR} && \
         cd ${DIR} && \
         curl -sSLf https://github.com/FFmpeg/nv-codec-headers/releases/download/n${NVCC_HDR_VERSION}/nv-codec-headers-${NVCC_HDR_VERSION}.tar.gz | tar -xz --strip-components=1 && \
-        sed -i 's|PREFIX.*=\(.*\)|PREFIX = '${PREFIX}'|g' Makefile && \
-        sudo make install ) || fail_exit "nvcc_headers"
+        sudo make PREFIX="${PREFIX}" LIBDIR=lib install ) || fail_exit "nvcc_headers"
     fi
 }
 
@@ -423,8 +422,8 @@ install_hiredis()
     mkdir -p ${DIR} && \
     cd ${DIR} && \
     curl -sSLf https://github.com/redis/hiredis/archive/refs/tags/v${HIREDIS_VERSION}.tar.gz | tar -xz --strip-components=1 && \
-    make -j$(nproc) && \
-    sudo make install PREFIX="${PREFIX}" && \
+    make -j$(nproc) PREFIX=${PREFIX} LIBRARY_PATH=lib && \
+    sudo make install PREFIX="${PREFIX}" LIBRARY_PATH=lib && \
     rm -rf ${DIR} ) || fail_exit "hiredis"
 }
 


### PR DESCRIPTION
### Summary

Fix an issue where the libdir path in hiredis.pc is incorrectly set due to the LIBRARY_PATH environment variable when building in CUDA-based Ubuntu Docker images.

### Root Cause

CUDA-based Docker images define the following environment variable:
```
LIBRARY_PATH=/usr/local/cuda/lib64/stubs
```
The hiredis Makefile uses LIBRARY_PATH when generating hiredis.pc:

```
PREFIX?=/usr/local
LIBRARY_PATH?=lib

$(PKGCONFNAME):
	@echo prefix=$(PREFIX) > $@
	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
```
If LIBRARY_PATH is set, it overrides the default value (lib), resulting in an incorrect libdir path in hiredis.pc.
ex) `ex) libdir=/opt/ovenmediaengine//usr/local/cuda/lib64/stubs`
### Solution

Explicitly override LIBRARY_PATH to lib during the build and installation steps in install_hiredis within InstallPrerequisites.cmake:
```
make ${_J} PREFIX=${PREFIX} LIBRARY_PATH=lib &&  sudo make install PREFIX=${PREFIX} LIBRARY_PATH=lib
```
This ensures that the correct libdir is set in hiredis.pc, regardless of the environment.