### PR TITLE
refactor: add expired flag to ICE state change callbacks

### DIFF
--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -1357,7 +1357,7 @@ void IcePort::NotifyIceSessionStateChanged(std::shared_ptr<IceSession> &session)
 {
 	if (session->GetObserver() != nullptr)
 	{
-		session->GetObserver()->OnStateChanged(*this, session->GetSessionID(), session->GetState(), session->GetUserData());
+		session->GetObserver()->OnStateChanged(*this, session->GetSessionID(), session->GetState(), session->IsExpired(), session->GetUserData());
 	}
 }
 

--- a/src/projects/modules/ice/ice_port_observer.h
+++ b/src/projects/modules/ice/ice_port_observer.h
@@ -41,7 +41,11 @@ public:
 		_turn_server_port = port;
 	}
 
-	virtual void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, std::any user_data)
+	// Notifies the observer that the ICE session changed state.
+	// `is_expired` is reported separately because lifetime-expired sessions may be
+	// delivered as the same transport state as ordinary disconnects, but Enterprise
+	// ingress alerts must classify them as PolicyExpired instead of NetworkError.
+	virtual void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, bool is_expired, std::any user_data)
 	{
 		// dummy function
 	}

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -564,7 +564,7 @@ namespace pvd
 	// IcePort
 	//------------------------
 
-	void WebRTCProvider::OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, std::any user_data)
+	void WebRTCProvider::OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, [[maybe_unused]] bool is_expired, std::any user_data)
 	{
 		logtt("WebRTCProvider::OnStateChanged : %d", static_cast<int>(state));
 

--- a/src/projects/providers/webrtc/webrtc_provider.h
+++ b/src/projects/providers/webrtc/webrtc_provider.h
@@ -54,7 +54,7 @@ namespace pvd
 		//--------------------------------------------------------------------
 		// IcePortObserver Implementation
 		//--------------------------------------------------------------------
-		void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, std::any user_data) override;
+		void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, bool is_expired, std::any user_data) override;
 		void OnDataReceived(IcePort &port, uint32_t session_id, std::shared_ptr<const ov::Data> data, std::any user_data) override;
 		//--------------------------------------------------------------------
 

--- a/src/projects/publishers/webrtc/webrtc_publisher.cpp
+++ b/src/projects/publishers/webrtc/webrtc_publisher.cpp
@@ -597,7 +597,7 @@ bool WebRtcPublisher::OnIceCandidate(const std::shared_ptr<http::svr::ws::WebSoc
  * IcePort Implementation
  */
 
-void WebRtcPublisher::OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, std::any user_data)
+void WebRtcPublisher::OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, [[maybe_unused]] bool is_expired, std::any user_data)
 {
 	logtt("IcePort OnStateChanged : %d", ov::ToUnderlyingType(state));
 

--- a/src/projects/publishers/webrtc/webrtc_publisher.h
+++ b/src/projects/publishers/webrtc/webrtc_publisher.h
@@ -30,7 +30,7 @@ public:
 	bool Stop() override;
 
 	// IcePortObserver Implementation
-	void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, std::any user_data) override;
+	void OnStateChanged(IcePort &port, uint32_t session_id, IceConnectionState state, bool is_expired, std::any user_data) override;
 	void OnDataReceived(IcePort &port, uint32_t session_id, std::shared_ptr<const ov::Data> data, std::any user_data) override;
 
 	// SignallingObserver Implementation


### PR DESCRIPTION
## Summary

Propagate ICE session expiration metadata through ICE state change callbacks.

This change extends `IcePortObserver::OnStateChanged(...)` with an `is_expired`
flag and passes `IceSession::IsExpired()` from `IcePort`. WebRTC observer
implementations are updated to match the new callback signature.

## Changes

- add `bool is_expired` to `IcePortObserver::OnStateChanged(...)`
- pass `session->IsExpired()` from `IcePort::NotifyIceSessionStateChanged(...)`
- update WebRTC provider callback signature
- update WebRTC publisher callback signature

## Why

`IceConnectionState` represents transport/session state, but it does not carry
the reason why a session reached a disconnected/closed state.

Session lifetime expiration is additional metadata, not a new transport state.
Passing it separately keeps the existing state model intact while allowing
callers to distinguish expiration from ordinary disconnect cases.