### PR TITLE
feat: add Transport field to SocketAddress

### DIFF
--- a/src/projects/base/ovsocket/client_socket.cpp
+++ b/src/projects/base/ovsocket/client_socket.cpp
@@ -105,6 +105,16 @@ namespace ov
 		}
 
 		_local_address = std::make_shared<SocketAddress>("", local_addr);
+		_local_address->SetTransport(GetType() == SocketType::Srt
+			? SocketAddress::Transport::Srt
+			: (GetType() == SocketType::Tcp
+				? SocketAddress::Transport::Tcp
+				: SocketAddress::Transport::Udp));
+
+		if (_remote_address != nullptr)
+		{
+			_remote_address->SetTransport(_local_address->GetTransport());
+		}
 
 		return true;
 	}

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -421,6 +421,9 @@ namespace ov
 				{
 					// Succeeded
 					_local_address = std::make_shared<SocketAddress>(address);
+					_local_address->SetTransport(GetType() == SocketType::Tcp
+						? SocketAddress::Transport::Tcp
+						: SocketAddress::Transport::Udp);
 				}
 				else
 				{
@@ -442,6 +445,7 @@ namespace ov
 				{
 					// Succeeded
 					_local_address = std::make_shared<SocketAddress>(address);
+					_local_address->SetTransport(SocketAddress::Transport::Srt);
 				}
 				else
 				{
@@ -1877,8 +1881,15 @@ namespace ov
 					{
 						const auto port = GetLocalAddress()->Port();
 
-						address_pair->SetLocalAddress(QueryLocalAddress(_family, port, remote, &msg));
-						address_pair->SetRemoteAddress(SocketAddress("", remote));
+						const auto transport = _local_address->GetTransport();
+
+						auto local = QueryLocalAddress(_family, port, remote, &msg);
+						local.SetTransport(transport);
+						address_pair->SetLocalAddress(local);
+
+						SocketAddress remote_addr("", remote);
+						remote_addr.SetTransport(transport);
+						address_pair->SetRemoteAddress(remote_addr);
 					}
 
 					UpdateLastRecvTime();

--- a/src/projects/base/ovsocket/socket_address.cpp
+++ b/src/projects/base/ovsocket/socket_address.cpp
@@ -463,6 +463,7 @@ namespace ov
 		_ip_address = address._ip_address;
 		_port_set = address._port_set;
 		_port = address._port;
+		_transport = address._transport;
 	}
 
 	SocketAddress::SocketAddress(SocketAddress &&address) noexcept
@@ -475,6 +476,7 @@ namespace ov
 		std::swap(_ip_address, address._ip_address);
 		std::swap(_port_set, address._port_set);
 		std::swap(_port, address._port);
+		std::swap(_transport, address._transport);
 	}
 
 	SocketAddress::~SocketAddress()
@@ -495,6 +497,7 @@ namespace ov
 		_ip_address = address._ip_address;
 		_port_set = address._port_set;
 		_port = address._port;
+		_transport = address._transport;
 
 		return *this;
 	}
@@ -768,6 +771,12 @@ namespace ov
 			if ((_is_wildcard_host == false) && ((hostname.IsEmpty() == false) && (hostname != ip)))
 			{
 				description.AppendFormat(" (host: '%s')", hostname.CStr());
+			}
+
+			auto transport_str = StringFromTransport(_transport);
+			if (transport_str != nullptr)
+			{
+				description.AppendFormat("/%s", transport_str);
 			}
 		}
 		else

--- a/src/projects/base/ovsocket/socket_address.h
+++ b/src/projects/base/ovsocket/socket_address.h
@@ -21,6 +21,36 @@ namespace ov
 	class SocketAddress
 	{
 	public:
+		enum class Transport : uint8_t
+		{
+			Unknown,
+			Udp,
+			Tcp,
+			Srt,
+		};
+
+		static const char *StringFromTransport(Transport t)
+		{
+			switch (t)
+			{
+				case Transport::Udp: return "udp";
+				case Transport::Tcp: return "tcp";
+				case Transport::Srt: return "srt";
+				default:             return nullptr;  // Unknown: no suffix
+			}
+		}
+
+		Transport GetTransport() const
+		{
+			return _transport;
+		}
+
+		void SetTransport(Transport transport)
+		{
+			_transport = transport;
+		}
+
+	public:
 		struct PortRange
 		{
 			uint16_t start_port{0};
@@ -347,6 +377,7 @@ namespace ov
 		ov::String _ip_address;
 		bool _port_set = false;
 		uint16_t _port = 0;
+		Transport _transport = Transport::Unknown;
 	};
 }  // namespace ov
 


### PR DESCRIPTION
## Summary

Add a `Transport` field (UDP/TCP/SRT) to `SocketAddress` so that transport
information is naturally included in log output everywhere an address is printed.

Before:

    <ClientSocket: 0x7ffee0000c10, #115, Connected, TCP, Nonblocking, 192.168.0.200:13914>

After:

    <ClientSocket: 0x7ffee0000c10, #115, Connected, TCP, Nonblocking, 192.168.0.200:13914/tcp>

## Motivation

OvenMediaEngine is planning to support TCP ICE Candidates. When both UDP and TCP
candidates coexist, logs that omit transport type cause confusion because it becomes
impossible to tell which transport a given address belongs to.

By embedding transport at the `SocketAddress` level, all log output gains this
context without any per-call changes.