### PR TITLE
fix: support negative RTMP extended timestamp deltas

### DIFF
--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
@@ -8,7 +8,10 @@
 //==============================================================================
 #include "rtmp_chunk_parser.h"
 
+// `rtmp_private.h` should be included before `rtmp_chunk_parser_helper.h` because it contains `OV_LOG_TAG`.
 #include "../rtmp_private.h"
+// ====
+#include "../rtmp_chunk_parser_helper.h"
 
 namespace
 {
@@ -287,84 +290,6 @@ bool RtmpChunkParser::IsContinuationChunk(const uint32_t chunk_stream_id) const
 	return false;
 }
 
-std::optional<uint32_t> RtmpChunkParser::ParseTimestampField(
-	const uint32_t stream_id,
-	ov::ByteStream &stream,
-	RtmpChunkHeader *chunk_header,
-	const uint32_t encoded_value)
-{
-	if (encoded_value != EXTENDED_TIMESTAMP_INDICATOR)
-	{
-		chunk_header->is_extended_timestamp = false;
-		chunk_header->extended_timestamp	= 0U;
-
-		return encoded_value;
-	}
-
-	if (stream.IsRemained(EXTENDED_TIMESTAMP_SIZE) == false)
-	{
-		logap("Need more data to parse extended timestamp field: %d bytes (current: %zu)", EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-		return std::nullopt;
-	}
-
-	logat("Extended timestamp is present for stream id: %u", stream_id);
-
-	const auto extended_timestamp		= stream.ReadBE32();
-
-	chunk_header->is_extended_timestamp = true;
-	chunk_header->extended_timestamp	= extended_timestamp;
-	chunk_header->message_header_length += EXTENDED_TIMESTAMP_SIZE;
-
-	return extended_timestamp;
-}
-
-std::optional<int64_t> RtmpChunkParser::ResolveTimestampDelta(
-	const uint32_t stream_id,
-	const int64_t preceding_timestamp,
-	const uint32_t timestamp_delta,
-	const bool is_extended_timestamp) const
-{
-	if (is_extended_timestamp && (timestamp_delta >= SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT))
-	{
-		// The sign bit is set in a 32-bit extended delta, so this could be a
-		// broken sender that wrote a signed int32_t onto the wire.
-		const auto signed_timestamp_delta = static_cast<int32_t>(timestamp_delta);
-		const auto backward_delta		  = -1 * static_cast<int64_t>(signed_timestamp_delta);
-
-		if ((signed_timestamp_delta < 0) && (backward_delta <= MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS))
-		{
-			// Accept only small backward jumps on the compatibility path. Large
-			// values are more likely to be legitimate unsigned deltas.
-			const auto resolved_timestamp = preceding_timestamp + signed_timestamp_delta;
-
-			if (resolved_timestamp < 0)
-			{
-				// Even on the compatibility path, never allow the absolute
-				// timestamp to move below zero.
-				logae("Reject signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
-					  stream_id,
-					  preceding_timestamp,
-					  timestamp_delta,
-					  signed_timestamp_delta);
-				return std::nullopt;
-			}
-
-			// This is the non-standard but tolerated case: a small negative
-			// extended delta that still resolves to a valid absolute timestamp.
-			logaw("Accept signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
-				  stream_id,
-				  preceding_timestamp,
-				  timestamp_delta,
-				  signed_timestamp_delta);
-
-			return resolved_timestamp;
-		}
-	}
-
-	// Standard RTMP behavior: interpret the delta as an unsigned increment.
-	return preceding_timestamp + timestamp_delta;
-}
-
 RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header)
 {
 	auto &basic_header	 = chunk_header->basic_header;
@@ -430,8 +355,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 
 			const auto parsed_timestamp		 = ParseTimestampField(
 				header.stream_id,
-				stream, chunk_header,
-				header.timestamp);
+				stream,
+				chunk_header->is_extended_timestamp,
+				chunk_header->extended_timestamp,
+				chunk_header->message_header_length,
+				header.timestamp,
+				EXTENDED_TIMESTAMP_INDICATOR,
+				EXTENDED_TIMESTAMP_SIZE);
 
 			if (parsed_timestamp.has_value() == false)
 
@@ -463,8 +393,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 
 			const auto parsed_timestamp_delta = ParseTimestampField(
 				preceding_completed_header->stream_id,
-				stream, chunk_header,
-				header.timestamp_delta);
+				stream,
+				chunk_header->is_extended_timestamp,
+				chunk_header->extended_timestamp,
+				chunk_header->message_header_length,
+				header.timestamp_delta,
+				EXTENDED_TIMESTAMP_INDICATOR,
+				EXTENDED_TIMESTAMP_SIZE);
 
 			if (parsed_timestamp_delta.has_value() == false)
 			{
@@ -478,7 +413,9 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				preceding_completed_header->stream_id,
 				preceding_completed_header->timestamp,
 				parsed_timestamp_delta.value(),
-				chunk_header->is_extended_timestamp);
+				chunk_header->is_extended_timestamp,
+				SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+				MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 			if (resolved_timestamp.has_value() == false)
 			{
@@ -503,8 +440,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 
 			const auto parsed_timestamp_delta = ParseTimestampField(
 				preceding_completed_header->stream_id,
-				stream, chunk_header,
-				header.timestamp_delta);
+				stream,
+				chunk_header->is_extended_timestamp,
+				chunk_header->extended_timestamp,
+				chunk_header->message_header_length,
+				header.timestamp_delta,
+				EXTENDED_TIMESTAMP_INDICATOR,
+				EXTENDED_TIMESTAMP_SIZE);
 
 			if (parsed_timestamp_delta.has_value() == false)
 			{
@@ -517,7 +459,9 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				preceding_completed_header->stream_id,
 				preceding_completed_header->timestamp,
 				parsed_timestamp_delta.value(),
-				chunk_header->is_extended_timestamp);
+				chunk_header->is_extended_timestamp,
+				SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+				MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 			if (resolved_timestamp.has_value() == false)
 			{
@@ -562,8 +506,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				{
 					const auto parsed_timestamp_field = ParseTimestampField(
 						completed.stream_id,
-						stream, chunk_header,
-						EXTENDED_TIMESTAMP_INDICATOR);
+						stream,
+						chunk_header->is_extended_timestamp,
+						chunk_header->extended_timestamp,
+						chunk_header->message_header_length,
+						EXTENDED_TIMESTAMP_INDICATOR,
+						EXTENDED_TIMESTAMP_INDICATOR,
+						EXTENDED_TIMESTAMP_SIZE);
 
 					if (parsed_timestamp_field.has_value() == false)
 					{
@@ -596,8 +545,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				// The origin message header is T0
 				const auto parsed_timestamp = ParseTimestampField(
 					completed.stream_id,
-					stream, chunk_header,
-					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : static_cast<uint32_t>(completed.timestamp));
+					stream,
+					chunk_header->is_extended_timestamp,
+					chunk_header->extended_timestamp,
+					chunk_header->message_header_length,
+					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : static_cast<uint32_t>(completed.timestamp),
+					EXTENDED_TIMESTAMP_INDICATOR,
+					EXTENDED_TIMESTAMP_SIZE);
 
 				if (parsed_timestamp.has_value() == false)
 				{
@@ -612,8 +566,13 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				// The origin message header is T1 or T2
 				const auto parsed_timestamp_delta = ParseTimestampField(
 					completed.stream_id,
-					stream, chunk_header,
-					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : completed.timestamp_delta);
+					stream,
+					chunk_header->is_extended_timestamp,
+					chunk_header->extended_timestamp,
+					chunk_header->message_header_length,
+					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : completed.timestamp_delta,
+					EXTENDED_TIMESTAMP_INDICATOR,
+					EXTENDED_TIMESTAMP_SIZE);
 
 				if (parsed_timestamp_delta.has_value() == false)
 				{
@@ -626,7 +585,9 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 					completed.stream_id,
 					completed.timestamp,
 					parsed_timestamp_delta.value(),
-					chunk_header->is_extended_timestamp);
+					chunk_header->is_extended_timestamp,
+					SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+					MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 				if (resolved_timestamp.has_value() == false)
 				{
@@ -671,125 +632,6 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseHeader(ov::ByteStream &stream
 	return ParseMessageHeader(stream, chunk_header);
 }
 
-int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
-{
-	// RTMP timestamps are carried as 32-bit serial numbers on the wire.
-	// Keep the serial width, its modulo, and the RFC1982 half-range explicit so
-	// the rollover math below reads directly in terms of the specification.
-	constexpr int64_t SERIAL_BITS					  = 32;
-	constexpr int64_t SERIAL_MODULO					  = (1LL << SERIAL_BITS);
-	constexpr int64_t SERIAL_HALF_RANGE				  = (1LL << (SERIAL_BITS - 1));
-	// Some senders behave as if the timestamp space were signed int32_t and
-	// restart near INT32_MAX -> 0. Keep that compatibility boundary separate
-	// from the real RTMP modulo so the fallback path stays clearly scoped.
-	constexpr int64_t SIGNED_SERIAL_MODULO			  = (1LL << (SERIAL_BITS - 1));
-	// Only the low 32 bits participate in RFC1982 ordering; higher bits belong
-	// to older unfolded epochs reconstructed locally by the receiver.
-	constexpr uint64_t SERIAL_VALUE_MASK			  = 0xFFFFFFFFULL;
-	// Some senders appear to reset absolute timestamps at the signed 31-bit
-	// boundary instead of RTMP's unsigned 32-bit boundary. Treat that as a
-	// compatibility path only when the implied forward delta is very small.
-	constexpr int64_t MAX_SIGNED_WRAP_COMPAT_DELTA_MS = 10 * 1000;
-
-	// RFC1982 comparison works on the 32-bit serial value only, not on the full
-	// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
-	// intentionally strips any older epoch bits before converting to uint32_t.
-	const auto last_serial							  = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
-	const auto parsed_serial						  = static_cast<uint32_t>(parsed_timestamp);
-
-	if (last_serial == parsed_serial)
-	{
-		return last_timestamp;
-	}
-
-	// RTMP specification
-	//
-	// Because timestamps are 32 bits long, they roll over every 49 days, 17
-	// hours, 2 minutes and 47.296 seconds. Because streams are allowed to
-	// run continuously, potentially for years on end, an RTMP application
-	// SHOULD use serial number arithmetic [RFC1982] when processing
-	// timestamps, and SHOULD be capable of handling wraparound. For
-	// example, an application assumes that all adjacent timestamps are
-	// within 2^31 - 1 milliseconds of each other, so 10000 comes after
-	// 4000000000, and 3000000000 comes before 4000000000.
-
-	// completed.timestamp calculated from this formula (https://tools.ietf.org/html/rfc1982#section-3.1):
-	//
-	// Serial numbers may be incremented by the addition of a positive
-	// integer n, where n is taken from the range of integers
-	// [0 .. (2^(SERIAL_BITS - 1) - 1)].  For a sequence number s, the
-	// result of such an addition, s', is defined as
-	//
-	//                 s' = (s + n) modulo (2 ^ SERIAL_BITS)
-	//
-	// where the addition and modulus operations here act upon values that
-	// are non-negative values of unbounded size in the usual ways of
-	// integer arithmetic.
-
-	// This helper is only for absolute timestamp paths (Type 0, or Type 3 that
-	// inherits Type 0 semantics). Type 1/2/3 delta paths already operate on an
-	// unfolded absolute timestamp plus a delta, so applying RFC1982 again there
-	// would be incorrect.
-	//
-	// Behavior:
-	// - if the parsed serial is after the previous serial and wrapped below it,
-	//   advance to the next 32-bit epoch
-	// - if the parsed serial is not after the previous serial, keep it in the
-	//   current/prior epoch so backward Type 0 timestamps remain backward
-	const int64_t serial_epoch_base = last_timestamp - static_cast<int64_t>(last_serial);
-	int64_t resolved_timestamp		= serial_epoch_base + parsed_serial;
-	const int64_t serial_diff		= static_cast<int64_t>(parsed_serial) - last_serial;
-	const bool parsed_serial_is_after_previous =
-		((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
-		((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
-
-	// Compatibility path for senders that appear to restart absolute
-	// timestamps at INT32_MAX -> 0 instead of UINT32_MAX -> 0. This is not
-	// standard RTMP rollover, so only accept it when the implied forward delta
-	// is very small.
-	const int64_t signed_wrap_forward_delta = SIGNED_SERIAL_MODULO - static_cast<int64_t>(last_serial) + parsed_serial;
-	const bool signed_wrap_compat_candidate =
-		(parsed_serial_is_after_previous == false) &&
-		(last_serial < SIGNED_SERIAL_MODULO) &&
-		(parsed_serial < SIGNED_SERIAL_MODULO) &&
-		(parsed_serial < last_serial) &&
-		(signed_wrap_forward_delta > 0) &&
-		(signed_wrap_forward_delta <= MAX_SIGNED_WRAP_COMPAT_DELTA_MS);
-
-	if (parsed_serial_is_after_previous)
-	{
-		if (resolved_timestamp <= last_timestamp)
-		{
-			resolved_timestamp += SERIAL_MODULO;
-			logad("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
-				  last_timestamp,
-				  parsed_timestamp,
-				  resolved_timestamp);
-		}
-	}
-	// Only reach this branch when the normal RFC1982 32-bit comparison says the
-	// parsed serial is not after the previous one.
-	else if (signed_wrap_compat_candidate)
-	{
-		resolved_timestamp = last_timestamp + signed_wrap_forward_delta;
-		logad("Timestamp is rolled forward with signed-31bit compatibility: last TS: %" PRId64 ", parsed: %" PRId64 ", delta: %" PRId64 ", resolved: %" PRId64,
-			  last_timestamp,
-			  parsed_timestamp,
-			  signed_wrap_forward_delta,
-			  resolved_timestamp);
-	}
-	else if (resolved_timestamp > last_timestamp)
-	{
-		resolved_timestamp -= SERIAL_MODULO;
-		logai("Timestamp is resolved as backward T0: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
-			  last_timestamp,
-			  parsed_timestamp,
-			  resolved_timestamp);
-	}
-
-	return resolved_timestamp;
-}
-
 std::shared_ptr<const RtmpMessage> RtmpChunkParser::GetMessage()
 {
 	if (_message_queue.IsEmpty())
@@ -810,20 +652,6 @@ std::shared_ptr<const RtmpMessage> RtmpChunkParser::GetMessage()
 size_t RtmpChunkParser::GetMessageCount() const
 {
 	return _message_queue.Size();
-}
-
-info::NamePath RtmpChunkParser::GetNamePath() const
-{
-	std::lock_guard lock_guard(_name_path_mutex);
-	return _name_path;
-}
-
-void RtmpChunkParser::UpdateNamePath(const info::NamePath &stream_name_path)
-{
-	std::lock_guard lock_guard(_name_path_mutex);
-
-	_name_path = stream_name_path;
-	_message_queue.SetAlias(ov::String::FormatString("RTMP queue for %s", _name_path.CStr()));
 }
 
 void RtmpChunkParser::Destroy()

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
@@ -673,16 +673,29 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseHeader(ov::ByteStream &stream
 
 int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
 {
-	constexpr int64_t SERIAL_BITS		 = 32;
-	constexpr int64_t SERIAL_MODULO		 = (1LL << SERIAL_BITS);
-	constexpr int64_t SERIAL_HALF_RANGE	 = (1LL << (SERIAL_BITS - 1));
-	constexpr uint64_t SERIAL_VALUE_MASK = 0xFFFFFFFFULL;
+	// RTMP timestamps are carried as 32-bit serial numbers on the wire.
+	// Keep the serial width, its modulo, and the RFC1982 half-range explicit so
+	// the rollover math below reads directly in terms of the specification.
+	constexpr int64_t SERIAL_BITS					  = 32;
+	constexpr int64_t SERIAL_MODULO					  = (1LL << SERIAL_BITS);
+	constexpr int64_t SERIAL_HALF_RANGE				  = (1LL << (SERIAL_BITS - 1));
+	// Some senders behave as if the timestamp space were signed int32_t and
+	// restart near INT32_MAX -> 0. Keep that compatibility boundary separate
+	// from the real RTMP modulo so the fallback path stays clearly scoped.
+	constexpr int64_t SIGNED_SERIAL_MODULO			  = (1LL << (SERIAL_BITS - 1));
+	// Only the low 32 bits participate in RFC1982 ordering; higher bits belong
+	// to older unfolded epochs reconstructed locally by the receiver.
+	constexpr uint64_t SERIAL_VALUE_MASK			  = 0xFFFFFFFFULL;
+	// Some senders appear to reset absolute timestamps at the signed 31-bit
+	// boundary instead of RTMP's unsigned 32-bit boundary. Treat that as a
+	// compatibility path only when the implied forward delta is very small.
+	constexpr int64_t MAX_SIGNED_WRAP_COMPAT_DELTA_MS = 10 * 1000;
 
 	// RFC1982 comparison works on the 32-bit serial value only, not on the full
 	// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
 	// intentionally strips any older epoch bits before converting to uint32_t.
-	const auto last_serial				 = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
-	const auto parsed_serial			 = static_cast<uint32_t>(parsed_timestamp);
+	const auto last_serial							  = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
+	const auto parsed_serial						  = static_cast<uint32_t>(parsed_timestamp);
 
 	if (last_serial == parsed_serial)
 	{
@@ -730,16 +743,40 @@ int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, cons
 		((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
 		((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
 
+	// Compatibility path for senders that appear to restart absolute
+	// timestamps at INT32_MAX -> 0 instead of UINT32_MAX -> 0. This is not
+	// standard RTMP rollover, so only accept it when the implied forward delta
+	// is very small.
+	const int64_t signed_wrap_forward_delta = SIGNED_SERIAL_MODULO - static_cast<int64_t>(last_serial) + parsed_serial;
+	const bool signed_wrap_compat_candidate =
+		(parsed_serial_is_after_previous == false) &&
+		(last_serial < SIGNED_SERIAL_MODULO) &&
+		(parsed_serial < SIGNED_SERIAL_MODULO) &&
+		(parsed_serial < last_serial) &&
+		(signed_wrap_forward_delta > 0) &&
+		(signed_wrap_forward_delta <= MAX_SIGNED_WRAP_COMPAT_DELTA_MS);
+
 	if (parsed_serial_is_after_previous)
 	{
 		if (resolved_timestamp <= last_timestamp)
 		{
 			resolved_timestamp += SERIAL_MODULO;
-			logai("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
+			logad("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
 				  last_timestamp,
 				  parsed_timestamp,
 				  resolved_timestamp);
 		}
+	}
+	// Only reach this branch when the normal RFC1982 32-bit comparison says the
+	// parsed serial is not after the previous one.
+	else if (signed_wrap_compat_candidate)
+	{
+		resolved_timestamp = last_timestamp + signed_wrap_forward_delta;
+		logad("Timestamp is rolled forward with signed-31bit compatibility: last TS: %" PRId64 ", parsed: %" PRId64 ", delta: %" PRId64 ", resolved: %" PRId64,
+			  last_timestamp,
+			  parsed_timestamp,
+			  signed_wrap_forward_delta,
+			  resolved_timestamp);
 	}
 	else if (resolved_timestamp > last_timestamp)
 	{

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
@@ -32,7 +32,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 	{
 		// Need to parse new header when parsing for the first time or when reaching the chunk size
 		auto parsed_chunk_header = std::make_shared<RtmpChunkHeader>();
-		auto status = ParseHeader(stream, parsed_chunk_header.get());
+		auto status				 = ParseHeader(stream, parsed_chunk_header.get());
 		if (status != ParseResult::Parsed)
 		{
 			// If the header parsing fails, the bytes_used value is not updated to try parsing again from the beginning next time.
@@ -42,7 +42,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 		_need_to_parse_new_header = false;
 
 #if DEBUG
-		parsed_chunk_header->chunk_index = _chunk_index;
+		parsed_chunk_header->chunk_index	  = _chunk_index;
 		parsed_chunk_header->from_byte_offset = _total_read_bytes;
 #endif	// DEBUG
 
@@ -50,9 +50,9 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 
 		if (_current_message != nullptr)
 		{
-			auto &current_chunk_header = _current_message->header;
+			auto &current_chunk_header		   = _current_message->header;
 			const auto current_chunk_stream_id = current_chunk_header->basic_header.chunk_stream_id;
-			const auto new_chunk_stream_id = parsed_chunk_header->basic_header.chunk_stream_id;
+			const auto new_chunk_stream_id	   = parsed_chunk_header->basic_header.chunk_stream_id;
 
 			if (current_chunk_stream_id != new_chunk_stream_id)
 			{
@@ -135,7 +135,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 
 	if (_current_message->ReadFromStream(stream, _chunk_size))
 	{
-		auto &current_message_header = _current_message->header;
+		auto &current_message_header													  = _current_message->header;
 		_preceding_chunk_header_map[current_message_header->basic_header.chunk_stream_id] = current_message_header;
 
 		if (_current_message->GetRemainedPayloadSize() == 0UL)
@@ -148,7 +148,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 			current_message_header->message_total_bytes = (_total_read_bytes + stream.GetOffset()) - current_message_header->from_byte_offset;
 #endif	// DEBUG
 
-			logap("New RTMP message is enqueued: %s, payload:\n%s",current_message_header->ToString().CStr(),  _current_message->payload->Dump().CStr());
+			logap("New RTMP message is enqueued: %s, payload:\n%s", current_message_header->ToString().CStr(), _current_message->payload->Dump().CStr());
 			_current_message = nullptr;
 		}
 		else
@@ -156,7 +156,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::Parse(const std::shared_ptr<const 
 			logap("Need to parse next chunk (%zu bytes remained to completed current messasge)", _current_message->GetRemainedPayloadSize());
 		}
 
-		status = ParseResult::Parsed;
+		status					  = ParseResult::Parsed;
 
 		// A new message is completed or the chunk size is reached, so a new header parsing is required.
 		_need_to_parse_new_header = true;
@@ -184,12 +184,12 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseBasicHeader(ov::ByteStream &s
 		return ParseResult::NeedMoreData;
 	}
 
-	const auto first_byte = stream.Read8();
+	const auto first_byte		 = stream.Read8();
 
-	auto &basic_header = chunk_header->basic_header;
+	auto &basic_header			 = chunk_header->basic_header;
 
 	// Parse basic header
-	basic_header.format_type = static_cast<RtmpMessageHeaderType>((first_byte & 0b11000000) >> 6);
+	basic_header.format_type	 = static_cast<RtmpMessageHeaderType>((first_byte & 0b11000000) >> 6);
 	basic_header.chunk_stream_id = (first_byte & 0b00111111);
 
 	switch (basic_header.chunk_stream_id)
@@ -264,8 +264,8 @@ RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedT
 	{
 		chunk_header->is_extended_timestamp = false;
 
-		completed_header->timestamp = timestamp;
-		completed_header->timestamp_delta = 0U;
+		completed_header->timestamp			= timestamp;
+		completed_header->timestamp_delta	= 0U;
 
 		return ParseResultForExtendedTimestamp::NotExtended;
 	}
@@ -278,12 +278,12 @@ RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedT
 
 	logat("Extended timestamp is present for stream id: %u", stream_id);
 
-	int64_t extended_timestamp = stream.ReadBE32();
+	int64_t extended_timestamp			= stream.ReadBE32();
 
 	chunk_header->is_extended_timestamp = true;
 	chunk_header->message_header_length += RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE;
 
-	completed_header->timestamp = extended_timestamp;
+	completed_header->timestamp		  = extended_timestamp;
 	completed_header->timestamp_delta = 0U;
 
 	return ParseResultForExtendedTimestamp::Extended;
@@ -301,8 +301,8 @@ RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedT
 	{
 		chunk_header->is_extended_timestamp = false;
 
-		completed_header->timestamp = preceding_timestamp + timestamp_delta;
-		completed_header->timestamp_delta = timestamp_delta;
+		completed_header->timestamp			= preceding_timestamp + timestamp_delta;
+		completed_header->timestamp_delta	= timestamp_delta;
 
 		return ParseResultForExtendedTimestamp::NotExtended;
 	}
@@ -317,12 +317,12 @@ RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedT
 
 	OV_ASSERT(RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE == 4, "Extended timestamp delta size must be 4 bytes");
 
-	int64_t extended_timestamp_delta = stream.ReadBE32();
+	int64_t extended_timestamp_delta	= stream.ReadBE32();
 
 	chunk_header->is_extended_timestamp = true;
 	chunk_header->message_header_length += RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE;
 
-	completed_header->timestamp = preceding_timestamp + extended_timestamp_delta;
+	completed_header->timestamp		  = preceding_timestamp + extended_timestamp_delta;
 	completed_header->timestamp_delta = extended_timestamp_delta;
 
 	return ParseResultForExtendedTimestamp::Extended;
@@ -330,9 +330,9 @@ RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedT
 
 RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header)
 {
-	auto &basic_header = chunk_header->basic_header;
+	auto &basic_header	 = chunk_header->basic_header;
 	auto &message_header = chunk_header->message_header;
-	auto &completed = chunk_header->completed;
+	auto &completed		 = chunk_header->completed;
 
 	// Obtains minimum message header size to parse
 	switch (basic_header.format_type)
@@ -358,7 +358,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 	}
 
 	// Parse message header
-	chunk_header->is_extended_timestamp = false;
+	chunk_header->is_extended_timestamp							  = false;
 
 	std::shared_ptr<const RtmpChunkHeader> preceding_chunk_header = GetPrecedingChunkHeader(basic_header.chunk_stream_id);
 
@@ -382,16 +382,16 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 	switch (basic_header.format_type)
 	{
 		case RtmpMessageHeaderType::T0: {
-			auto &header = message_header.type_0;
-			header.timestamp = stream.ReadBE24();
-			header.length = stream.ReadBE24();
-			header.type_id = static_cast<RtmpMessageTypeID>(stream.Read8());
-			header.stream_id = stream.ReadLE32();
+			auto &header					 = message_header.type_0;
+			header.timestamp				 = stream.ReadBE24();
+			header.length					 = stream.ReadBE24();
+			header.type_id					 = static_cast<RtmpMessageTypeID>(stream.Read8());
+			header.stream_id				 = stream.ReadLE32();
 
 			chunk_header->is_timestamp_delta = false;
-			chunk_header->message_length = header.length;
+			chunk_header->message_length	 = header.length;
 
-			auto result = ParseExtendedTimestamp(
+			auto result						 = ParseExtendedTimestamp(
 				header.stream_id,
 				stream, chunk_header,
 				header.timestamp, &completed);
@@ -406,21 +406,21 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				completed.timestamp = CalculateRolledTimestamp(header.stream_id, preceding_completed_header->timestamp, completed.timestamp);
 			}
 
-			completed.type_id = header.type_id;
+			completed.type_id	= header.type_id;
 			completed.stream_id = header.stream_id;
 			break;
 		}
 
 		case RtmpMessageHeaderType::T1: {
-			auto &header = message_header.type_1;
-			header.timestamp_delta = stream.ReadBE24();
-			header.length = stream.ReadBE24();
-			header.type_id = static_cast<RtmpMessageTypeID>(stream.Read8());
+			auto &header					 = message_header.type_1;
+			header.timestamp_delta			 = stream.ReadBE24();
+			header.length					 = stream.ReadBE24();
+			header.type_id					 = static_cast<RtmpMessageTypeID>(stream.Read8());
 
 			chunk_header->is_timestamp_delta = true;
-			chunk_header->message_length = header.length;
+			chunk_header->message_length	 = header.length;
 
-			auto result = ParseExtendedTimestampDelta(
+			auto result						 = ParseExtendedTimestampDelta(
 				preceding_completed_header->stream_id,
 				stream, chunk_header,
 				preceding_completed_header->timestamp,
@@ -432,20 +432,20 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				return ParseResult::NeedMoreData;
 			}
 
-			completed.type_id = header.type_id;
+			completed.type_id	= header.type_id;
 			completed.stream_id = preceding_completed_header->stream_id;
 
 			break;
 		}
 
 		case RtmpMessageHeaderType::T2: {
-			auto &header = message_header.type_2;
-			header.timestamp_delta = stream.ReadBE24();
+			auto &header					 = message_header.type_2;
+			header.timestamp_delta			 = stream.ReadBE24();
 
 			chunk_header->is_timestamp_delta = true;
-			chunk_header->message_length = preceding_chunk_header->message_length;
+			chunk_header->message_length	 = preceding_chunk_header->message_length;
 
-			auto result = ParseExtendedTimestampDelta(
+			auto result						 = ParseExtendedTimestampDelta(
 				preceding_completed_header->stream_id,
 				stream, chunk_header,
 				preceding_completed_header->timestamp,
@@ -457,7 +457,7 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 				return ParseResult::NeedMoreData;
 			}
 
-			completed.type_id = preceding_completed_header->type_id;
+			completed.type_id	= preceding_completed_header->type_id;
 			completed.stream_id = preceding_completed_header->stream_id;
 
 			break;
@@ -465,14 +465,14 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 
 		case RtmpMessageHeaderType::T3: {
 			chunk_header->is_extended_timestamp = preceding_chunk_header->is_extended_timestamp;
-			chunk_header->is_timestamp_delta = preceding_chunk_header->is_timestamp_delta;
-			chunk_header->message_length = preceding_chunk_header->message_length;
+			chunk_header->is_timestamp_delta	= preceding_chunk_header->is_timestamp_delta;
+			chunk_header->message_length		= preceding_chunk_header->message_length;
 
-			completed.timestamp = preceding_completed_header->timestamp;
-			completed.timestamp_delta = preceding_completed_header->timestamp_delta;
+			completed.timestamp					= preceding_completed_header->timestamp;
+			completed.timestamp_delta			= preceding_completed_header->timestamp_delta;
 
-			completed.type_id = preceding_completed_header->type_id;
-			completed.stream_id = preceding_completed_header->stream_id;
+			completed.type_id					= preceding_completed_header->type_id;
+			completed.stream_id					= preceding_completed_header->stream_id;
 
 			ParseResultForExtendedTimestamp result;
 
@@ -530,8 +530,8 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseHeader(ov::ByteStream &stream
 int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
 {
 	const static int64_t SERIAL_BITS = 31;
-	int64_t new_timestamp = parsed_timestamp;
-	int64_t delta = ::llabs(last_timestamp - parsed_timestamp);
+	int64_t new_timestamp			 = parsed_timestamp;
+	int64_t delta					 = ::llabs(last_timestamp - parsed_timestamp);
 
 	// RTMP specification
 	//

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.cpp
@@ -10,6 +10,20 @@
 
 #include "../rtmp_private.h"
 
+namespace
+{
+	constexpr size_t EXTENDED_TIMESTAMP_SIZE					= 4;
+	constexpr size_t EXTENDED_TIMESTAMP_INDICATOR				= 0xFFFFFF;
+	// Extended timestamp deltas at or above this value have the sign bit set and
+	// would become negative if a sender incorrectly serialized the field from a
+	// signed int32_t instead of RTMP's unsigned 32-bit wire format.
+	constexpr uint32_t SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT = 0x80000000U;
+	// Some encoders send extended timestamp deltas as signed 32-bit values
+	// even though RTMP defines them as unsigned. Only allow small backward
+	// deltas so large valid unsigned deltas are not misread as negative.
+	constexpr int64_t MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS	= 10 * 1000;
+}  // namespace
+
 RtmpChunkParser::RtmpChunkParser(size_t chunk_size)
 {
 	_chunk_size = chunk_size;
@@ -253,79 +267,102 @@ std::shared_ptr<const RtmpChunkHeader> RtmpChunkParser::GetPrecedingChunkHeader(
 	return header->second;
 }
 
-RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedTimestamp(
+bool RtmpChunkParser::IsContinuationChunk(const uint32_t chunk_stream_id) const
+{
+	if ((_current_message != nullptr) &&
+		(_current_message->header->basic_header.chunk_stream_id == chunk_stream_id) &&
+		(_current_message->GetRemainedPayloadSize() > 0U))
+	{
+		return true;
+	}
+
+	const auto pending_message = _pending_message_map.find(chunk_stream_id);
+	if ((pending_message != _pending_message_map.end()) &&
+		(pending_message->second != nullptr) &&
+		(pending_message->second->GetRemainedPayloadSize() > 0U))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+std::optional<uint32_t> RtmpChunkParser::ParseTimestampField(
 	const uint32_t stream_id,
 	ov::ByteStream &stream,
 	RtmpChunkHeader *chunk_header,
-	const int64_t timestamp,
-	RtmpChunkHeader::CompletedHeader *completed_header)
+	const uint32_t encoded_value)
 {
-	if (timestamp != 0xFFFFFF)
+	if (encoded_value != EXTENDED_TIMESTAMP_INDICATOR)
 	{
 		chunk_header->is_extended_timestamp = false;
+		chunk_header->extended_timestamp	= 0U;
 
-		completed_header->timestamp			= timestamp;
-		completed_header->timestamp_delta	= 0U;
-
-		return ParseResultForExtendedTimestamp::NotExtended;
+		return encoded_value;
 	}
 
-	if (stream.IsRemained(RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE) == false)
+	if (stream.IsRemained(EXTENDED_TIMESTAMP_SIZE) == false)
 	{
-		logap("Need more data to parse extended timestamp: %d bytes (current: %zu)", RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-		return ParseResultForExtendedTimestamp::NeedMoreData;
+		logap("Need more data to parse extended timestamp field: %d bytes (current: %zu)", EXTENDED_TIMESTAMP_SIZE, stream.Remained());
+		return std::nullopt;
 	}
 
 	logat("Extended timestamp is present for stream id: %u", stream_id);
 
-	int64_t extended_timestamp			= stream.ReadBE32();
+	const auto extended_timestamp		= stream.ReadBE32();
 
 	chunk_header->is_extended_timestamp = true;
-	chunk_header->message_header_length += RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE;
+	chunk_header->extended_timestamp	= extended_timestamp;
+	chunk_header->message_header_length += EXTENDED_TIMESTAMP_SIZE;
 
-	completed_header->timestamp		  = extended_timestamp;
-	completed_header->timestamp_delta = 0U;
-
-	return ParseResultForExtendedTimestamp::Extended;
+	return extended_timestamp;
 }
 
-RtmpChunkParser::ParseResultForExtendedTimestamp RtmpChunkParser::ParseExtendedTimestampDelta(
+std::optional<int64_t> RtmpChunkParser::ResolveTimestampDelta(
 	const uint32_t stream_id,
-	ov::ByteStream &stream,
-	RtmpChunkHeader *chunk_header,
 	const int64_t preceding_timestamp,
-	const int64_t timestamp_delta,
-	RtmpChunkHeader::CompletedHeader *completed_header)
+	const uint32_t timestamp_delta,
+	const bool is_extended_timestamp) const
 {
-	if (timestamp_delta != 0xFFFFFF)
+	if (is_extended_timestamp && (timestamp_delta >= SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT))
 	{
-		chunk_header->is_extended_timestamp = false;
+		// The sign bit is set in a 32-bit extended delta, so this could be a
+		// broken sender that wrote a signed int32_t onto the wire.
+		const auto signed_timestamp_delta = static_cast<int32_t>(timestamp_delta);
+		const auto backward_delta		  = -1 * static_cast<int64_t>(signed_timestamp_delta);
 
-		completed_header->timestamp			= preceding_timestamp + timestamp_delta;
-		completed_header->timestamp_delta	= timestamp_delta;
+		if ((signed_timestamp_delta < 0) && (backward_delta <= MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS))
+		{
+			// Accept only small backward jumps on the compatibility path. Large
+			// values are more likely to be legitimate unsigned deltas.
+			const auto resolved_timestamp = preceding_timestamp + signed_timestamp_delta;
 
-		return ParseResultForExtendedTimestamp::NotExtended;
+			if (resolved_timestamp < 0)
+			{
+				// Even on the compatibility path, never allow the absolute
+				// timestamp to move below zero.
+				logae("Reject signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
+					  stream_id,
+					  preceding_timestamp,
+					  timestamp_delta,
+					  signed_timestamp_delta);
+				return std::nullopt;
+			}
+
+			// This is the non-standard but tolerated case: a small negative
+			// extended delta that still resolves to a valid absolute timestamp.
+			logaw("Accept signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
+				  stream_id,
+				  preceding_timestamp,
+				  timestamp_delta,
+				  signed_timestamp_delta);
+
+			return resolved_timestamp;
+		}
 	}
 
-	if (stream.IsRemained(RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE) == false)
-	{
-		logap("Need more data to parse extended timestamp delta: %d bytes (current: %zu)", RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-		return ParseResultForExtendedTimestamp::NeedMoreData;
-	}
-
-	logat("Extended timestamp delta is present for stream id: %u", stream_id);
-
-	OV_ASSERT(RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE == 4, "Extended timestamp delta size must be 4 bytes");
-
-	int64_t extended_timestamp_delta	= stream.ReadBE32();
-
-	chunk_header->is_extended_timestamp = true;
-	chunk_header->message_header_length += RtmpChunkHeader::EXTENDED_TIMESTAMP_SIZE;
-
-	completed_header->timestamp		  = preceding_timestamp + extended_timestamp_delta;
-	completed_header->timestamp_delta = extended_timestamp_delta;
-
-	return ParseResultForExtendedTimestamp::Extended;
+	// Standard RTMP behavior: interpret the delta as an unsigned increment.
+	return preceding_timestamp + timestamp_delta;
 }
 
 RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header)
@@ -391,15 +428,19 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 			chunk_header->is_timestamp_delta = false;
 			chunk_header->message_length	 = header.length;
 
-			auto result						 = ParseExtendedTimestamp(
+			const auto parsed_timestamp		 = ParseTimestampField(
 				header.stream_id,
 				stream, chunk_header,
-				header.timestamp, &completed);
+				header.timestamp);
 
-			if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+			if (parsed_timestamp.has_value() == false)
+
 			{
 				return ParseResult::NeedMoreData;
 			}
+
+			completed.timestamp		  = parsed_timestamp.value();
+			completed.timestamp_delta = 0U;
 
 			if (preceding_completed_header != nullptr)
 			{
@@ -412,53 +453,82 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 		}
 
 		case RtmpMessageHeaderType::T1: {
-			auto &header					 = message_header.type_1;
-			header.timestamp_delta			 = stream.ReadBE24();
-			header.length					 = stream.ReadBE24();
-			header.type_id					 = static_cast<RtmpMessageTypeID>(stream.Read8());
+			auto &header					  = message_header.type_1;
+			header.timestamp_delta			  = stream.ReadBE24();
+			header.length					  = stream.ReadBE24();
+			header.type_id					  = static_cast<RtmpMessageTypeID>(stream.Read8());
 
-			chunk_header->is_timestamp_delta = true;
-			chunk_header->message_length	 = header.length;
+			chunk_header->is_timestamp_delta  = true;
+			chunk_header->message_length	  = header.length;
 
-			auto result						 = ParseExtendedTimestampDelta(
+			const auto parsed_timestamp_delta = ParseTimestampField(
 				preceding_completed_header->stream_id,
 				stream, chunk_header,
-				preceding_completed_header->timestamp,
-				header.timestamp_delta,
-				&completed);
+				header.timestamp_delta);
 
-			if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+			if (parsed_timestamp_delta.has_value() == false)
 			{
 				return ParseResult::NeedMoreData;
 			}
 
-			completed.type_id	= header.type_id;
-			completed.stream_id = preceding_completed_header->stream_id;
+			// Type 1 carries a timestamp delta, not a wrapped absolute timestamp.
+			// Once the preceding timestamp has already been unfolded into the
+			// current absolute epoch, simple addition is the correct RTMP behavior.
+			const auto resolved_timestamp = ResolveTimestampDelta(
+				preceding_completed_header->stream_id,
+				preceding_completed_header->timestamp,
+				parsed_timestamp_delta.value(),
+				chunk_header->is_extended_timestamp);
+
+			if (resolved_timestamp.has_value() == false)
+			{
+				return ParseResult::Error;
+			}
+
+			completed.timestamp		  = resolved_timestamp.value();
+			completed.timestamp_delta = parsed_timestamp_delta.value();
+
+			completed.type_id		  = header.type_id;
+			completed.stream_id		  = preceding_completed_header->stream_id;
 
 			break;
 		}
 
 		case RtmpMessageHeaderType::T2: {
-			auto &header					 = message_header.type_2;
-			header.timestamp_delta			 = stream.ReadBE24();
+			auto &header					  = message_header.type_2;
+			header.timestamp_delta			  = stream.ReadBE24();
 
-			chunk_header->is_timestamp_delta = true;
-			chunk_header->message_length	 = preceding_chunk_header->message_length;
+			chunk_header->is_timestamp_delta  = true;
+			chunk_header->message_length	  = preceding_chunk_header->message_length;
 
-			auto result						 = ParseExtendedTimestampDelta(
+			const auto parsed_timestamp_delta = ParseTimestampField(
 				preceding_completed_header->stream_id,
 				stream, chunk_header,
-				preceding_completed_header->timestamp,
-				header.timestamp_delta,
-				&completed);
+				header.timestamp_delta);
 
-			if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+			if (parsed_timestamp_delta.has_value() == false)
 			{
 				return ParseResult::NeedMoreData;
 			}
 
-			completed.type_id	= preceding_completed_header->type_id;
-			completed.stream_id = preceding_completed_header->stream_id;
+			// Type 2 is the same timestamp-delta model as Type 1, just with fewer
+			// header fields. Do not run RFC1982 rollover logic here.
+			const auto resolved_timestamp = ResolveTimestampDelta(
+				preceding_completed_header->stream_id,
+				preceding_completed_header->timestamp,
+				parsed_timestamp_delta.value(),
+				chunk_header->is_extended_timestamp);
+
+			if (resolved_timestamp.has_value() == false)
+			{
+				return ParseResult::Error;
+			}
+
+			completed.timestamp		  = resolved_timestamp.value();
+			completed.timestamp_delta = parsed_timestamp_delta.value();
+
+			completed.type_id		  = preceding_completed_header->type_id;
+			completed.stream_id		  = preceding_completed_header->stream_id;
 
 			break;
 		}
@@ -474,33 +544,97 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 			completed.type_id					= preceding_completed_header->type_id;
 			completed.stream_id					= preceding_completed_header->stream_id;
 
-			ParseResultForExtendedTimestamp result;
+			if (IsContinuationChunk(basic_header.chunk_stream_id))
+			{
+				// Type 3 is also used for continuation chunks of the same message.
+				// In that case the message timestamp was already fixed by the first
+				// chunk, so do not re-apply either the absolute timestamp or delta.
+				// If the preceding chunk used extended timestamp encoding, this
+				// continuation chunk still carries the 4-byte field on the wire and
+				// it must be consumed even though its semantic value is unchanged.
+				//
+				// If the preceding chunk was not extended, there is no reliable way
+				// to distinguish a malformed extra 4-byte field from normal payload
+				// bytes here. Rejecting based on heuristics would risk corrupting
+				// valid payload, so the parser only validates the repeated extended
+				// field when the message actually uses extended timestamp encoding.
+				if (chunk_header->is_extended_timestamp)
+				{
+					const auto parsed_timestamp_field = ParseTimestampField(
+						completed.stream_id,
+						stream, chunk_header,
+						EXTENDED_TIMESTAMP_INDICATOR);
 
-			if (chunk_header->is_timestamp_delta == false)
+					if (parsed_timestamp_field.has_value() == false)
+					{
+						return ParseResult::NeedMoreData;
+					}
+
+					// A Type 3 continuation chunk should repeat the same extended
+					// timestamp field as the first chunk of the message. If it does
+					// not, keep the pre-existing compatibility behavior and continue
+					// parsing with the already fixed message timestamp instead of
+					// failing the whole session.
+					//
+					// The log below keeps just enough context to explain whether the
+					// stored semantic meaning came from an absolute timestamp path or
+					// a timestamp-delta path.
+					if (parsed_timestamp_field.value() != preceding_chunk_header->extended_timestamp)
+					{
+						logaw("Type3 ext mismatch: sid=%u csid=%u origin=%d semantic=%s expected=0x%08x parsed=0x%08x",
+							  completed.stream_id,
+							  basic_header.chunk_stream_id,
+							  ov::ToUnderlyingType(preceding_chunk_header->basic_header.format_type),
+							  preceding_chunk_header->is_timestamp_delta ? "delta" : "absolute",
+							  preceding_chunk_header->extended_timestamp,
+							  parsed_timestamp_field.value());
+					}
+				}
+			}
+			else if (chunk_header->is_timestamp_delta == false)
 			{
 				// The origin message header is T0
-				result = ParseExtendedTimestamp(
+				const auto parsed_timestamp = ParseTimestampField(
 					completed.stream_id,
 					stream, chunk_header,
-					chunk_header->is_extended_timestamp ? 0xffffff : completed.timestamp, &completed);
+					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : static_cast<uint32_t>(completed.timestamp));
 
-				if (result != ParseResultForExtendedTimestamp::NeedMoreData)
+				if (parsed_timestamp.has_value() == false)
 				{
-					completed.timestamp = CalculateRolledTimestamp(completed.stream_id, preceding_completed_header->timestamp, completed.timestamp);
+					return ParseResult::NeedMoreData;
 				}
+
+				completed.timestamp		  = CalculateRolledTimestamp(completed.stream_id, preceding_completed_header->timestamp, parsed_timestamp.value());
+				completed.timestamp_delta = 0U;
 			}
 			else
 			{
 				// The origin message header is T1 or T2
-				result = ParseExtendedTimestampDelta(
+				const auto parsed_timestamp_delta = ParseTimestampField(
 					completed.stream_id,
 					stream, chunk_header,
-					completed.timestamp, chunk_header->is_extended_timestamp ? 0xffffff : completed.timestamp_delta, &completed);
-			}
+					chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_INDICATOR : completed.timestamp_delta);
 
-			if (result == ParseResultForExtendedTimestamp::NeedMoreData)
-			{
-				return ParseResult::NeedMoreData;
+				if (parsed_timestamp_delta.has_value() == false)
+				{
+					return ParseResult::NeedMoreData;
+				}
+
+				// Type 3 reuses the timestamp delta semantics of the preceding Type 1
+				// or Type 2 header, so it stays on the same absolute+delta path.
+				const auto resolved_timestamp = ResolveTimestampDelta(
+					completed.stream_id,
+					completed.timestamp,
+					parsed_timestamp_delta.value(),
+					chunk_header->is_extended_timestamp);
+
+				if (resolved_timestamp.has_value() == false)
+				{
+					return ParseResult::Error;
+				}
+
+				completed.timestamp		  = resolved_timestamp.value();
+				completed.timestamp_delta = parsed_timestamp_delta.value();
 			}
 
 			break;
@@ -508,6 +642,16 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseMessageHeader(ov::ByteStream 
 
 		default:
 			break;
+	}
+
+	if (completed.timestamp < 0)
+	{
+		logae("Rejecting RTMP chunk because it produces a negative absolute timestamp: stream_id: %u, chunk_stream_id: %u, type: %d, timestamp: %" PRId64,
+			  completed.stream_id,
+			  basic_header.chunk_stream_id,
+			  ov::ToUnderlyingType(basic_header.format_type),
+			  completed.timestamp);
+		return ParseResult::Error;
 	}
 
 	return ParseResult::Parsed;
@@ -529,9 +673,21 @@ RtmpChunkParser::ParseResult RtmpChunkParser::ParseHeader(ov::ByteStream &stream
 
 int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
 {
-	const static int64_t SERIAL_BITS = 31;
-	int64_t new_timestamp			 = parsed_timestamp;
-	int64_t delta					 = ::llabs(last_timestamp - parsed_timestamp);
+	constexpr int64_t SERIAL_BITS		 = 32;
+	constexpr int64_t SERIAL_MODULO		 = (1LL << SERIAL_BITS);
+	constexpr int64_t SERIAL_HALF_RANGE	 = (1LL << (SERIAL_BITS - 1));
+	constexpr uint64_t SERIAL_VALUE_MASK = 0xFFFFFFFFULL;
+
+	// RFC1982 comparison works on the 32-bit serial value only, not on the full
+	// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
+	// intentionally strips any older epoch bits before converting to uint32_t.
+	const auto last_serial				 = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
+	const auto parsed_serial			 = static_cast<uint32_t>(parsed_timestamp);
+
+	if (last_serial == parsed_serial)
+	{
+		return last_timestamp;
+	}
 
 	// RTMP specification
 	//
@@ -557,23 +713,44 @@ int64_t RtmpChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, cons
 	// are non-negative values of unbounded size in the usual ways of
 	// integer arithmetic.
 
-	// Check if the timestamp is an adjacent timestamp
-	if (delta <= ((1LL << (SERIAL_BITS - 1)) - 1))
-	{
-		// Adjacent timestamp - No need to roll timestamp
-	}
-	else
-	{
-		// Non-adjacent timestamp - Need to roll timestamp
-		new_timestamp = last_timestamp + (1LL << SERIAL_BITS) - (last_timestamp % (1LL << SERIAL_BITS)) + parsed_timestamp;
+	// This helper is only for absolute timestamp paths (Type 0, or Type 3 that
+	// inherits Type 0 semantics). Type 1/2/3 delta paths already operate on an
+	// unfolded absolute timestamp plus a delta, so applying RFC1982 again there
+	// would be incorrect.
+	//
+	// Behavior:
+	// - if the parsed serial is after the previous serial and wrapped below it,
+	//   advance to the next 32-bit epoch
+	// - if the parsed serial is not after the previous serial, keep it in the
+	//   current/prior epoch so backward Type 0 timestamps remain backward
+	const int64_t serial_epoch_base = last_timestamp - static_cast<int64_t>(last_serial);
+	int64_t resolved_timestamp		= serial_epoch_base + parsed_serial;
+	const int64_t serial_diff		= static_cast<int64_t>(parsed_serial) - last_serial;
+	const bool parsed_serial_is_after_previous =
+		((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
+		((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
 
-		logai("Timestamp is rolled: last TS: %" PRId64 ", parsed: %" PRId64 ", new: %" PRId64,
+	if (parsed_serial_is_after_previous)
+	{
+		if (resolved_timestamp <= last_timestamp)
+		{
+			resolved_timestamp += SERIAL_MODULO;
+			logai("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
+				  last_timestamp,
+				  parsed_timestamp,
+				  resolved_timestamp);
+		}
+	}
+	else if (resolved_timestamp > last_timestamp)
+	{
+		resolved_timestamp -= SERIAL_MODULO;
+		logai("Timestamp is resolved as backward T0: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
 			  last_timestamp,
 			  parsed_timestamp,
-			  new_timestamp);
+			  resolved_timestamp);
 	}
 
-	return new_timestamp;
+	return resolved_timestamp;
 }
 
 std::shared_ptr<const RtmpMessage> RtmpChunkParser::GetMessage()

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
@@ -13,6 +13,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <optional>
 
 #include "rtmp_datastructure.h"
 #include "rtmp_define.h"
@@ -28,17 +29,23 @@ public:
 		Parsed,
 	};
 
-	enum class ParseResultForExtendedTimestamp
-	{
-		NeedMoreData,
-		Extended,
-		NotExtended,
-	};
-
 public:
 	RtmpChunkParser(size_t chunk_size);
 	virtual ~RtmpChunkParser();
 
+	/// Parses as much of a single RTMP chunk as possible from the supplied data.
+	///
+	/// @param data Input bytes beginning at the next unread RTMP chunk boundary.
+	/// @param bytes_used Receives the number of bytes consumed from @p data.
+	///
+	/// @return `Parsed` when a chunk payload step completed, `NeedMoreData` when
+	///         more bytes are required, or `Error` when the chunk stream is
+	///         malformed.
+	///
+	/// @note When this returns `NeedMoreData`, @p bytes_used is set to `0` and
+	///       the caller must replay the same unconsumed prefix again with more
+	///       bytes appended. Header parsing is not resumable from the middle of
+	///       a partially received header.
 	ParseResult Parse(const std::shared_ptr<const ov::Data> &data, size_t *bytes_used);
 
 	std::shared_ptr<const RtmpMessage> GetMessage();
@@ -55,25 +62,88 @@ public:
 	void Destroy();
 
 private:
+	/// Returns the most recent completed header for a chunk stream.
+	///
+	/// @param chunk_stream_id RTMP chunk stream identifier.
+	///
+	/// @return The preceding parsed header for @p chunk_stream_id, or `nullptr`
+	///         if no header has been completed on that chunk stream yet.
 	std::shared_ptr<const RtmpChunkHeader> GetPrecedingChunkHeader(const uint32_t chunk_stream_id);
 
+	/// Checks whether the next header belongs to an unfinished message.
+	///
+	/// @param chunk_stream_id RTMP chunk stream identifier for the incoming chunk.
+	///
+	/// @return `true` when the parser is expecting a continuation chunk for the
+	///         same chunk stream, including interleaved pending-message cases.
+	bool IsContinuationChunk(const uint32_t chunk_stream_id) const;
+
+	/// Parses the RTMP basic header.
+	///
+	/// @param stream Input byte stream positioned at the RTMP basic header.
+	/// @param chunk_header Destination header object to populate.
+	///
+	/// @return `Parsed`, `NeedMoreData`, or `Error`.
 	ParseResult ParseBasicHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header);
-	ParseResultForExtendedTimestamp ParseExtendedTimestamp(
+
+	/// Parses a 24-bit timestamp field and its optional extended timestamp.
+	///
+	/// @param stream_id RTMP message stream identifier used for logging/context.
+	/// @param stream Input byte stream positioned at the timestamp field.
+	/// @param chunk_header Destination header object whose extended-timestamp
+	///        metadata is updated on success.
+	/// @param encoded_value The already-read 24-bit timestamp or timestamp-delta
+	///        field value.
+	///
+	/// @return The semantic timestamp value on success, or `std::nullopt` when
+	///         more bytes are required to finish parsing the field.
+	std::optional<uint32_t> ParseTimestampField(
 		const uint32_t stream_id,
 		ov::ByteStream &stream,
 		RtmpChunkHeader *chunk_header,
-		const int64_t timestamp,
-		RtmpChunkHeader::CompletedHeader *completed_header);
-	ParseResultForExtendedTimestamp ParseExtendedTimestampDelta(
+		const uint32_t encoded_value);
+
+	/// Resolves a timestamp delta against the preceding absolute timestamp.
+	///
+	/// @param stream_id RTMP message stream identifier used for logging/context.
+	/// @param preceding_timestamp Previously resolved absolute timestamp.
+	/// @param timestamp_delta Parsed timestamp-delta field value.
+	/// @param is_extended_timestamp True when the delta came from the extended
+	///        timestamp field.
+	///
+	/// @return The resolved absolute timestamp, or `std::nullopt` when the
+	///         non-standard signed-delta compatibility path would produce an
+	///         invalid negative absolute timestamp.
+	std::optional<int64_t> ResolveTimestampDelta(
 		const uint32_t stream_id,
-		ov::ByteStream &stream,
-		RtmpChunkHeader *chunk_header,
 		const int64_t preceding_timestamp,
-		const int64_t timestamp_delta,
-		RtmpChunkHeader::CompletedHeader *completed_header);
+		const uint32_t timestamp_delta,
+		const bool is_extended_timestamp) const;
+
+	/// Parses the RTMP message header for an already-parsed basic header.
+	///
+	/// @param stream Input byte stream positioned at the RTMP message header.
+	/// @param chunk_header Destination header object to populate.
+	///
+	/// @return `Parsed`, `NeedMoreData`, or `Error`.
 	ParseResult ParseMessageHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header);
+
+	/// Parses both the RTMP basic header and message header.
+	///
+	/// @param stream Input byte stream positioned at the start of an RTMP header.
+	/// @param chunk_header Destination header object to populate.
+	///
+	/// @return `Parsed`, `NeedMoreData`, or `Error`.
 	ParseResult ParseHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header);
 
+	/// Unfolds a 32-bit absolute RTMP timestamp using RFC1982 serial arithmetic.
+	///
+	/// @param stream_id RTMP message stream identifier used for logging/context.
+	/// @param last_timestamp Previously resolved absolute timestamp.
+	/// @param parsed_timestamp Newly parsed 32-bit serial timestamp value.
+	///
+	/// @return The resolved absolute timestamp in the current or next serial
+	///         epoch.
 	int64_t CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp);
 
 private:

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
@@ -8,28 +8,16 @@
 //==============================================================================
 #pragma once
 
-#include <base/info/info.h>
-
-#include <deque>
-#include <map>
-#include <memory>
-#include <optional>
-
+#include "../rtmp_chunk_parser_common.h"
 #include "rtmp_datastructure.h"
 #include "rtmp_define.h"
 #include "rtmp_mux_util.h"
 
-class RtmpChunkParser
+class RtmpChunkParser : public RtmpChunkParserCommon<RtmpChunkHeader, RtmpMessage>
 {
 public:
-	enum class ParseResult
-	{
-		Error,
-		NeedMoreData,
-		Parsed,
-	};
+	using ParseResult = typename RtmpChunkParserCommon<RtmpChunkHeader, RtmpMessage>::ParseResult;
 
-public:
 	RtmpChunkParser(size_t chunk_size);
 	virtual ~RtmpChunkParser();
 
@@ -55,9 +43,6 @@ public:
 	{
 		_chunk_size = chunk_size;
 	}
-
-	info::NamePath GetNamePath() const;
-	void UpdateNamePath(const info::NamePath &stream_name_path);
 
 	void Destroy();
 
@@ -86,40 +71,6 @@ private:
 	/// @return `Parsed`, `NeedMoreData`, or `Error`.
 	ParseResult ParseBasicHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header);
 
-	/// Parses a 24-bit timestamp field and its optional extended timestamp.
-	///
-	/// @param stream_id RTMP message stream identifier used for logging/context.
-	/// @param stream Input byte stream positioned at the timestamp field.
-	/// @param chunk_header Destination header object whose extended-timestamp
-	///        metadata is updated on success.
-	/// @param encoded_value The already-read 24-bit timestamp or timestamp-delta
-	///        field value.
-	///
-	/// @return The semantic timestamp value on success, or `std::nullopt` when
-	///         more bytes are required to finish parsing the field.
-	std::optional<uint32_t> ParseTimestampField(
-		const uint32_t stream_id,
-		ov::ByteStream &stream,
-		RtmpChunkHeader *chunk_header,
-		const uint32_t encoded_value);
-
-	/// Resolves a timestamp delta against the preceding absolute timestamp.
-	///
-	/// @param stream_id RTMP message stream identifier used for logging/context.
-	/// @param preceding_timestamp Previously resolved absolute timestamp.
-	/// @param timestamp_delta Parsed timestamp-delta field value.
-	/// @param is_extended_timestamp True when the delta came from the extended
-	///        timestamp field.
-	///
-	/// @return The resolved absolute timestamp, or `std::nullopt` when the
-	///         non-standard signed-delta compatibility path would produce an
-	///         invalid negative absolute timestamp.
-	std::optional<int64_t> ResolveTimestampDelta(
-		const uint32_t stream_id,
-		const int64_t preceding_timestamp,
-		const uint32_t timestamp_delta,
-		const bool is_extended_timestamp) const;
-
 	/// Parses the RTMP message header for an already-parsed basic header.
 	///
 	/// @param stream Input byte stream positioned at the RTMP message header.
@@ -135,31 +86,4 @@ private:
 	///
 	/// @return `Parsed`, `NeedMoreData`, or `Error`.
 	ParseResult ParseHeader(ov::ByteStream &stream, RtmpChunkHeader *chunk_header);
-
-	/// Unfolds a 32-bit absolute RTMP timestamp using RFC1982 serial arithmetic.
-	///
-	/// @param stream_id RTMP message stream identifier used for logging/context.
-	/// @param last_timestamp Previously resolved absolute timestamp.
-	/// @param parsed_timestamp Newly parsed 32-bit serial timestamp value.
-	///
-	/// @return The resolved absolute timestamp in the current or next serial
-	///         epoch.
-	int64_t CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp);
-
-private:
-#if DEBUG
-	uint64_t _chunk_index	   = 0ULL;
-	uint64_t _total_read_bytes = 0ULL;
-#endif	// DEBUG
-
-	bool _need_to_parse_new_header = true;
-	std::shared_ptr<RtmpMessage> _current_message;
-	std::map<uint32_t, std::shared_ptr<RtmpMessage>> _pending_message_map;
-	std::map<uint32_t, std::shared_ptr<const RtmpChunkHeader>> _preceding_chunk_header_map;
-
-	ov::Queue<std::shared_ptr<const RtmpMessage>> _message_queue{nullptr, 500};
-	size_t _chunk_size;
-
-	mutable std::mutex _name_path_mutex;
-	info::NamePath _name_path;
 };

--- a/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_chunk_parser.h
@@ -78,7 +78,7 @@ private:
 
 private:
 #if DEBUG
-	uint64_t _chunk_index = 0ULL;
+	uint64_t _chunk_index	   = 0ULL;
 	uint64_t _total_read_bytes = 0ULL;
 #endif	// DEBUG
 

--- a/src/projects/modules/rtmp/chunk/rtmp_datastructure.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_datastructure.h
@@ -39,7 +39,7 @@ struct RtmpChunkHeader
 
 	// Indicates whether the timestamp is extended
 	bool is_extended_timestamp = false;
-	bool is_timestamp_delta = false;
+	bool is_timestamp_delta	   = false;
 
 	// Total chunk header size (basic header + message header + extended timestamp)
 	uint32_t GetTotalHeaderLength() const
@@ -48,16 +48,16 @@ struct RtmpChunkHeader
 	}
 
 #if DEBUG
-	uint64_t chunk_index = 0ULL;
+	uint64_t chunk_index				 = 0ULL;
 
-	uint64_t from_byte_offset = 0ULL;
+	uint64_t from_byte_offset			 = 0ULL;
 	mutable uint64_t message_total_bytes = 0ULL;
 #endif	// DEBUG
 
 	// 1 or 2 or 3
-	uint8_t basic_header_length = 0U;
+	uint8_t basic_header_length	   = 0U;
 	uint32_t message_header_length = 0U;
-	uint32_t message_length = 0U;
+	uint32_t message_length		   = 0U;
 
 	// uint32_t expected_type_3_header{};
 	// The payload size that including type 3 messages
@@ -80,11 +80,11 @@ struct RtmpChunkHeader
 	struct CompletedHeader
 	{
 		// Accumulated timestamp
-		int64_t timestamp = 0LL;
-		uint32_t timestamp_delta = 0U;
+		int64_t timestamp		  = 0LL;
+		uint32_t timestamp_delta  = 0U;
 
 		RtmpMessageTypeID type_id = RtmpMessageTypeID::Unknown;
-		uint32_t stream_id = 0U;
+		uint32_t stream_id		  = 0U;
 	} completed;
 
 	// Message Header

--- a/src/projects/modules/rtmp/chunk/rtmp_datastructure.h
+++ b/src/projects/modules/rtmp/chunk/rtmp_datastructure.h
@@ -23,8 +23,6 @@ enum class RtmpMessageHeaderType : uint8_t
 #pragma pack(push, 1)
 struct RtmpChunkHeader
 {
-	static constexpr const size_t EXTENDED_TIMESTAMP_SIZE = 4;
-
 	RtmpChunkHeader()
 	{
 		::memset(&message_header, 0, sizeof(message_header));
@@ -75,7 +73,7 @@ struct RtmpChunkHeader
 
 	// Extended Timestamp/Timestamp delta
 	uint32_t extended_timestamp = 0U;
-	static_assert(sizeof(RtmpChunkHeader::extended_timestamp) == EXTENDED_TIMESTAMP_SIZE, "Extended timestamp size must be 4 bytes");
+	static_assert(sizeof(RtmpChunkHeader::extended_timestamp) == RTMP_EXTEND_TIMESTAMP_SIZE, "Extended timestamp size must be 4 bytes");
 
 	struct CompletedHeader
 	{

--- a/src/projects/modules/rtmp/rtmp_chunk_parser_common.h
+++ b/src/projects/modules/rtmp/rtmp_chunk_parser_common.h
@@ -1,0 +1,56 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include <base/info/info.h>
+#include <base/ovlibrary/queue.h>
+
+template <typename Theader, typename Tmessage>
+class RtmpChunkParserCommon
+{
+public:
+	enum class ParseResult
+	{
+		Error,
+		NeedMoreData,
+		Parsed,
+	};
+
+public:
+	info::NamePath GetNamePath() const
+	{
+		std::lock_guard lock_guard(_name_path_mutex);
+		return _name_path;
+	}
+
+	virtual void UpdateNamePath(const info::NamePath &stream_name_path)
+	{
+		std::lock_guard lock_guard(_name_path_mutex);
+		_name_path = stream_name_path;
+		_message_queue.SetAlias(ov::String::FormatString("RTMP queue for %s", _name_path.CStr()));
+	}
+
+protected:
+	bool _need_to_parse_new_header = true;
+	std::shared_ptr<Tmessage> _current_message;
+	std::map<uint32_t, std::shared_ptr<Tmessage>> _pending_message_map;
+
+#if DEBUG
+	uint64_t _chunk_index	   = 0ULL;
+	uint64_t _total_read_bytes = 0ULL;
+#endif	// DEBUG
+
+	std::map<uint32_t, std::shared_ptr<const Theader>> _preceding_chunk_header_map;
+	ov::Queue<std::shared_ptr<const Tmessage>> _message_queue{nullptr, 500};
+	size_t _chunk_size = 0;
+
+private:
+	mutable std::mutex _name_path_mutex;
+	info::NamePath _name_path;
+};

--- a/src/projects/modules/rtmp/rtmp_chunk_parser_helper.h
+++ b/src/projects/modules/rtmp/rtmp_chunk_parser_helper.h
@@ -1,0 +1,150 @@
+//==============================================================================
+//
+//  OvenMediaEngine
+//
+//  Created by Hyunjun Jang
+//  Copyright (c) 2026 AirenSoft. All rights reserved.
+//
+//==============================================================================
+
+// Intentionally included from RTMP chunk parser .cpp files only.
+namespace
+{
+	std::optional<uint32_t> ParseTimestampField(
+		const uint32_t stream_id,
+		ov::ByteStream &stream,
+		bool &is_extended_timestamp,
+		uint32_t &extended_timestamp,
+		uint32_t &message_header_length,
+		const uint32_t encoded_value,
+		const uint32_t extended_timestamp_indicator,
+		const size_t extended_timestamp_size)
+	{
+		if (encoded_value != extended_timestamp_indicator)
+		{
+			is_extended_timestamp = false;
+			extended_timestamp	  = 0U;
+			return encoded_value;
+		}
+
+		if (stream.IsRemained(extended_timestamp_size) == false)
+		{
+			logtp("Need more data to parse extended timestamp field: %zu bytes (current: %zu)", extended_timestamp_size, stream.Remained());
+			return std::nullopt;
+		}
+
+		logtd("Extended timestamp is present for stream id: %u", stream_id);
+
+		extended_timestamp	  = stream.ReadBE32();
+		is_extended_timestamp = true;
+		message_header_length += static_cast<uint32_t>(extended_timestamp_size);
+
+		return extended_timestamp;
+	}
+
+	std::optional<int64_t> ResolveTimestampDelta(
+		const uint32_t stream_id,
+		const int64_t preceding_timestamp,
+		const uint32_t timestamp_delta,
+		const bool is_extended_timestamp,
+		const uint32_t signed_extended_timestamp_delta_sign_bit,
+		const int64_t max_negative_extended_timestamp_delta_ms)
+	{
+		if (is_extended_timestamp && (timestamp_delta >= signed_extended_timestamp_delta_sign_bit))
+		{
+			const auto signed_timestamp_delta = static_cast<int32_t>(timestamp_delta);
+			const auto backward_delta		  = -1 * static_cast<int64_t>(signed_timestamp_delta);
+
+			if ((signed_timestamp_delta < 0) && (backward_delta <= max_negative_extended_timestamp_delta_ms))
+			{
+				const auto resolved_timestamp = preceding_timestamp + signed_timestamp_delta;
+				if (resolved_timestamp < 0)
+				{
+					logte("Reject signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
+						  stream_id,
+						  preceding_timestamp,
+						  timestamp_delta,
+						  signed_timestamp_delta);
+					return std::nullopt;
+				}
+
+				logtw("Accept signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId32,
+					  stream_id,
+					  preceding_timestamp,
+					  timestamp_delta,
+					  signed_timestamp_delta);
+				return resolved_timestamp;
+			}
+		}
+
+		return preceding_timestamp + timestamp_delta;
+	}
+
+	int64_t CalculateRolledTimestamp(
+		[[maybe_unused]] const uint32_t stream_id,
+		const int64_t last_timestamp,
+		int64_t parsed_timestamp)
+	{
+		constexpr int64_t SERIAL_BITS					  = 32;
+		constexpr int64_t SERIAL_MODULO					  = (1LL << SERIAL_BITS);
+		constexpr int64_t SERIAL_HALF_RANGE				  = (1LL << (SERIAL_BITS - 1));
+		constexpr int64_t SIGNED_SERIAL_MODULO			  = (1LL << (SERIAL_BITS - 1));
+		constexpr uint64_t SERIAL_VALUE_MASK			  = 0xFFFFFFFFULL;
+		constexpr int64_t MAX_SIGNED_WRAP_COMPAT_DELTA_MS = 10 * 1000;
+
+		const auto last_serial							  = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
+		const auto parsed_serial						  = static_cast<uint32_t>(parsed_timestamp);
+
+		if (last_serial == parsed_serial)
+		{
+			return last_timestamp;
+		}
+
+		const int64_t serial_epoch_base = last_timestamp - static_cast<int64_t>(last_serial);
+		int64_t resolved_timestamp		= serial_epoch_base + parsed_serial;
+		const int64_t serial_diff		= static_cast<int64_t>(parsed_serial) - last_serial;
+		const bool parsed_serial_is_after_previous =
+			((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
+			((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
+
+		const int64_t signed_wrap_forward_delta = SIGNED_SERIAL_MODULO - static_cast<int64_t>(last_serial) + parsed_serial;
+		const bool signed_wrap_compat_candidate =
+			(parsed_serial_is_after_previous == false) &&
+			(last_serial < SIGNED_SERIAL_MODULO) &&
+			(parsed_serial < SIGNED_SERIAL_MODULO) &&
+			(parsed_serial < last_serial) &&
+			(signed_wrap_forward_delta > 0) &&
+			(signed_wrap_forward_delta <= MAX_SIGNED_WRAP_COMPAT_DELTA_MS);
+
+		if (parsed_serial_is_after_previous)
+		{
+			if (resolved_timestamp <= last_timestamp)
+			{
+				resolved_timestamp += SERIAL_MODULO;
+				logtd("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
+					  last_timestamp,
+					  parsed_timestamp,
+					  resolved_timestamp);
+			}
+		}
+		else if (signed_wrap_compat_candidate)
+		{
+			resolved_timestamp = last_timestamp + signed_wrap_forward_delta;
+			logtd("Timestamp is rolled forward with signed-31bit compatibility: last TS: %" PRId64 ", parsed: %" PRId64 ", delta: %" PRId64 ", resolved: %" PRId64,
+				  last_timestamp,
+				  parsed_timestamp,
+				  signed_wrap_forward_delta,
+				  resolved_timestamp);
+		}
+		else if (resolved_timestamp > last_timestamp)
+		{
+			resolved_timestamp -= SERIAL_MODULO;
+			logti("Timestamp is resolved as backward T0: last TS: %" PRId64 ", parsed: %" PRId64 ", resolved: %" PRId64,
+				  last_timestamp,
+				  parsed_timestamp,
+				  resolved_timestamp);
+		}
+
+		return resolved_timestamp;
+	}
+}  // namespace

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
@@ -13,6 +13,12 @@
 
 namespace modules::rtmp
 {
+	namespace
+	{
+		constexpr uint32_t SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT = 0x80000000U;
+		constexpr int64_t MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS	= 10 * 1000;
+	}  // namespace
+
 	ChunkParser::ChunkParser(int chunk_size)
 	{
 		_chunk_size = chunk_size;
@@ -35,7 +41,7 @@ namespace modules::rtmp
 		{
 			// Need to parse new header when parsing for the first time or when reaching the chunk size
 			auto parsed_chunk_header = std::make_shared<ChunkHeader>();
-			auto status = ParseHeader(stream, parsed_chunk_header.get());
+			auto status				 = ParseHeader(stream, parsed_chunk_header.get());
 			if (status != ParseResult::Parsed)
 			{
 				// If the header parsing fails, the bytes_used value is not updated to try parsing again from the beginning next time.
@@ -45,7 +51,7 @@ namespace modules::rtmp
 			_need_to_parse_new_header = false;
 
 #if DEBUG
-			parsed_chunk_header->chunk_index = _chunk_index;
+			parsed_chunk_header->chunk_index	  = _chunk_index;
 			parsed_chunk_header->from_byte_offset = _total_read_bytes;
 #endif	// DEBUG
 
@@ -53,9 +59,9 @@ namespace modules::rtmp
 
 			if (_current_message != nullptr)
 			{
-				auto &current_chunk_header = _current_message->header;
+				auto &current_chunk_header		   = _current_message->header;
 				const auto current_chunk_stream_id = current_chunk_header->basic_header.chunk_stream_id;
-				const auto new_chunk_stream_id = parsed_chunk_header->basic_header.chunk_stream_id;
+				const auto new_chunk_stream_id	   = parsed_chunk_header->basic_header.chunk_stream_id;
 
 				if (current_chunk_stream_id != new_chunk_stream_id)
 				{
@@ -138,7 +144,7 @@ namespace modules::rtmp
 
 		if (_current_message->ReadFromStream(stream, _chunk_size))
 		{
-			auto &current_message_header = _current_message->header;
+			auto &current_message_header													  = _current_message->header;
 			_preceding_chunk_header_map[current_message_header->basic_header.chunk_stream_id] = current_message_header;
 
 			if (_current_message->GetRemainedPayloadSize() == 0UL)
@@ -160,7 +166,7 @@ namespace modules::rtmp
 				logtp("Need to parse next chunk (%zu bytes remained to completed current messasge)", _current_message->GetRemainedPayloadSize());
 			}
 
-			status = ParseResult::Parsed;
+			status					  = ParseResult::Parsed;
 
 			// A new message is completed or the chunk size is reached, so a new header parsing is required.
 			_need_to_parse_new_header = true;
@@ -188,13 +194,13 @@ namespace modules::rtmp
 			return ParseResult::NeedMoreData;
 		}
 
-		const auto first_byte = stream.Read8();
+		const auto first_byte			  = stream.Read8();
 
-		auto &basic_header = chunk_header->basic_header;
+		auto &basic_header				  = chunk_header->basic_header;
 
 		// Parse basic header
-		basic_header.format_type = static_cast<MessageHeaderType>((first_byte & 0b11000000) >> 6);
-		basic_header.chunk_stream_id = (first_byte & 0b00111111);
+		basic_header.format_type		  = static_cast<MessageHeaderType>((first_byte & 0b11000000) >> 6);
+		basic_header.chunk_stream_id	  = (first_byte & 0b00111111);
 
 		chunk_header->basic_header_length = GetBasicHeaderLength(basic_header.chunk_stream_id);
 
@@ -230,86 +236,109 @@ namespace modules::rtmp
 		return header->second;
 	}
 
-	ChunkParser::ParseResultForExtendedTimestamp ChunkParser::ParseExtendedTimestamp(
+	bool ChunkParser::IsContinuationChunk(const uint32_t chunk_stream_id) const
+	{
+		if ((_current_message != nullptr) &&
+			(_current_message->header->basic_header.chunk_stream_id == chunk_stream_id) &&
+			(_current_message->GetRemainedPayloadSize() > 0))
+		{
+			return true;
+		}
+
+		const auto pending_message = _pending_message_map.find(chunk_stream_id);
+		if (pending_message == _pending_message_map.end())
+		{
+			return false;
+		}
+
+		return (pending_message->second != nullptr) && (pending_message->second->GetRemainedPayloadSize() > 0);
+	}
+
+	std::optional<uint32_t> ChunkParser::ParseTimestampField(
 		const uint32_t stream_id,
 		ov::ByteStream &stream,
 		ChunkHeader *chunk_header,
-		const int64_t timestamp,
-		ChunkHeader::CompletedHeader *completed_header)
+		const uint32_t encoded_value)
 	{
-		if (timestamp != EXTENDED_TIMESTAMP_VALUE)
+		if (encoded_value != EXTENDED_TIMESTAMP_VALUE)
 		{
+			// The 24-bit field already contains the semantic timestamp value, so
+			// there is no 32-bit extended field to consume on the wire.
 			chunk_header->is_extended_timestamp = false;
-
-			completed_header->timestamp = timestamp;
-			completed_header->timestamp_delta = 0U;
-
-			return ParseResultForExtendedTimestamp::NotExtended;
+			chunk_header->extended_timestamp	= 0U;
+			return encoded_value;
 		}
 
 		if (stream.IsRemained(EXTENDED_TIMESTAMP_SIZE) == false)
 		{
 			logtp("Need more data to parse extended timestamp: %d bytes (current: %zu)", EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-			return ParseResultForExtendedTimestamp::NeedMoreData;
+			return std::nullopt;
 		}
 
 		logtt("Extended timestamp is present for stream id: %u", stream_id);
 
-		int64_t extended_timestamp = stream.ReadBE32();
+		const uint32_t extended_timestamp	= stream.ReadBE32();
 
+		// The 24-bit field carried the sentinel value, so the real 32-bit value
+		// follows immediately and becomes the semantic timestamp field value.
 		chunk_header->is_extended_timestamp = true;
 		chunk_header->message_header_length += EXTENDED_TIMESTAMP_SIZE;
+		chunk_header->extended_timestamp = extended_timestamp;
 
-		completed_header->timestamp = extended_timestamp;
-		completed_header->timestamp_delta = 0U;
-
-		return ParseResultForExtendedTimestamp::Extended;
+		return extended_timestamp;
 	}
 
-	ChunkParser::ParseResultForExtendedTimestamp ChunkParser::ParseExtendedTimestampDelta(
+	std::optional<int64_t> ChunkParser::ResolveTimestampDelta(
 		const uint32_t stream_id,
-		ov::ByteStream &stream,
-		ChunkHeader *chunk_header,
 		const int64_t preceding_timestamp,
-		const int64_t timestamp_delta,
-		ChunkHeader::CompletedHeader *completed_header)
+		const uint32_t timestamp_delta,
+		const bool is_extended_timestamp) const
 	{
-		if (timestamp_delta != EXTENDED_TIMESTAMP_VALUE)
+		if (is_extended_timestamp && (timestamp_delta >= SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT))
 		{
-			chunk_header->is_extended_timestamp = false;
+			// The sign bit is set in a 32-bit extended delta, so this could be a
+			// broken sender that wrote a signed int32_t onto the wire.
+			const int64_t signed_timestamp_delta = static_cast<int32_t>(timestamp_delta);
 
-			completed_header->timestamp = preceding_timestamp + timestamp_delta;
-			completed_header->timestamp_delta = timestamp_delta;
+			if ((signed_timestamp_delta < 0) && ((-signed_timestamp_delta) <= MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS))
+			{
+				// Accept only small backward jumps on the compatibility path. Large
+				// values are more likely to be legitimate unsigned deltas.
+				const int64_t resolved_timestamp = preceding_timestamp + signed_timestamp_delta;
 
-			return ParseResultForExtendedTimestamp::NotExtended;
+				if (resolved_timestamp < 0)
+				{
+					// Even on the compatibility path, never allow the absolute
+					// timestamp to move below zero.
+					logte("Reject signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId64,
+						  stream_id,
+						  preceding_timestamp,
+						  timestamp_delta,
+						  signed_timestamp_delta);
+					return std::nullopt;
+				}
+
+				// This is the non-standard but tolerated case: a small negative
+				// extended delta that still resolves to a valid absolute timestamp.
+				logtw("Accept signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId64,
+					  stream_id,
+					  preceding_timestamp,
+					  timestamp_delta,
+					  signed_timestamp_delta);
+
+				return resolved_timestamp;
+			}
 		}
 
-		if (stream.IsRemained(EXTENDED_TIMESTAMP_SIZE) == false)
-		{
-			logtp("Need more data to parse extended timestamp delta: %d bytes (current: %zu)", EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-			return ParseResultForExtendedTimestamp::NeedMoreData;
-		}
-
-		logtt("Extended timestamp delta is present for stream id: %u", stream_id);
-
-		OV_ASSERT(EXTENDED_TIMESTAMP_SIZE == 4, "Extended timestamp delta size must be 4 bytes");
-
-		int64_t extended_timestamp_delta = stream.ReadBE32();
-
-		chunk_header->is_extended_timestamp = true;
-		chunk_header->message_header_length += EXTENDED_TIMESTAMP_SIZE;
-
-		completed_header->timestamp = preceding_timestamp + extended_timestamp_delta;
-		completed_header->timestamp_delta = extended_timestamp_delta;
-
-		return ParseResultForExtendedTimestamp::Extended;
+		// Standard RTMP behavior: interpret the delta as an unsigned increment.
+		return preceding_timestamp + timestamp_delta;
 	}
 
 	ChunkParser::ParseResult ChunkParser::ParseMessageHeader(ov::ByteStream &stream, ChunkHeader *chunk_header)
 	{
-		auto &basic_header = chunk_header->basic_header;
-		auto &message_header = chunk_header->message_header;
-		auto &completed = chunk_header->completed;
+		auto &basic_header					= chunk_header->basic_header;
+		auto &message_header				= chunk_header->message_header;
+		auto &completed						= chunk_header->completed;
 
 		// Obtains minimum message header size to parse
 		chunk_header->message_header_length = GetMessageHeaderLength(basic_header.format_type, false);
@@ -321,7 +350,7 @@ namespace modules::rtmp
 		}
 
 		// Parse message header
-		chunk_header->is_extended_timestamp = false;
+		chunk_header->is_extended_timestamp						  = false;
 
 		std::shared_ptr<const ChunkHeader> preceding_chunk_header = GetPrecedingChunkHeader(basic_header.chunk_stream_id);
 
@@ -345,132 +374,240 @@ namespace modules::rtmp
 		switch (basic_header.format_type)
 		{
 			case MessageHeaderType::T0: {
-				auto &header = message_header.type_0;
-				header.timestamp = stream.ReadBE24();
-				header.length = stream.ReadBE24();
-				header.type_id = static_cast<MessageTypeID>(stream.Read8());
-				header.stream_id = stream.ReadLE32();
+				auto &header					 = message_header.type_0;
+				header.timestamp				 = stream.ReadBE24();
+				header.length					 = stream.ReadBE24();
+				header.type_id					 = static_cast<MessageTypeID>(stream.Read8());
+				header.stream_id				 = stream.ReadLE32();
 
 				chunk_header->is_timestamp_delta = false;
-				chunk_header->message_length = header.length;
+				chunk_header->message_length	 = header.length;
 
-				auto result = ParseExtendedTimestamp(
+				const auto parsed_timestamp		 = ParseTimestampField(
 					header.stream_id,
 					stream, chunk_header,
-					header.timestamp, &completed);
+					header.timestamp);
 
-				if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+				if (parsed_timestamp.has_value() == false)
 				{
 					return ParseResult::NeedMoreData;
 				}
+
+				// Type 0 carries an absolute timestamp. If there is a preceding
+				// absolute timestamp on the same chunk stream, unfold the 32-bit
+				// serial value into the current absolute epoch with RFC1982 logic.
+				completed.timestamp		  = parsed_timestamp.value();
+				completed.timestamp_delta = 0U;
 
 				if (preceding_completed_header != nullptr)
 				{
 					completed.timestamp = CalculateRolledTimestamp(header.stream_id, preceding_completed_header->timestamp, completed.timestamp);
 				}
 
-				completed.type_id = header.type_id;
+				completed.type_id	= header.type_id;
 				completed.stream_id = header.stream_id;
 				break;
 			}
 
 			case MessageHeaderType::T1: {
-				auto &header = message_header.type_1;
-				header.timestamp_delta = stream.ReadBE24();
-				header.length = stream.ReadBE24();
-				header.type_id = static_cast<MessageTypeID>(stream.Read8());
+				auto &header					  = message_header.type_1;
+				header.timestamp_delta			  = stream.ReadBE24();
+				header.length					  = stream.ReadBE24();
+				header.type_id					  = static_cast<MessageTypeID>(stream.Read8());
 
-				chunk_header->is_timestamp_delta = true;
-				chunk_header->message_length = header.length;
+				chunk_header->is_timestamp_delta  = true;
+				chunk_header->message_length	  = header.length;
 
-				auto result = ParseExtendedTimestampDelta(
+				const auto parsed_timestamp_delta = ParseTimestampField(
 					preceding_completed_header->stream_id,
 					stream, chunk_header,
-					preceding_completed_header->timestamp,
-					header.timestamp_delta,
-					&completed);
+					header.timestamp_delta);
 
-				if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+				if (parsed_timestamp_delta.has_value() == false)
 				{
 					return ParseResult::NeedMoreData;
 				}
 
-				completed.type_id = header.type_id;
-				completed.stream_id = preceding_completed_header->stream_id;
+				const auto resolved_timestamp = ResolveTimestampDelta(
+					preceding_completed_header->stream_id,
+					preceding_completed_header->timestamp,
+					parsed_timestamp_delta.value(),
+					chunk_header->is_extended_timestamp);
+
+				if (resolved_timestamp.has_value() == false)
+				{
+					return ParseResult::Error;
+				}
+
+				// Type 1 carries a timestamp delta, not a wrapped absolute timestamp.
+				// Once the preceding timestamp has already been unfolded into the
+				// current absolute epoch, simple addition is the correct RTMP behavior.
+				completed.timestamp		  = resolved_timestamp.value();
+				completed.timestamp_delta = parsed_timestamp_delta.value();
+				completed.type_id		  = header.type_id;
+				completed.stream_id		  = preceding_completed_header->stream_id;
 
 				break;
 			}
 
 			case MessageHeaderType::T2: {
-				auto &header = message_header.type_2;
-				header.timestamp_delta = stream.ReadBE24();
+				auto &header					  = message_header.type_2;
+				header.timestamp_delta			  = stream.ReadBE24();
 
-				chunk_header->is_timestamp_delta = true;
-				chunk_header->message_length = preceding_chunk_header->message_length;
+				chunk_header->is_timestamp_delta  = true;
+				chunk_header->message_length	  = preceding_chunk_header->message_length;
 
-				auto result = ParseExtendedTimestampDelta(
+				const auto parsed_timestamp_delta = ParseTimestampField(
 					preceding_completed_header->stream_id,
 					stream, chunk_header,
-					preceding_completed_header->timestamp,
-					header.timestamp_delta,
-					&completed);
+					header.timestamp_delta);
 
-				if (result == ParseResultForExtendedTimestamp::NeedMoreData)
+				if (parsed_timestamp_delta.has_value() == false)
 				{
 					return ParseResult::NeedMoreData;
 				}
 
-				completed.type_id = preceding_completed_header->type_id;
-				completed.stream_id = preceding_completed_header->stream_id;
+				const auto resolved_timestamp = ResolveTimestampDelta(
+					preceding_completed_header->stream_id,
+					preceding_completed_header->timestamp,
+					parsed_timestamp_delta.value(),
+					chunk_header->is_extended_timestamp);
+
+				if (resolved_timestamp.has_value() == false)
+				{
+					return ParseResult::Error;
+				}
+
+				// Type 2 is the same timestamp-delta model as Type 1, just with fewer
+				// header fields. Do not run RFC1982 rollover logic here.
+				completed.timestamp		  = resolved_timestamp.value();
+				completed.timestamp_delta = parsed_timestamp_delta.value();
+				completed.type_id		  = preceding_completed_header->type_id;
+				completed.stream_id		  = preceding_completed_header->stream_id;
 
 				break;
 			}
 
 			case MessageHeaderType::T3: {
 				chunk_header->is_extended_timestamp = preceding_chunk_header->is_extended_timestamp;
-				chunk_header->is_timestamp_delta = preceding_chunk_header->is_timestamp_delta;
-				chunk_header->message_length = preceding_chunk_header->message_length;
+				chunk_header->is_timestamp_delta	= preceding_chunk_header->is_timestamp_delta;
+				chunk_header->message_length		= preceding_chunk_header->message_length;
 
-				completed.timestamp = preceding_completed_header->timestamp;
-				completed.timestamp_delta = preceding_completed_header->timestamp_delta;
+				completed.timestamp					= preceding_completed_header->timestamp;
+				completed.timestamp_delta			= preceding_completed_header->timestamp_delta;
 
-				completed.type_id = preceding_completed_header->type_id;
-				completed.stream_id = preceding_completed_header->stream_id;
+				completed.type_id					= preceding_completed_header->type_id;
+				completed.stream_id					= preceding_completed_header->stream_id;
 
-				ParseResultForExtendedTimestamp result;
-
-				if (chunk_header->is_timestamp_delta == false)
+				if (IsContinuationChunk(basic_header.chunk_stream_id))
 				{
-					// The origin message header is T0
-					result = ParseExtendedTimestamp(
+					// Type 3 is also used for continuation chunks of the same message.
+					// In that case the message timestamp was already fixed by the first
+					// chunk, so do not re-apply either the absolute timestamp or delta.
+					// If the preceding chunk used extended timestamp encoding, this
+					// continuation chunk still carries the 4-byte field on the wire and
+					// it must be consumed even though its semantic value is unchanged.
+					//
+					// If the preceding chunk was not extended, there is no reliable way
+					// to distinguish a malformed extra 4-byte field from normal payload
+					// bytes here. Rejecting based on heuristics would risk corrupting
+					// valid payload, so the parser only validates the repeated extended
+					// field when the message actually uses extended timestamp encoding.
+					if (chunk_header->is_extended_timestamp)
+					{
+						const auto parsed_timestamp_field = ParseTimestampField(
+							completed.stream_id,
+							stream, chunk_header,
+							EXTENDED_TIMESTAMP_VALUE);
+
+						if (parsed_timestamp_field.has_value() == false)
+						{
+							return ParseResult::NeedMoreData;
+						}
+
+						// A Type 3 continuation chunk should repeat the same extended
+						// timestamp field as the first chunk of the message. If it does
+						// not, keep the pre-existing compatibility behavior and continue
+						// parsing with the already fixed message timestamp instead of
+						// failing the whole session.
+						//
+						// The log below keeps just enough context to explain whether the
+						// stored semantic meaning came from an absolute timestamp path or
+						// a timestamp-delta path.
+						if (parsed_timestamp_field.value() != preceding_chunk_header->extended_timestamp)
+						{
+							logtw("Type3 ext mismatch: sid=%u csid=%u origin=%d semantic=%s expected=0x%08x parsed=0x%08x",
+								  completed.stream_id,
+								  basic_header.chunk_stream_id,
+								  ov::ToUnderlyingType(preceding_chunk_header->basic_header.format_type),
+								  preceding_chunk_header->is_timestamp_delta ? "delta" : "absolute",
+								  preceding_chunk_header->extended_timestamp,
+								  parsed_timestamp_field.value());
+						}
+					}
+				}
+				else if (chunk_header->is_timestamp_delta == false)
+				{
+					// The origin message header is T0.
+					const auto parsed_timestamp = ParseTimestampField(
 						completed.stream_id,
 						stream, chunk_header,
-						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : completed.timestamp, &completed);
+						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : static_cast<uint32_t>(completed.timestamp));
 
-					if (result != ParseResultForExtendedTimestamp::NeedMoreData)
+					if (parsed_timestamp.has_value() == false)
 					{
-						completed.timestamp = CalculateRolledTimestamp(completed.stream_id, preceding_completed_header->timestamp, completed.timestamp);
+						return ParseResult::NeedMoreData;
 					}
+
+					// Type 3 inherited from Type 0, so this path still resolves a
+					// wrapped absolute timestamp rather than a delta.
+					completed.timestamp		  = CalculateRolledTimestamp(completed.stream_id, preceding_completed_header->timestamp, parsed_timestamp.value());
+					completed.timestamp_delta = 0U;
 				}
 				else
 				{
-					// The origin message header is T1 or T2
-					result = ParseExtendedTimestampDelta(
+					// The origin message header is T1 or T2.
+					const auto parsed_timestamp_delta = ParseTimestampField(
 						completed.stream_id,
 						stream, chunk_header,
-						completed.timestamp, chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : completed.timestamp_delta, &completed);
-				}
+						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : completed.timestamp_delta);
 
-				if (result == ParseResultForExtendedTimestamp::NeedMoreData)
-				{
-					return ParseResult::NeedMoreData;
-				}
+					if (parsed_timestamp_delta.has_value() == false)
+					{
+						return ParseResult::NeedMoreData;
+					}
 
+					const auto resolved_timestamp = ResolveTimestampDelta(
+						completed.stream_id,
+						completed.timestamp,
+						parsed_timestamp_delta.value(),
+						chunk_header->is_extended_timestamp);
+
+					if (resolved_timestamp.has_value() == false)
+					{
+						return ParseResult::Error;
+					}
+
+					completed.timestamp		  = resolved_timestamp.value();
+					completed.timestamp_delta = parsed_timestamp_delta.value();
+				}
 				break;
 			}
 
 			default:
 				break;
+		}
+
+		if (completed.timestamp < 0)
+		{
+			// Keep the parser invariant explicit: downstream code assumes RTMP
+			// timestamps are non-negative once a chunk header has been accepted.
+			logte("Rejecting RTMP chunk because it produces a negative absolute timestamp: stream_id: %u, chunk_stream_id: %u, type: %d, timestamp: %" PRId64,
+				  completed.stream_id,
+				  basic_header.chunk_stream_id,
+				  ov::ToUnderlyingType(basic_header.format_type),
+				  completed.timestamp);
+			return ParseResult::Error;
 		}
 
 		return ParseResult::Parsed;
@@ -492,9 +629,21 @@ namespace modules::rtmp
 
 	int64_t ChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
 	{
-		const static int64_t SERIAL_BITS = 31;
-		int64_t new_timestamp = parsed_timestamp;
-		int64_t delta = ::llabs(last_timestamp - parsed_timestamp);
+		constexpr int64_t SERIAL_BITS		 = 32;
+		constexpr int64_t SERIAL_MODULO		 = (1LL << SERIAL_BITS);
+		constexpr int64_t SERIAL_HALF_RANGE	 = (1LL << (SERIAL_BITS - 1));
+		constexpr uint64_t SERIAL_VALUE_MASK = 0xFFFFFFFFULL;
+
+		// RFC1982 comparison works on the 32-bit serial value only, not on the full
+		// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
+		// intentionally strips any older epoch bits before converting to uint32_t.
+		const auto last_serial				 = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
+		const auto parsed_serial			 = static_cast<uint32_t>(parsed_timestamp);
+
+		if (last_serial == parsed_serial)
+		{
+			return last_timestamp;
+		}
 
 		// RTMP specification
 		//
@@ -520,24 +669,44 @@ namespace modules::rtmp
 		// are non-negative values of unbounded size in the usual ways of
 		// integer arithmetic.
 
-		// Check if the timestamp is an adjacent timestamp
-		if (delta <= ((1LL << (SERIAL_BITS - 1)) - 1))
-		{
-			// Adjacent timestamp - No need to roll timestamp
-		}
-		else
-		{
-			// Non-adjacent timestamp - Need to roll timestamp
-			new_timestamp = last_timestamp + (1LL << SERIAL_BITS) - (last_timestamp % (1LL << SERIAL_BITS)) + parsed_timestamp;
+		// This helper is only for absolute timestamp paths (Type 0, or Type 3 that
+		// inherits Type 0 semantics). Type 1/2/3 delta paths already operate on an
+		// unfolded absolute timestamp plus a delta, so applying RFC1982 again there
+		// would be incorrect.
+		//
+		// Behavior:
+		// - if the parsed serial is after the previous serial and wrapped below it,
+		//   advance to the next 32-bit epoch
+		// - if the parsed serial is not after the previous serial, keep it in the
+		//   current/prior epoch so backward Type 0 timestamps remain backward
+		const int64_t serial_epoch_base = last_timestamp - static_cast<int64_t>(last_serial);
+		int64_t resolved_timestamp		= serial_epoch_base + parsed_serial;
+		const int64_t serial_diff		= static_cast<int64_t>(parsed_serial) - last_serial;
+		const bool parsed_serial_is_after_previous =
+			((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
+			((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
 
-			logti("Timestamp is rolled for stream id: %u: last TS: %" PRId64 ", parsed: %" PRId64 ", new: %" PRId64,
-				  stream_id,
+		if (parsed_serial_is_after_previous)
+		{
+			if (resolved_timestamp <= last_timestamp)
+			{
+				resolved_timestamp += SERIAL_MODULO;
+				logti("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
+					  last_timestamp,
+					  parsed_serial,
+					  resolved_timestamp);
+			}
+		}
+		else if (resolved_timestamp > last_timestamp)
+		{
+			resolved_timestamp -= SERIAL_MODULO;
+			logti("Timestamp is resolved as backward T0: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
 				  last_timestamp,
-				  parsed_timestamp,
-				  new_timestamp);
+				  parsed_serial,
+				  resolved_timestamp);
 		}
 
-		return new_timestamp;
+		return resolved_timestamp;
 	}
 
 	std::shared_ptr<const Message> ChunkParser::GetMessage()

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
@@ -8,7 +8,10 @@
 //==============================================================================
 #include "rtmp_chunk_parser.h"
 
+// `rtmp_private.h` should be included before `rtmp_chunk_parser_helper.h` because it contains `OV_LOG_TAG`.
 #include "../rtmp_private.h"
+// ====
+#include "../../rtmp/rtmp_chunk_parser_helper.h"
 #include "./rtmp_utilities.h"
 
 namespace modules::rtmp
@@ -254,86 +257,6 @@ namespace modules::rtmp
 		return (pending_message->second != nullptr) && (pending_message->second->GetRemainedPayloadSize() > 0);
 	}
 
-	std::optional<uint32_t> ChunkParser::ParseTimestampField(
-		const uint32_t stream_id,
-		ov::ByteStream &stream,
-		ChunkHeader *chunk_header,
-		const uint32_t encoded_value)
-	{
-		if (encoded_value != EXTENDED_TIMESTAMP_VALUE)
-		{
-			// The 24-bit field already contains the semantic timestamp value, so
-			// there is no 32-bit extended field to consume on the wire.
-			chunk_header->is_extended_timestamp = false;
-			chunk_header->extended_timestamp	= 0U;
-			return encoded_value;
-		}
-
-		if (stream.IsRemained(EXTENDED_TIMESTAMP_SIZE) == false)
-		{
-			logtp("Need more data to parse extended timestamp: %d bytes (current: %zu)", EXTENDED_TIMESTAMP_SIZE, stream.Remained());
-			return std::nullopt;
-		}
-
-		logtt("Extended timestamp is present for stream id: %u", stream_id);
-
-		const uint32_t extended_timestamp	= stream.ReadBE32();
-
-		// The 24-bit field carried the sentinel value, so the real 32-bit value
-		// follows immediately and becomes the semantic timestamp field value.
-		chunk_header->is_extended_timestamp = true;
-		chunk_header->message_header_length += EXTENDED_TIMESTAMP_SIZE;
-		chunk_header->extended_timestamp = extended_timestamp;
-
-		return extended_timestamp;
-	}
-
-	std::optional<int64_t> ChunkParser::ResolveTimestampDelta(
-		const uint32_t stream_id,
-		const int64_t preceding_timestamp,
-		const uint32_t timestamp_delta,
-		const bool is_extended_timestamp) const
-	{
-		if (is_extended_timestamp && (timestamp_delta >= SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT))
-		{
-			// The sign bit is set in a 32-bit extended delta, so this could be a
-			// broken sender that wrote a signed int32_t onto the wire.
-			const int64_t signed_timestamp_delta = static_cast<int32_t>(timestamp_delta);
-
-			if ((signed_timestamp_delta < 0) && ((-signed_timestamp_delta) <= MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS))
-			{
-				// Accept only small backward jumps on the compatibility path. Large
-				// values are more likely to be legitimate unsigned deltas.
-				const int64_t resolved_timestamp = preceding_timestamp + signed_timestamp_delta;
-
-				if (resolved_timestamp < 0)
-				{
-					// Even on the compatibility path, never allow the absolute
-					// timestamp to move below zero.
-					logte("Reject signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId64,
-						  stream_id,
-						  preceding_timestamp,
-						  timestamp_delta,
-						  signed_timestamp_delta);
-					return std::nullopt;
-				}
-
-				// This is the non-standard but tolerated case: a small negative
-				// extended delta that still resolves to a valid absolute timestamp.
-				logtw("Accept signed ext delta: sid=%u prev=%" PRId64 " raw=0x%08x signed=%" PRId64,
-					  stream_id,
-					  preceding_timestamp,
-					  timestamp_delta,
-					  signed_timestamp_delta);
-
-				return resolved_timestamp;
-			}
-		}
-
-		// Standard RTMP behavior: interpret the delta as an unsigned increment.
-		return preceding_timestamp + timestamp_delta;
-	}
-
 	ChunkParser::ParseResult ChunkParser::ParseMessageHeader(ov::ByteStream &stream, ChunkHeader *chunk_header)
 	{
 		auto &basic_header					= chunk_header->basic_header;
@@ -385,8 +308,13 @@ namespace modules::rtmp
 
 				const auto parsed_timestamp		 = ParseTimestampField(
 					header.stream_id,
-					stream, chunk_header,
-					header.timestamp);
+					stream,
+					chunk_header->is_extended_timestamp,
+					chunk_header->extended_timestamp,
+					chunk_header->message_header_length,
+					header.timestamp,
+					EXTENDED_TIMESTAMP_VALUE,
+					EXTENDED_TIMESTAMP_SIZE);
 
 				if (parsed_timestamp.has_value() == false)
 				{
@@ -420,8 +348,13 @@ namespace modules::rtmp
 
 				const auto parsed_timestamp_delta = ParseTimestampField(
 					preceding_completed_header->stream_id,
-					stream, chunk_header,
-					header.timestamp_delta);
+					stream,
+					chunk_header->is_extended_timestamp,
+					chunk_header->extended_timestamp,
+					chunk_header->message_header_length,
+					header.timestamp_delta,
+					EXTENDED_TIMESTAMP_VALUE,
+					EXTENDED_TIMESTAMP_SIZE);
 
 				if (parsed_timestamp_delta.has_value() == false)
 				{
@@ -432,7 +365,9 @@ namespace modules::rtmp
 					preceding_completed_header->stream_id,
 					preceding_completed_header->timestamp,
 					parsed_timestamp_delta.value(),
-					chunk_header->is_extended_timestamp);
+					chunk_header->is_extended_timestamp,
+					SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+					MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 				if (resolved_timestamp.has_value() == false)
 				{
@@ -459,8 +394,13 @@ namespace modules::rtmp
 
 				const auto parsed_timestamp_delta = ParseTimestampField(
 					preceding_completed_header->stream_id,
-					stream, chunk_header,
-					header.timestamp_delta);
+					stream,
+					chunk_header->is_extended_timestamp,
+					chunk_header->extended_timestamp,
+					chunk_header->message_header_length,
+					header.timestamp_delta,
+					EXTENDED_TIMESTAMP_VALUE,
+					EXTENDED_TIMESTAMP_SIZE);
 
 				if (parsed_timestamp_delta.has_value() == false)
 				{
@@ -471,7 +411,9 @@ namespace modules::rtmp
 					preceding_completed_header->stream_id,
 					preceding_completed_header->timestamp,
 					parsed_timestamp_delta.value(),
-					chunk_header->is_extended_timestamp);
+					chunk_header->is_extended_timestamp,
+					SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+					MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 				if (resolved_timestamp.has_value() == false)
 				{
@@ -517,8 +459,13 @@ namespace modules::rtmp
 					{
 						const auto parsed_timestamp_field = ParseTimestampField(
 							completed.stream_id,
-							stream, chunk_header,
-							EXTENDED_TIMESTAMP_VALUE);
+							stream,
+							chunk_header->is_extended_timestamp,
+							chunk_header->extended_timestamp,
+							chunk_header->message_header_length,
+							EXTENDED_TIMESTAMP_VALUE,
+							EXTENDED_TIMESTAMP_VALUE,
+							EXTENDED_TIMESTAMP_SIZE);
 
 						if (parsed_timestamp_field.has_value() == false)
 						{
@@ -551,8 +498,13 @@ namespace modules::rtmp
 					// The origin message header is T0.
 					const auto parsed_timestamp = ParseTimestampField(
 						completed.stream_id,
-						stream, chunk_header,
-						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : static_cast<uint32_t>(completed.timestamp));
+						stream,
+						chunk_header->is_extended_timestamp,
+						chunk_header->extended_timestamp,
+						chunk_header->message_header_length,
+						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : static_cast<uint32_t>(completed.timestamp),
+						EXTENDED_TIMESTAMP_VALUE,
+						EXTENDED_TIMESTAMP_SIZE);
 
 					if (parsed_timestamp.has_value() == false)
 					{
@@ -569,8 +521,13 @@ namespace modules::rtmp
 					// The origin message header is T1 or T2.
 					const auto parsed_timestamp_delta = ParseTimestampField(
 						completed.stream_id,
-						stream, chunk_header,
-						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : completed.timestamp_delta);
+						stream,
+						chunk_header->is_extended_timestamp,
+						chunk_header->extended_timestamp,
+						chunk_header->message_header_length,
+						chunk_header->is_extended_timestamp ? EXTENDED_TIMESTAMP_VALUE : completed.timestamp_delta,
+						EXTENDED_TIMESTAMP_VALUE,
+						EXTENDED_TIMESTAMP_SIZE);
 
 					if (parsed_timestamp_delta.has_value() == false)
 					{
@@ -581,7 +538,9 @@ namespace modules::rtmp
 						completed.stream_id,
 						completed.timestamp,
 						parsed_timestamp_delta.value(),
-						chunk_header->is_extended_timestamp);
+						chunk_header->is_extended_timestamp,
+						SIGNED_EXTENDED_TIMESTAMP_DELTA_SIGN_BIT,
+						MAX_NEGATIVE_EXTENDED_TIMESTAMP_DELTA_MS);
 
 					if (resolved_timestamp.has_value() == false)
 					{
@@ -627,124 +586,6 @@ namespace modules::rtmp
 		return ParseMessageHeader(stream, chunk_header);
 	}
 
-	int64_t ChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
-	{
-		// RTMP timestamps are carried as 32-bit serial numbers on the wire.
-		// Keep the serial width, its modulo, and the RFC1982 half-range explicit so
-		// the rollover math below reads directly in terms of the specification.
-		constexpr int64_t SERIAL_BITS		 = 32;
-		constexpr int64_t SERIAL_MODULO		 = (1LL << SERIAL_BITS);
-		constexpr int64_t SERIAL_HALF_RANGE	 = (1LL << (SERIAL_BITS - 1));
-		// Some senders behave as if the timestamp space were signed int32_t and
-		// restart near INT32_MAX -> 0. Keep that compatibility boundary separate
-		// from the real RTMP modulo so the fallback path stays clearly scoped.
-		constexpr int64_t SIGNED_SERIAL_MODULO = (1LL << (SERIAL_BITS - 1));
-		// Only the low 32 bits participate in RFC1982 ordering; higher bits belong
-		// to older unfolded epochs reconstructed locally by the receiver.
-		constexpr uint64_t SERIAL_VALUE_MASK = 0xFFFFFFFFULL;
-		// Some senders appear to reset absolute timestamps at the signed 31-bit
-		// boundary instead of RTMP's unsigned 32-bit boundary. Treat that as a
-		// compatibility path only when the implied forward delta is very small.
-		constexpr int64_t MAX_SIGNED_WRAP_COMPAT_DELTA_MS = 10 * 1000;
-
-		// RFC1982 comparison works on the 32-bit serial value only, not on the full
-		// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
-		// intentionally strips any older epoch bits before converting to uint32_t.
-		const auto last_serial				 = static_cast<uint32_t>(last_timestamp & SERIAL_VALUE_MASK);
-		const auto parsed_serial			 = static_cast<uint32_t>(parsed_timestamp);
-
-		if (last_serial == parsed_serial)
-		{
-			return last_timestamp;
-		}
-
-		// RTMP specification
-		//
-		// Because timestamps are 32 bits long, they roll over every 49 days, 17
-		// hours, 2 minutes and 47.296 seconds. Because streams are allowed to
-		// run continuously, potentially for years on end, an RTMP application
-		// SHOULD use serial number arithmetic [RFC1982] when processing
-		// timestamps, and SHOULD be capable of handling wraparound. For
-		// example, an application assumes that all adjacent timestamps are
-		// within 2^31 - 1 milliseconds of each other, so 10000 comes after
-		// 4000000000, and 3000000000 comes before 4000000000.
-
-		// completed.timestamp calculated from this formula (https://tools.ietf.org/html/rfc1982#section-3.1):
-		//
-		// Serial numbers may be incremented by the addition of a positive
-		// integer n, where n is taken from the range of integers
-		// [0 .. (2^(SERIAL_BITS - 1) - 1)].  For a sequence number s, the
-		// result of such an addition, s', is defined as
-		//
-		//                 s' = (s + n) modulo (2 ^ SERIAL_BITS)
-		//
-		// where the addition and modulus operations here act upon values that
-		// are non-negative values of unbounded size in the usual ways of
-		// integer arithmetic.
-
-		// This helper is only for absolute timestamp paths (Type 0, or Type 3 that
-		// inherits Type 0 semantics). Type 1/2/3 delta paths already operate on an
-		// unfolded absolute timestamp plus a delta, so applying RFC1982 again there
-		// would be incorrect.
-		//
-		// Behavior:
-		// - if the parsed serial is after the previous serial and wrapped below it,
-		//   advance to the next 32-bit epoch
-		// - if the parsed serial is not after the previous serial, keep it in the
-		//   current/prior epoch so backward Type 0 timestamps remain backward
-		const int64_t serial_epoch_base = last_timestamp - static_cast<int64_t>(last_serial);
-		int64_t resolved_timestamp		= serial_epoch_base + parsed_serial;
-		const int64_t serial_diff		= static_cast<int64_t>(parsed_serial) - last_serial;
-		const bool parsed_serial_is_after_previous =
-			((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
-			((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
-		// Compatibility path for senders that appear to restart absolute
-		// timestamps at INT32_MAX -> 0 instead of UINT32_MAX -> 0. This is not
-		// standard RTMP rollover, so only accept it when the implied forward delta
-		// is very small.
-		const int64_t signed_wrap_forward_delta = SIGNED_SERIAL_MODULO - static_cast<int64_t>(last_serial) + parsed_serial;
-		const bool signed_wrap_compat_candidate =
-			(parsed_serial_is_after_previous == false) &&
-			(last_serial < SIGNED_SERIAL_MODULO) &&
-			(parsed_serial < SIGNED_SERIAL_MODULO) &&
-			(parsed_serial < last_serial) &&
-			(signed_wrap_forward_delta > 0) &&
-			(signed_wrap_forward_delta <= MAX_SIGNED_WRAP_COMPAT_DELTA_MS);
-
-		if (parsed_serial_is_after_previous)
-		{
-			if (resolved_timestamp <= last_timestamp)
-			{
-				resolved_timestamp += SERIAL_MODULO;
-				logtd("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
-					  last_timestamp,
-					  parsed_serial,
-					  resolved_timestamp);
-			}
-		}
-		// Only reach this branch when the normal RFC1982 32-bit comparison says
-		// the parsed serial is not after the previous one.
-		else if (signed_wrap_compat_candidate)
-		{
-			resolved_timestamp = last_timestamp + signed_wrap_forward_delta;
-			logtd("Timestamp is rolled forward with signed-31bit compatibility: last TS: %" PRId64 ", parsed: %" PRIu32 ", delta: %" PRId64 ", resolved: %" PRId64,
-				  last_timestamp,
-				  parsed_serial,
-				  signed_wrap_forward_delta,
-				  resolved_timestamp);
-		}
-		else if (resolved_timestamp > last_timestamp)
-		{
-			resolved_timestamp -= SERIAL_MODULO;
-			logti("Timestamp is resolved as backward T0: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
-				  last_timestamp,
-				  parsed_serial,
-				  resolved_timestamp);
-		}
-
-		return resolved_timestamp;
-	}
-
 	std::shared_ptr<const Message> ChunkParser::GetMessage()
 	{
 		return _message_queue.Dequeue(0).value_or(nullptr);
@@ -753,20 +594,6 @@ namespace modules::rtmp
 	size_t ChunkParser::GetMessageCount() const
 	{
 		return _message_queue.Size();
-	}
-
-	info::NamePath ChunkParser::GetNamePath() const
-	{
-		std::lock_guard lock_guard(_name_path_mutex);
-		return _name_path;
-	}
-
-	void ChunkParser::UpdateNamePath(const info::NamePath &stream_name_path)
-	{
-		std::lock_guard lock_guard(_name_path_mutex);
-
-		_name_path = stream_name_path;
-		_message_queue.SetAlias(ov::String::FormatString("RTMP queue for %s", _name_path.CStr()));
 	}
 
 	void ChunkParser::Destroy()

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.cpp
@@ -629,10 +629,23 @@ namespace modules::rtmp
 
 	int64_t ChunkParser::CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp)
 	{
+		// RTMP timestamps are carried as 32-bit serial numbers on the wire.
+		// Keep the serial width, its modulo, and the RFC1982 half-range explicit so
+		// the rollover math below reads directly in terms of the specification.
 		constexpr int64_t SERIAL_BITS		 = 32;
 		constexpr int64_t SERIAL_MODULO		 = (1LL << SERIAL_BITS);
 		constexpr int64_t SERIAL_HALF_RANGE	 = (1LL << (SERIAL_BITS - 1));
+		// Some senders behave as if the timestamp space were signed int32_t and
+		// restart near INT32_MAX -> 0. Keep that compatibility boundary separate
+		// from the real RTMP modulo so the fallback path stays clearly scoped.
+		constexpr int64_t SIGNED_SERIAL_MODULO = (1LL << (SERIAL_BITS - 1));
+		// Only the low 32 bits participate in RFC1982 ordering; higher bits belong
+		// to older unfolded epochs reconstructed locally by the receiver.
 		constexpr uint64_t SERIAL_VALUE_MASK = 0xFFFFFFFFULL;
+		// Some senders appear to reset absolute timestamps at the signed 31-bit
+		// boundary instead of RTMP's unsigned 32-bit boundary. Treat that as a
+		// compatibility path only when the implied forward delta is very small.
+		constexpr int64_t MAX_SIGNED_WRAP_COMPAT_DELTA_MS = 10 * 1000;
 
 		// RFC1982 comparison works on the 32-bit serial value only, not on the full
 		// accumulated absolute timestamp. Masking with an unsigned 32-bit pattern
@@ -685,17 +698,40 @@ namespace modules::rtmp
 		const bool parsed_serial_is_after_previous =
 			((serial_diff > 0) && (serial_diff < SERIAL_HALF_RANGE)) ||
 			((serial_diff < 0) && ((-serial_diff) > SERIAL_HALF_RANGE));
+		// Compatibility path for senders that appear to restart absolute
+		// timestamps at INT32_MAX -> 0 instead of UINT32_MAX -> 0. This is not
+		// standard RTMP rollover, so only accept it when the implied forward delta
+		// is very small.
+		const int64_t signed_wrap_forward_delta = SIGNED_SERIAL_MODULO - static_cast<int64_t>(last_serial) + parsed_serial;
+		const bool signed_wrap_compat_candidate =
+			(parsed_serial_is_after_previous == false) &&
+			(last_serial < SIGNED_SERIAL_MODULO) &&
+			(parsed_serial < SIGNED_SERIAL_MODULO) &&
+			(parsed_serial < last_serial) &&
+			(signed_wrap_forward_delta > 0) &&
+			(signed_wrap_forward_delta <= MAX_SIGNED_WRAP_COMPAT_DELTA_MS);
 
 		if (parsed_serial_is_after_previous)
 		{
 			if (resolved_timestamp <= last_timestamp)
 			{
 				resolved_timestamp += SERIAL_MODULO;
-				logti("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
+				logtd("Timestamp is rolled forward: last TS: %" PRId64 ", parsed: %" PRIu32 ", resolved: %" PRId64,
 					  last_timestamp,
 					  parsed_serial,
 					  resolved_timestamp);
 			}
+		}
+		// Only reach this branch when the normal RFC1982 32-bit comparison says
+		// the parsed serial is not after the previous one.
+		else if (signed_wrap_compat_candidate)
+		{
+			resolved_timestamp = last_timestamp + signed_wrap_forward_delta;
+			logtd("Timestamp is rolled forward with signed-31bit compatibility: last TS: %" PRId64 ", parsed: %" PRIu32 ", delta: %" PRId64 ", resolved: %" PRId64,
+				  last_timestamp,
+				  parsed_serial,
+				  signed_wrap_forward_delta,
+				  resolved_timestamp);
 		}
 		else if (resolved_timestamp > last_timestamp)
 		{
@@ -717,6 +753,20 @@ namespace modules::rtmp
 	size_t ChunkParser::GetMessageCount() const
 	{
 		return _message_queue.Size();
+	}
+
+	info::NamePath ChunkParser::GetNamePath() const
+	{
+		std::lock_guard lock_guard(_name_path_mutex);
+		return _name_path;
+	}
+
+	void ChunkParser::UpdateNamePath(const info::NamePath &stream_name_path)
+	{
+		std::lock_guard lock_guard(_name_path_mutex);
+
+		_name_path = stream_name_path;
+		_message_queue.SetAlias(ov::String::FormatString("RTMP queue for %s", _name_path.CStr()));
 	}
 
 	void ChunkParser::Destroy()

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
@@ -51,6 +51,8 @@ namespace modules::rtmp
 
 		std::shared_ptr<const Message> GetMessage();
 		size_t GetMessageCount() const;
+		info::NamePath GetNamePath() const;
+		void UpdateNamePath(const info::NamePath &stream_name_path);
 
 		void SetChunkSize(size_t chunk_size)
 		{
@@ -162,6 +164,8 @@ namespace modules::rtmp
 		std::map<uint32_t, std::shared_ptr<const ChunkHeader>> _preceding_chunk_header_map;
 
 		ov::Queue<std::shared_ptr<const Message>> _message_queue{nullptr, 500};
+		mutable std::mutex _name_path_mutex;
+		info::NamePath _name_path;
 		size_t _chunk_size;
 	};
 }  // namespace modules::rtmp

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
@@ -13,6 +13,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <optional>
 
 #include "rtmp_datastructure.h"
 #include "rtmp_define.h"
@@ -29,17 +30,23 @@ namespace modules::rtmp
 			Parsed,
 		};
 
-		enum class ParseResultForExtendedTimestamp
-		{
-			NeedMoreData,
-			Extended,
-			NotExtended,
-		};
-
 	public:
 		ChunkParser(int chunk_size);
 		virtual ~ChunkParser();
 
+		/// Parses as much of a single RTMP chunk as possible from the supplied data.
+		///
+		/// @param data Input bytes beginning at the next unread RTMP chunk boundary.
+		/// @param bytes_used Receives the number of bytes consumed from @p data.
+		///
+		/// @return `Parsed` when a chunk payload step completed, `NeedMoreData` when
+		///         more bytes are required, or `Error` when the chunk stream is
+		///         malformed.
+		///
+		/// @note When this returns `NeedMoreData`, @p bytes_used is set to `0` and
+		///       the caller must replay the same unconsumed prefix again with more
+		///       bytes appended. Header parsing is not resumable from the middle of
+		///       a partially received header.
 		ParseResult Parse(const std::shared_ptr<const ov::Data> &data, size_t *bytes_used);
 
 		std::shared_ptr<const Message> GetMessage();
@@ -59,32 +66,93 @@ namespace modules::rtmp
 		void Destroy();
 
 	private:
+		/// Returns the most recent completed header for a chunk stream.
+		///
+		/// @param chunk_stream_id RTMP chunk stream identifier.
+		///
+		/// @return The preceding parsed header for @p chunk_stream_id, or `nullptr`
+		///         if no header has been completed on that chunk stream yet.
 		std::shared_ptr<const ChunkHeader> GetPrecedingChunkHeader(const uint32_t chunk_stream_id);
 
+		/// Checks whether the next header belongs to an unfinished message.
+		///
+		/// @param chunk_stream_id RTMP chunk stream identifier for the incoming chunk.
+		///
+		/// @return `true` when the parser is expecting a continuation chunk for the
+		///         same chunk stream, including interleaved pending-message cases.
+		bool IsContinuationChunk(const uint32_t chunk_stream_id) const;
+
+		/// Parses the RTMP basic header.
+		///
+		/// @param stream Input byte stream positioned at the RTMP basic header.
+		/// @param chunk_header Destination header object to populate.
+		///
+		/// @return `Parsed`, `NeedMoreData`, or `Error`.
 		ParseResult ParseBasicHeader(ov::ByteStream &stream, ChunkHeader *chunk_header);
-		ParseResultForExtendedTimestamp ParseExtendedTimestamp(
+
+		/// Parses a 24-bit timestamp field and its optional extended timestamp.
+		///
+		/// @param stream_id RTMP message stream identifier used for logging/context.
+		/// @param stream Input byte stream positioned at the timestamp field.
+		/// @param chunk_header Destination header object whose extended-timestamp
+		///        metadata is updated on success.
+		/// @param encoded_value The already-read 24-bit timestamp or timestamp-delta
+		///        field value.
+		///
+		/// @return The semantic timestamp value on success, or `std::nullopt` when
+		///         more bytes are required to finish parsing the field.
+		std::optional<uint32_t> ParseTimestampField(
 			const uint32_t stream_id,
 			ov::ByteStream &stream,
 			ChunkHeader *chunk_header,
-			const int64_t timestamp,
-			ChunkHeader::CompletedHeader *completed_header);
-		ParseResultForExtendedTimestamp ParseExtendedTimestampDelta(
+			const uint32_t encoded_value);
+
+		/// Resolves a timestamp delta against the preceding absolute timestamp.
+		///
+		/// @param stream_id RTMP message stream identifier used for logging/context.
+		/// @param preceding_timestamp Previously resolved absolute timestamp.
+		/// @param timestamp_delta Parsed timestamp-delta field value.
+		/// @param is_extended_timestamp True when the delta came from the extended
+		///        timestamp field.
+		///
+		/// @return The resolved absolute timestamp, or `std::nullopt` when the
+		///         non-standard signed-delta compatibility path would produce an
+		///         invalid negative absolute timestamp.
+		std::optional<int64_t> ResolveTimestampDelta(
 			const uint32_t stream_id,
-			ov::ByteStream &stream,
-			ChunkHeader *chunk_header,
 			const int64_t preceding_timestamp,
-			const int64_t timestamp_delta,
-			ChunkHeader::CompletedHeader *completed_header);
+			const uint32_t timestamp_delta,
+			const bool is_extended_timestamp) const;
+
+		/// Parses the RTMP message header for an already-parsed basic header.
+		///
+		/// @param stream Input byte stream positioned at the RTMP message header.
+		/// @param chunk_header Destination header object to populate.
+		///
+		/// @return `Parsed`, `NeedMoreData`, or `Error`.
 		ParseResult ParseMessageHeader(ov::ByteStream &stream, ChunkHeader *chunk_header);
+
+		/// Parses both the RTMP basic header and message header.
+		///
+		/// @param stream Input byte stream positioned at the start of an RTMP header.
+		/// @param chunk_header Destination header object to populate.
+		///
+		/// @return `Parsed`, `NeedMoreData`, or `Error`.
 		ParseResult ParseHeader(ov::ByteStream &stream, ChunkHeader *chunk_header);
 
+		/// Unfolds a 32-bit absolute RTMP timestamp using RFC1982 serial arithmetic.
+		///
+		/// @param stream_id RTMP message stream identifier used for logging/context.
+		/// @param last_timestamp Previously resolved absolute timestamp.
+		/// @param parsed_timestamp Newly parsed 32-bit serial timestamp value.
+		///
+		/// @return The resolved absolute timestamp in the current or next serial
+		///         epoch.
 		int64_t CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp);
-
-		void UpdateAppStreamName();
 
 	private:
 #if DEBUG
-		uint64_t _chunk_index = 0ULL;
+		uint64_t _chunk_index	   = 0ULL;
 		uint64_t _total_read_bytes = 0ULL;
 #endif	// DEBUG
 

--- a/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
+++ b/src/projects/modules/rtmp_v2/chunk/rtmp_chunk_parser.h
@@ -8,29 +8,17 @@
 //==============================================================================
 #pragma once
 
-#include <base/info/info.h>
-
-#include <deque>
-#include <map>
-#include <memory>
-#include <optional>
-
+#include "../../rtmp/rtmp_chunk_parser_common.h"
 #include "rtmp_datastructure.h"
 #include "rtmp_define.h"
 
 namespace modules::rtmp
 {
-	class ChunkParser
+	class ChunkParser : public ::RtmpChunkParserCommon<ChunkHeader, Message>
 	{
 	public:
-		enum class ParseResult
-		{
-			Error,
-			NeedMoreData,
-			Parsed,
-		};
+		using ParseResult = typename ::RtmpChunkParserCommon<ChunkHeader, Message>::ParseResult;
 
-	public:
 		ChunkParser(int chunk_size);
 		virtual ~ChunkParser();
 
@@ -51,8 +39,6 @@ namespace modules::rtmp
 
 		std::shared_ptr<const Message> GetMessage();
 		size_t GetMessageCount() const;
-		info::NamePath GetNamePath() const;
-		void UpdateNamePath(const info::NamePath &stream_name_path);
 
 		void SetChunkSize(size_t chunk_size)
 		{
@@ -92,40 +78,6 @@ namespace modules::rtmp
 		/// @return `Parsed`, `NeedMoreData`, or `Error`.
 		ParseResult ParseBasicHeader(ov::ByteStream &stream, ChunkHeader *chunk_header);
 
-		/// Parses a 24-bit timestamp field and its optional extended timestamp.
-		///
-		/// @param stream_id RTMP message stream identifier used for logging/context.
-		/// @param stream Input byte stream positioned at the timestamp field.
-		/// @param chunk_header Destination header object whose extended-timestamp
-		///        metadata is updated on success.
-		/// @param encoded_value The already-read 24-bit timestamp or timestamp-delta
-		///        field value.
-		///
-		/// @return The semantic timestamp value on success, or `std::nullopt` when
-		///         more bytes are required to finish parsing the field.
-		std::optional<uint32_t> ParseTimestampField(
-			const uint32_t stream_id,
-			ov::ByteStream &stream,
-			ChunkHeader *chunk_header,
-			const uint32_t encoded_value);
-
-		/// Resolves a timestamp delta against the preceding absolute timestamp.
-		///
-		/// @param stream_id RTMP message stream identifier used for logging/context.
-		/// @param preceding_timestamp Previously resolved absolute timestamp.
-		/// @param timestamp_delta Parsed timestamp-delta field value.
-		/// @param is_extended_timestamp True when the delta came from the extended
-		///        timestamp field.
-		///
-		/// @return The resolved absolute timestamp, or `std::nullopt` when the
-		///         non-standard signed-delta compatibility path would produce an
-		///         invalid negative absolute timestamp.
-		std::optional<int64_t> ResolveTimestampDelta(
-			const uint32_t stream_id,
-			const int64_t preceding_timestamp,
-			const uint32_t timestamp_delta,
-			const bool is_extended_timestamp) const;
-
 		/// Parses the RTMP message header for an already-parsed basic header.
 		///
 		/// @param stream Input byte stream positioned at the RTMP message header.
@@ -141,31 +93,5 @@ namespace modules::rtmp
 		///
 		/// @return `Parsed`, `NeedMoreData`, or `Error`.
 		ParseResult ParseHeader(ov::ByteStream &stream, ChunkHeader *chunk_header);
-
-		/// Unfolds a 32-bit absolute RTMP timestamp using RFC1982 serial arithmetic.
-		///
-		/// @param stream_id RTMP message stream identifier used for logging/context.
-		/// @param last_timestamp Previously resolved absolute timestamp.
-		/// @param parsed_timestamp Newly parsed 32-bit serial timestamp value.
-		///
-		/// @return The resolved absolute timestamp in the current or next serial
-		///         epoch.
-		int64_t CalculateRolledTimestamp(const uint32_t stream_id, const int64_t last_timestamp, int64_t parsed_timestamp);
-
-	private:
-#if DEBUG
-		uint64_t _chunk_index	   = 0ULL;
-		uint64_t _total_read_bytes = 0ULL;
-#endif	// DEBUG
-
-		bool _need_to_parse_new_header = true;
-		std::shared_ptr<Message> _current_message;
-		std::map<uint32_t, std::shared_ptr<Message>> _pending_message_map;
-		std::map<uint32_t, std::shared_ptr<const ChunkHeader>> _preceding_chunk_header_map;
-
-		ov::Queue<std::shared_ptr<const Message>> _message_queue{nullptr, 500};
-		mutable std::mutex _name_path_mutex;
-		info::NamePath _name_path;
-		size_t _chunk_size;
 	};
 }  // namespace modules::rtmp

--- a/src/projects/modules/rtmp_v2/rtmp_private.h
+++ b/src/projects/modules/rtmp_v2/rtmp_private.h
@@ -9,3 +9,6 @@
 #pragma once
 
 #define OV_LOG_TAG "Modules.RTMPv2"
+
+#define OV_LOG_PREFIX_FORMAT "[%s] "
+#define OV_LOG_PREFIX_VALUE GetNamePath().CStr()

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -1568,7 +1568,7 @@ namespace pvd::rtmp
 			{
 				if (rtmp_track->GetMediaPacketList().size() > MAX_PACKET_COUNT_BEFORE_SEQ_HEADER)
 				{
-					logaw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
+					logaw("Track %u has too many media packets without sequence header, ignoring the track", track_id);
 
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();
@@ -1720,7 +1720,7 @@ namespace pvd::rtmp
 			{
 				if (rtmp_track->GetMediaPacketList().size() > MAX_PACKET_COUNT_BEFORE_SEQ_HEADER)
 				{
-					logaw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
+					logaw("Track %u has too many media packets without sequence header, ignoring the track", track_id);
 
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -334,7 +334,7 @@ namespace pvd::rtmp
 		previous_last_audio_timestamp = last_audio_timestamp;
 	}
 
-	int32_t RtmpChunkHandler::Stats::GetVADelta() const
+	int64_t RtmpChunkHandler::Stats::GetVADelta() const
 	{
 		return last_video_timestamp - last_audio_timestamp;
 	}
@@ -342,7 +342,7 @@ namespace pvd::rtmp
 	ov::String RtmpChunkHandler::Stats::GetStatsString(int64_t elapsed_ms) const
 	{
 		return ov::String::FormatString(
-			"keyint_ms(%u) ts_ms(v:%u/a:%u/v-a:%d) fps(v:%.2f/a:%.2f) gap_ms(v:%u/a:%u)",
+			"keyint_ms(%u) ts_ms(v:%" PRId64 "/a:%" PRId64 "/v-a:%" PRId64 ") fps(v:%.2f/a:%.2f) gap_ms(v:%" PRId64 "/a:%" PRId64 ")",
 			key_frame_interval,
 			last_video_timestamp, last_audio_timestamp, GetVADelta(),
 			((video_frame_count * 1000) / static_cast<double>(elapsed_ms)),

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -607,7 +607,14 @@ namespace pvd::rtmp
 
 	info::NamePath RtmpChunkHandler::GetNamePath() const
 	{
-		return _stream->GetNamePath();
+		std::lock_guard lock_guard(_name_path_mutex);
+		return _name_path;
+	}
+
+	void RtmpChunkHandler::UpdateNamePath(const info::NamePath &stream_name_path)
+	{
+		std::lock_guard lock_guard(_name_path_mutex);
+		_name_path = stream_name_path;
 	}
 
 	void RtmpChunkHandler::UpdateQueueAlias()
@@ -647,7 +654,7 @@ namespace pvd::rtmp
 	{
 		double object_encoding = 0.0;
 
-		logtt("Received RTMP document\n%s", document.ToString().CStr());
+		logat("Received RTMP document\n%s", document.ToString().CStr());
 
 		auto meta_property = document.GetObject(2);
 		if (meta_property == nullptr)
@@ -689,7 +696,7 @@ namespace pvd::rtmp
 
 		if (SendSetChunkSize(DEFAULT_CHUNK_SIZE) == false)
 		{
-			logte("Failed to send SetChunkSize(%zu)", DEFAULT_CHUNK_SIZE);
+			logae("Failed to send SetChunkSize(%zu)", DEFAULT_CHUNK_SIZE);
 			return false;
 		}
 
@@ -831,7 +838,7 @@ namespace pvd::rtmp
 				return false;
 			}
 		}
-		
+
 		return _stream->PostPublish(document);
 	}
 
@@ -977,7 +984,7 @@ namespace pvd::rtmp
 			_meta_data_context.waiting_video_track_count = 1;
 		}
 
-		logti("RTMP onMetadata:\n%s", _meta_data_context.ToString().CStr());
+		logai("RTMP onMetadata:\n%s", _meta_data_context.ToString().CStr());
 
 		return true;
 	}
@@ -1561,7 +1568,7 @@ namespace pvd::rtmp
 			{
 				if (rtmp_track->GetMediaPacketList().size() > MAX_PACKET_COUNT_BEFORE_SEQ_HEADER)
 				{
-					logtw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
+					logaw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
 
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();
@@ -1634,7 +1641,7 @@ namespace pvd::rtmp
 #if DEBUG
 			if (parsed_data->video_metadata.has_value())
 			{
-				logtt("Metadata: \n%s", parsed_data->video_metadata.value().ToString().CStr());
+				logat("Metadata: \n%s", parsed_data->video_metadata.value().ToString().CStr());
 			}
 #endif	// DEBUG
 
@@ -1646,7 +1653,7 @@ namespace pvd::rtmp
 				{
 					auto name = metadata->GetString(0).value_or("");
 
-					logtw("Video metadata [%s] has been received, but not handled", name.CStr());
+					logaw("Video metadata [%s] has been received, but not handled", name.CStr());
 				}
 				else
 				{
@@ -1713,7 +1720,7 @@ namespace pvd::rtmp
 			{
 				if (rtmp_track->GetMediaPacketList().size() > MAX_PACKET_COUNT_BEFORE_SEQ_HEADER)
 				{
-					logtw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
+					logaw("Track %u has too many media packets without sequence header, ignoreing the track", track_id);
 
 					rtmp_track->SetIgnored(true);
 					rtmp_track->ClearMediaPacketList();

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
@@ -28,18 +28,18 @@ namespace pvd::rtmp
 			int64_t last_stream_check_time		   = 0;
 
 			uint32_t key_frame_interval			   = 0;
-			uint32_t previous_key_frame_timestamp  = 0;
-			uint32_t last_audio_timestamp		   = 0;
-			uint32_t last_video_timestamp		   = 0;
-			uint32_t previous_last_audio_timestamp = 0;
-			uint32_t previous_last_video_timestamp = 0;
+			int64_t previous_key_frame_timestamp  = 0;
+			int64_t last_audio_timestamp		   = 0;
+			int64_t last_video_timestamp		   = 0;
+			int64_t previous_last_audio_timestamp = 0;
+			int64_t previous_last_video_timestamp = 0;
 			uint32_t audio_frame_count			   = 0;
 			uint32_t video_frame_count			   = 0;
 
 			Stats();
 			int64_t GetElapsedInMs() const;
 			void ResetCheckTime();
-			int32_t GetVADelta() const;
+			int64_t GetVADelta() const;
 			ov::String GetStatsString(int64_t elapsed_ms) const;
 		};
 

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.h
@@ -89,8 +89,9 @@ namespace pvd::rtmp
 
 		int32_t HandleData(const std::shared_ptr<const ov::Data> &data);
 
-		void UpdateQueueAlias();
 		info::NamePath GetNamePath() const;
+		void UpdateNamePath(const info::NamePath &stream_name_path);
+		void UpdateQueueAlias();
 
 		int GetWaitingTrackCount() const;
 
@@ -183,5 +184,8 @@ namespace pvd::rtmp
 		std::vector<std::shared_ptr<const modules::rtmp::Message>> _message_buffer;
 
 		cfg::vhost::app::pvd::EventGenerator _event_generator_config;
+
+		mutable std::mutex _name_path_mutex;
+		info::NamePath _name_path;
 	};
 }  // namespace pvd::rtmp

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -1736,9 +1736,8 @@ namespace pvd
 
 			if (check_gap >= 10)
 			{
-				logi("RTMPProvider.Stat", "Rtmp Provider Info - stream(%s/%s) key(%ums) timestamp(v:%ums/a:%ums/g:%dms) fps(v:%u/a:%u) gap(v:%ums/a:%ums)",
-					 _vhost_app_name.CStr(),
-					 GetName().CStr(),
+				logi("RTMPProvider.Stat", "[%s] RTMP info: key(%ums) timestamp(v:%" PRId64 "ms/a:%" PRId64 "ms/g:%" PRId64 "ms) fps(v:%u/a:%u) gap(v:%" PRId64 "ms/a:%" PRId64 "ms)",
+					 GetNamePath().CStr(),
 					 _key_frame_interval,
 					 _last_video_timestamp,
 					 _last_audio_timestamp,

--- a/src/projects/providers/rtmp/rtmp_stream.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream.cpp
@@ -11,10 +11,10 @@
 
 #include <base/info/media_extradata.h>
 #include <base/mediarouter/media_type.h>
-#include <modules/bitstream/h264/h264_decoder_configuration_record.h>
-#include <modules/containers/flv/flv_parser.h>
 #include <base/modules/data_format/id3v2/frames/id3v2_frames.h>
 #include <base/modules/data_format/id3v2/id3v2.h>
+#include <modules/bitstream/h264/h264_decoder_configuration_record.h>
+#include <modules/containers/flv/flv_parser.h>
 #include <orchestrator/orchestrator.h>
 
 #include "base/info/application.h"
@@ -98,9 +98,9 @@ namespace pvd
 		_remote = client_socket;
 		SetMediaSource(_remote->GetRemoteAddressAsUrl());
 
-		_import_chunk = std::make_shared<RtmpChunkParser>(RTMP_DEFAULT_CHUNK_SIZE);
-		_export_chunk = std::make_shared<RtmpExportChunk>(false, RTMP_DEFAULT_CHUNK_SIZE);
-		_media_info = std::make_shared<RtmpMediaInfo>();
+		_import_chunk	   = std::make_shared<RtmpChunkParser>(RTMP_DEFAULT_CHUNK_SIZE);
+		_export_chunk	   = std::make_shared<RtmpExportChunk>(false, RTMP_DEFAULT_CHUNK_SIZE);
+		_media_info		   = std::make_shared<RtmpMediaInfo>();
 
 		// For debug statistics
 		_stream_check_time = time(nullptr);
@@ -128,7 +128,7 @@ namespace pvd
 
 		// Send Close to Admission Webhooks
 		auto requested_url = GetRequestedUrl();
-		auto final_url = GetFinalUrl();
+		auto final_url	   = GetFinalUrl();
 		if (_remote && requested_url && final_url)
 		{
 			auto request_info = std::make_shared<ac::RequestInfo>(requested_url, final_url, _remote, nullptr);
@@ -254,7 +254,7 @@ namespace pvd
 			return false;
 		}
 
-		auto stream_name = document.GetProperty(3)->GetString();
+		auto stream_name	= document.GetProperty(3)->GetString();
 		auto query_position = stream_name.IndexOf('?');
 		if (query_position >= 0)
 		{
@@ -273,9 +273,9 @@ namespace pvd
 			url->SetPort(_remote->GetLocalAddress()->Port());
 		}
 
-		_url = url;
+		_url		 = url;
 		_publish_url = _url;
-		_stream_name = _url->Stream();
+		SetName(_url->Stream());
 		_import_chunk->UpdateNamePath(GetNamePath());
 
 		SetRequestedUrl(_url);
@@ -288,13 +288,13 @@ namespace pvd
 	{
 		double object_encoding = 0.0;
 
-		auto meta_property = document.GetProperty(2, AmfTypeMarker::Object);
+		auto meta_property	   = document.GetProperty(2, AmfTypeMarker::Object);
 		if (meta_property != nullptr)
 		{
 			auto object = meta_property->GetObject();
 
 			// object encoding
-			auto pair = object->GetPair("objectEncoding", AmfTypeMarker::Number);
+			auto pair	= object->GetPair("objectEncoding", AmfTypeMarker::Number);
 			if (pair != nullptr)
 			{
 				object_encoding = pair->property.GetNumber();
@@ -401,9 +401,9 @@ namespace pvd
 	bool RtmpStream::CheckAccessControl()
 	{
 		// Check SignedPolicy
-		auto provider = GetProvider();
+		auto provider								= GetProvider();
 
-		auto request_info = std::make_shared<ac::RequestInfo>(_url, nullptr, _remote, nullptr);
+		auto request_info							= std::make_shared<ac::RequestInfo>(_url, nullptr, _remote, nullptr);
 
 		auto [signed_policy_result, _signed_policy] = provider->VerifyBySignedPolicy(request_info);
 		switch (signed_policy_result)
@@ -485,10 +485,10 @@ namespace pvd
 			return false;
 		}
 
-		auto orchestrator = ocst::Orchestrator::GetInstance();
+		auto orchestrator	= ocst::Orchestrator::GetInstance();
 		auto vhost_app_name = orchestrator->ResolveApplicationNameFromDomain(_publish_url->Host(), _publish_url->App());
 
-		auto app_info = orchestrator->GetApplicationInfo(vhost_app_name);
+		auto app_info		= orchestrator->GetApplicationInfo(vhost_app_name);
 
 		if (app_info.IsValid())
 		{
@@ -502,7 +502,7 @@ namespace pvd
 
 	bool RtmpStream::OnAmfFCPublish(const std::shared_ptr<const RtmpChunkHeader> &header, AmfDocument &document, double transaction_id)
 	{
-		if (_stream_name.IsEmpty())
+		if (GetName().IsEmpty())
 		{
 			auto property = document.GetProperty(3, AmfTypeMarker::String);
 
@@ -527,7 +527,7 @@ namespace pvd
 
 	bool RtmpStream::OnAmfPublish(const std::shared_ptr<const RtmpChunkHeader> &header, AmfDocument &document, double transaction_id)
 	{
-		if (_stream_name.IsEmpty())
+		if (GetName().IsEmpty())
 		{
 			auto property = document.GetProperty(3, AmfTypeMarker::String);
 			if (property != nullptr)
@@ -626,14 +626,14 @@ namespace pvd
 		}
 
 		// Video Codec
-		bool video_available = false;
+		bool video_available		   = false;
 		RtmpCodecType video_codec_type = RtmpCodecType::Unknown;
 		{
 			auto property_pair = object->GetPair("videocodecid");
 
 			if (property_pair != nullptr)
 			{
-				auto &property = property_pair->property;
+				auto &property	= property_pair->property;
 				video_available = true;
 
 				switch (property.GetType())
@@ -666,17 +666,17 @@ namespace pvd
 		double frame_rate;
 		{
 			auto value = object->GetDoubleValue("framerate");
-			value = value.has_value() ? value : object->GetDoubleValue("videoframerate");
+			value	   = value.has_value() ? value : object->GetDoubleValue("videoframerate");
 			frame_rate = value.value_or(30.0);
 		}
 
-		double video_width = object->GetDoubleValue("width").value_or(0.0);
+		double video_width	= object->GetDoubleValue("width").value_or(0.0);
 		double video_height = object->GetDoubleValue("height").value_or(0.0);
 
 		double video_bitrate;
 		{
 			auto value = object->GetDoubleValue("videodatarate");
-			value = value.has_value() ? value : object->GetDoubleValue("bitrate");
+			value	   = value.has_value() ? value : object->GetDoubleValue("bitrate");
 		}
 
 		{
@@ -704,15 +704,15 @@ namespace pvd
 			}
 		}
 
-		_media_info->video_codec_type = video_codec_type;
-		_media_info->video_width = static_cast<int32_t>(video_width);
-		_media_info->video_height = static_cast<int32_t>(video_height);
-		_media_info->video_framerate = static_cast<float>(frame_rate);
-		_media_info->video_bitrate = static_cast<int32_t>(video_bitrate);
+		_media_info->video_codec_type  = video_codec_type;
+		_media_info->video_width	   = static_cast<int32_t>(video_width);
+		_media_info->video_height	   = static_cast<int32_t>(video_height);
+		_media_info->video_framerate   = static_cast<float>(frame_rate);
+		_media_info->video_bitrate	   = static_cast<int32_t>(video_bitrate);
 
 		// Audio Codec
 		RtmpCodecType audio_codec_type = RtmpCodecType::Unknown;
-		bool audio_available = false;
+		bool audio_available		   = false;
 		{
 			auto property_pair = object->GetPair("audiocodecid");
 
@@ -720,8 +720,8 @@ namespace pvd
 			{
 				audio_available = true;
 
-				auto &property = property_pair->property;
-				auto type = property.GetType();
+				auto &property	= property_pair->property;
+				auto type		= property.GetType();
 
 				switch (type)
 				{
@@ -839,11 +839,11 @@ namespace pvd
 		}
 
 		_media_info->audio_codec_type = audio_codec_type;
-		_media_info->audio_bitrate = static_cast<int32_t>(audio_bitrate);
-		_media_info->audio_channels = static_cast<int32_t>(audio_channels);
-		_media_info->audio_bits = static_cast<int32_t>(audio_samplesize);
+		_media_info->audio_bitrate	  = static_cast<int32_t>(audio_bitrate);
+		_media_info->audio_channels	  = static_cast<int32_t>(audio_channels);
+		_media_info->audio_bits		  = static_cast<int32_t>(audio_samplesize);
 		_media_info->audio_samplerate = static_cast<int32_t>(audio_samplerate);
-		_media_info->encoder_type = encoder_type;
+		_media_info->encoder_type	  = encoder_type;
 
 		if ((video_available && (video_codec_type != RtmpCodecType::H264)) ||
 			(audio_available && (audio_codec_type != RtmpCodecType::AAC)))
@@ -992,8 +992,8 @@ namespace pvd
 
 	int32_t RtmpStream::ReceiveChunkPacket(const std::shared_ptr<const ov::Data> &data)
 	{
-		int32_t process_size = 0;
-		size_t import_size = 0;
+		int32_t process_size						 = 0;
+		size_t import_size							 = 0;
 		std::shared_ptr<const ov::Data> current_data = data;
 
 		while (current_data->IsEmpty() == false)
@@ -1105,7 +1105,7 @@ namespace pvd
 
 	bool RtmpStream::ReceiveUserControlMessage(const std::shared_ptr<const RtmpMessage> &message)
 	{
-		auto data = message->payload;
+		auto data			   = message->payload;
 
 		// RTMP Spec. v1.0 - 6.2. User Control Messages
 		//
@@ -1113,7 +1113,7 @@ namespace pvd
 		// control stream) and, when sent over RTMP Chunk Stream, be sent on
 		// chunk stream ID 2.
 		auto message_stream_id = message->header->completed.stream_id;
-		auto chunk_stream_id = message->header->basic_header.chunk_stream_id;
+		auto chunk_stream_id   = message->header->basic_header.chunk_stream_id;
 		if (
 			(message_stream_id != 0) ||
 			(chunk_stream_id != 2))
@@ -1148,9 +1148,9 @@ namespace pvd
 				// |               | PingRequest request.                             |
 				// +---------------+--------------------------------------------------+
 				// ping response == event type (16 bits) + timestamp (32 bits)
-				auto body = std::make_shared<std::vector<uint8_t>>(2 + 4);
-				auto write_buffer = body->data();
-				auto message_header = RtmpMuxMessageHeader::Create(chunk_stream_id, RtmpMessageTypeID::UserControl, message_stream_id, 6);
+				auto body									  = std::make_shared<std::vector<uint8_t>>(2 + 4);
+				auto write_buffer							  = body->data();
+				auto message_header							  = RtmpMuxMessageHeader::Create(chunk_stream_id, RtmpMessageTypeID::UserControl, message_stream_id, 6);
 
 				*(reinterpret_cast<uint16_t *>(write_buffer)) = ov::HostToBE16(ov::ToUnderlyingType(UserControlMessageId::PingResponse));
 				write_buffer += sizeof(uint16_t);
@@ -1294,7 +1294,7 @@ namespace pvd
 		// Obtain the message name
 		ov::String message_name;
 		auto message_name_property = document.GetProperty(0);
-		auto message_name_type = (message_name_property != nullptr) ? message_name_property->GetType() : AmfTypeMarker::Undefined;
+		auto message_name_type	   = (message_name_property != nullptr) ? message_name_property->GetType() : AmfTypeMarker::Undefined;
 		if (message_name_type == AmfTypeMarker::String)
 		{
 			message_name = message_name_property->GetString();
@@ -1303,14 +1303,14 @@ namespace pvd
 		// Obtain the data name
 		ov::String data_name;
 		auto data_name_property = document.GetProperty(1);
-		auto data_name_type = (data_name_property != nullptr) ? data_name_property->GetType() : AmfTypeMarker::Undefined;
+		auto data_name_type		= (data_name_property != nullptr) ? data_name_property->GetType() : AmfTypeMarker::Undefined;
 		if (data_name_type == AmfTypeMarker::String)
 		{
 			data_name = data_name_property->GetString();
 		}
 
 		auto third_property = document.GetProperty(2);
-		auto third_type = (third_property != nullptr) ? third_property->GetType() : AmfTypeMarker::Undefined;
+		auto third_type		= (third_property != nullptr) ? third_property->GetType() : AmfTypeMarker::Undefined;
 
 		switch (RtmpCommandFromString(message_name))
 		{
@@ -1358,7 +1358,7 @@ namespace pvd
 
 		for (const auto &event : _event_generator.GetEvents())
 		{
-			auto trigger = event.GetTrigger();
+			auto trigger	  = event.GetTrigger();
 			auto trigger_list = trigger.Split(".");
 
 			// Trigger length must be 3 or more
@@ -1407,7 +1407,7 @@ namespace pvd
 
 								if (property_pair != nullptr)
 								{
-									found = true;
+									found	   = true;
 									auto value = property_pair->property.GetString();
 									GenerateEvent(event, value);
 								}
@@ -1415,7 +1415,7 @@ namespace pvd
 						}
 						else if (property->GetType() == AmfTypeMarker::String)
 						{
-							found = true;
+							found	   = true;
 							auto value = property->GetString();
 							GenerateEvent(event, value);
 						}
@@ -1484,7 +1484,7 @@ namespace pvd
 			else if (id3v2_event.GetFrameType() == "PRIV")
 			{
 				auto owner = id3v2_event.GetInfo();
-				auto data = id3v2_event.GetData();
+				auto data  = id3v2_event.GetData();
 
 				if (owner == "${TriggerValue}")
 				{
@@ -1698,15 +1698,12 @@ namespace pvd
 															 cmn::BitstreamFormat::H264_AVCC,  // RTMP's packet type is AVCC
 															 packet_type);
 
-			SendFrame(video_frame);
+			logat("Sending Video packet: type: %d, pts: %10" PRId64 ", dts: %10" PRId64 ", size: %zu",
+				  ov::ToUnderlyingType(flv_video.PacketType()),
+				  pts, dts,
+				  flv_video.PayloadLength());
 
-			// logac("Video packet sent - stream(%s/%s) type(%d) size(%d) pts(%" PRId64 ") dts(%" PRId64 ")",
-			// 	  _vhost_app_name.CStr(),
-			// 	  _stream_name.CStr(),
-			// 	  flv_video.PacketType(),
-			// 	  flv_video.PayloadLength(),
-			// 	  pts,
-			// 	  dts);
+			SendFrame(video_frame);
 
 			_last_video_pts_in_ms = dts;
 
@@ -1722,7 +1719,7 @@ namespace pvd
 			// Statistics for debugging
 			if (flv_video.FrameType() == flv::VideoFrameType::Key)
 			{
-				_key_frame_interval = message->header->completed.timestamp - _previous_key_frame_timestamp;
+				_key_frame_interval			  = message->header->completed.timestamp - _previous_key_frame_timestamp;
 				_previous_key_frame_timestamp = message->header->completed.timestamp;
 				video_frame->SetFlag(MediaPacketFlag::Key);
 			}
@@ -1735,13 +1732,13 @@ namespace pvd
 			_video_frame_count++;
 
 			time_t current_time = time(nullptr);
-			uint32_t check_gap = current_time - _stream_check_time;
+			uint32_t check_gap	= current_time - _stream_check_time;
 
 			if (check_gap >= 10)
 			{
 				logi("RTMPProvider.Stat", "Rtmp Provider Info - stream(%s/%s) key(%ums) timestamp(v:%ums/a:%ums/g:%dms) fps(v:%u/a:%u) gap(v:%ums/a:%ums)",
 					 _vhost_app_name.CStr(),
-					 _stream_name.CStr(),
+					 GetName().CStr(),
 					 _key_frame_interval,
 					 _last_video_timestamp,
 					 _last_audio_timestamp,
@@ -1751,9 +1748,9 @@ namespace pvd
 					 _last_video_timestamp - _previous_last_video_timestamp,
 					 _last_audio_timestamp - _previous_last_audio_timestamp);
 
-				_stream_check_time = time(nullptr);
-				_video_frame_count = 0;
-				_audio_frame_count = 0;
+				_stream_check_time			   = time(nullptr);
+				_video_frame_count			   = 0;
+				_audio_frame_count			   = 0;
 				_previous_last_video_timestamp = _last_video_timestamp;
 				_previous_last_audio_timestamp = _last_audio_timestamp;
 			}
@@ -1842,7 +1839,7 @@ namespace pvd
 				return false;
 			}
 
-			auto data = std::make_shared<ov::Data>(flv_audio.Payload(), flv_audio.PayloadLength());
+			auto data	= std::make_shared<ov::Data>(flv_audio.Payload(), flv_audio.PayloadLength());
 
 			int64_t dts = message->header->completed.timestamp;
 			int64_t pts = dts;
@@ -1877,6 +1874,11 @@ namespace pvd
 													   MediaPacketFlag::Unknown,
 													   cmn::BitstreamFormat::AAC_RAW,
 													   packet_type);
+
+			logat("Sending Audio packet: type: %d, pts: %10" PRId64 ", dts: %10" PRId64 ", size: %zu",
+				  ov::ToUnderlyingType(flv_audio.PacketType()),
+				  pts, dts,
+				  flv_audio.PayloadLength());
 
 			SendFrame(frame);
 
@@ -1913,9 +1915,10 @@ namespace pvd
 		}
 
 		_vhost_app_name = ocst::Orchestrator::GetInstance()->ResolveApplicationNameFromDomain(_publish_url->Host(), _publish_url->App());
-		_stream_name = _publish_url->Stream();
+		SetName(_publish_url->Stream());
 
 		UpdateNamePath(_vhost_app_name);
+		_import_chunk->UpdateNamePath(GetNamePath());
 
 		// Get application config
 		if (GetProvider() == nullptr)
@@ -1934,7 +1937,7 @@ namespace pvd
 
 		const auto &rtmp_provider = application->GetConfig().GetProviders().GetRtmpProvider();
 
-		_event_generator = rtmp_provider.GetEventGenerator();
+		_event_generator		  = rtmp_provider.GetEventGenerator();
 
 		SetName(_publish_url->Stream());
 
@@ -2139,7 +2142,7 @@ namespace pvd
 
 	bool RtmpStream::SendWindowAcknowledgementSize(uint32_t size)
 	{
-		auto body = std::make_shared<std::vector<uint8_t>>(sizeof(int));
+		auto body			= std::make_shared<std::vector<uint8_t>>(sizeof(int));
 		auto message_header = RtmpMuxMessageHeader::Create(
 			RtmpChunkStreamId::Urgent, RtmpMessageTypeID::WindowAcknowledgementSize, 0, body->size());
 
@@ -2150,7 +2153,7 @@ namespace pvd
 
 	bool RtmpStream::SendAcknowledgementSize(uint32_t acknowledgement_traffic)
 	{
-		auto body = std::make_shared<std::vector<uint8_t>>(sizeof(int));
+		auto body			= std::make_shared<std::vector<uint8_t>>(sizeof(int));
 		auto message_header = RtmpMuxMessageHeader::Create(
 			RtmpChunkStreamId::Urgent, RtmpMessageTypeID::Acknowledgement, 0, body->size());
 
@@ -2161,7 +2164,7 @@ namespace pvd
 
 	bool RtmpStream::SendSetPeerBandwidth(uint32_t bandwidth)
 	{
-		auto body = std::make_shared<std::vector<uint8_t>>(5);
+		auto body			= std::make_shared<std::vector<uint8_t>>(5);
 		auto message_header = RtmpMuxMessageHeader::Create(
 			RtmpChunkStreamId::Urgent, RtmpMessageTypeID::SetPeerBandwidth, 0, body->size());
 
@@ -2188,7 +2191,7 @@ namespace pvd
 
 		return SendUserControlMessage(UserControlMessageId::StreamEof, body);
 	}
-	
+
 	bool RtmpStream::SendSetChunkSize(uint32_t chunk_size)
 	{
 		auto body			= std::make_shared<std::vector<uint8_t>>(sizeof(int));
@@ -2213,7 +2216,7 @@ namespace pvd
 			return false;
 		}
 
-		auto data = stream.GetData();
+		auto data				  = stream.GetData();
 		message_header->body_size = data->GetLength();
 
 		return SendMessagePacket(message_header, data);

--- a/src/projects/providers/rtmp/rtmp_stream.h
+++ b/src/projects/providers/rtmp/rtmp_stream.h
@@ -182,7 +182,7 @@ namespace pvd
 		time_t _stream_check_time = 0;
 
 		uint32_t _key_frame_interval = 0;
-		uint32_t _previous_key_frame_timestamp = 0;
+		int64_t _previous_key_frame_timestamp = 0;
 		int64_t _last_video_timestamp = 0;
 		int64_t _last_audio_timestamp = 0;
 		int64_t _previous_last_video_timestamp = 0;

--- a/src/projects/providers/rtmp/rtmp_stream.h
+++ b/src/projects/providers/rtmp/rtmp_stream.h
@@ -156,7 +156,6 @@ namespace pvd
 		ov::String _app_name;
 		ov::String _domain_name;
 		info::VHostAppName _vhost_app_name = info::VHostAppName::InvalidVHostAppName();
-		ov::String _stream_name;
 		ov::String _device_string;
 
 		std::shared_ptr<ov::Url> _publish_url = nullptr;  // AccessControl can redirect url set in RTMP to another url.

--- a/src/projects/providers/rtmp/rtmp_stream.h
+++ b/src/projects/providers/rtmp/rtmp_stream.h
@@ -183,10 +183,10 @@ namespace pvd
 
 		uint32_t _key_frame_interval = 0;
 		uint32_t _previous_key_frame_timestamp = 0;
-		uint32_t _last_video_timestamp = 0;
-		uint32_t _last_audio_timestamp = 0;
-		uint32_t _previous_last_video_timestamp = 0;
-		uint32_t _previous_last_audio_timestamp = 0;
+		int64_t _last_video_timestamp = 0;
+		int64_t _last_audio_timestamp = 0;
+		int64_t _previous_last_video_timestamp = 0;
+		int64_t _previous_last_audio_timestamp = 0;
 		uint32_t _video_frame_count = 0;
 		uint32_t _audio_frame_count = 0;
 

--- a/src/projects/providers/rtmp/rtmp_stream_v2.cpp
+++ b/src/projects/providers/rtmp/rtmp_stream_v2.cpp
@@ -169,7 +169,9 @@ namespace pvd::rtmp
 			return false;
 		}
 
-		_name			= url->Stream();
+		// Keep the provisional stream name in sync with the parsed tcUrl so
+		// pre-publish logs and duplicate-name checks see the same source value.
+		SetName(url->Stream());
 		_tc_url			= tc_url;
 
 		_vhost_app_name = ocst::Orchestrator::GetInstance()->ResolveApplicationNameFromDomain(url->Host(), url->App());
@@ -177,6 +179,7 @@ namespace pvd::rtmp
 		if (_vhost_app_name.IsValid())
 		{
 			UpdateNamePath(_vhost_app_name);
+			_chunk_handler.UpdateNamePath(GetNamePath());
 		}
 		else
 		{
@@ -261,6 +264,12 @@ namespace pvd::rtmp
 
 			SetRequestedUrlWithPort(url);
 			SetFinalUrl(url);
+
+			// Reflect the publish command's stream name immediately. Admission
+			// Webhooks may still redirect it later, but the pre-publish phase
+			// should already expose the same provisional name through GetName().
+			SetName(url->Stream());
+			_chunk_handler.UpdateNamePath(GetNamePath());
 		}
 
 		_is_post_published = CheckAccessControl() && ValidatePublishUrl();
@@ -375,7 +384,13 @@ namespace pvd::rtmp
 
 		_vhost_app_name = app_info.GetVHostAppName();
 		UpdateNamePath(_vhost_app_name);
+		_chunk_handler.UpdateNamePath(GetNamePath());
+
+		// This is the first point where the final URL is guaranteed to be
+		// validated, so update the public stream name to the post-redirect value.
 		SetName(final_url->Stream());
+		_chunk_handler.UpdateNamePath(GetNamePath());
+		_chunk_handler.UpdateQueueAlias();
 
 		return true;
 	}
@@ -468,6 +483,19 @@ namespace pvd::rtmp
 
 	bool RtmpStreamV2::PublishStream()
 	{
+		const auto final_url = GetFinalUrl();
+		if (final_url == nullptr)
+		{
+			logae("Could not find final URL");
+			OV_ASSERT2(false);
+			return false;
+		}
+
+		// Publish must use the final validated URL, not the earlier provisional
+		// name from tcUrl or the publish command.
+		SetName(final_url->Stream());
+		_chunk_handler.UpdateNamePath(GetNamePath());
+
 		// Get application config
 		auto provider = GetProvider();
 		if (provider == nullptr)

--- a/src/projects/providers/rtmp/rtmp_test.cpp
+++ b/src/projects/providers/rtmp/rtmp_test.cpp
@@ -1,2 +1,460 @@
-// Placeholder — add tests here.
 #include <gtest/gtest.h>
+
+#define private public
+#include "../../modules/rtmp/chunk/rtmp_chunk_parser.h"
+#undef private
+
+#include <vector>
+
+namespace
+{
+	constexpr const char *TEST_APP_STREAM_NAME = "dummy/stream";
+
+	std::shared_ptr<const ov::Data> ToData(const std::vector<uint8_t> &bytes)
+	{
+		return std::make_shared<ov::Data>(bytes.data(), bytes.size());
+	}
+
+	RtmpChunkParser::ParseResult ParseChunk(RtmpChunkParser &parser, const std::vector<uint8_t> &bytes, size_t &bytes_used)
+	{
+		return parser.Parse(ToData(bytes), &bytes_used);
+	}
+
+	std::vector<uint8_t> MakeType0ExtendedChunk(uint32_t extended_timestamp, uint32_t stream_id = 1U, uint8_t chunk_stream_id = 3U)
+	{
+		return {
+			chunk_stream_id,
+			0xFF,
+			0xFF,
+			0xFF,
+			0x00,
+			0x00,
+			0x00,
+			static_cast<uint8_t>(ov::ToUnderlyingType(RtmpMessageTypeID::Amf0Command)),
+			static_cast<uint8_t>(stream_id & 0xFF),
+			static_cast<uint8_t>((stream_id >> 8) & 0xFF),
+			static_cast<uint8_t>((stream_id >> 16) & 0xFF),
+			static_cast<uint8_t>((stream_id >> 24) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp >> 24) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp >> 16) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp >> 8) & 0xFF),
+			static_cast<uint8_t>(extended_timestamp & 0xFF),
+		};
+	}
+
+	std::vector<uint8_t> MakeType1ExtendedChunk(uint32_t extended_timestamp_delta, uint32_t message_length = 0U, uint8_t chunk_stream_id = 3U)
+	{
+		return {
+			static_cast<uint8_t>(0x40 | chunk_stream_id),
+			0xFF,
+			0xFF,
+			0xFF,
+			static_cast<uint8_t>((message_length >> 16) & 0xFF),
+			static_cast<uint8_t>((message_length >> 8) & 0xFF),
+			static_cast<uint8_t>(message_length & 0xFF),
+			static_cast<uint8_t>(ov::ToUnderlyingType(RtmpMessageTypeID::Amf0Command)),
+			static_cast<uint8_t>((extended_timestamp_delta >> 24) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp_delta >> 16) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp_delta >> 8) & 0xFF),
+			static_cast<uint8_t>(extended_timestamp_delta & 0xFF),
+		};
+	}
+
+	std::vector<uint8_t> MakeType1ExtendedChunkWithPayload(uint32_t extended_timestamp_delta, const std::vector<uint8_t> &payload, uint8_t chunk_stream_id = 3U)
+	{
+		auto chunk = MakeType1ExtendedChunk(extended_timestamp_delta, static_cast<uint32_t>(payload.size()), chunk_stream_id);
+		chunk.insert(chunk.end(), payload.begin(), payload.end());
+		return chunk;
+	}
+
+	std::vector<uint8_t> MakeType1ExtendedChunkWithMessageLengthAndPayload(uint32_t extended_timestamp_delta, uint32_t message_length, const std::vector<uint8_t> &payload, uint8_t chunk_stream_id = 3U)
+	{
+		auto chunk = MakeType1ExtendedChunk(extended_timestamp_delta, message_length, chunk_stream_id);
+		chunk.insert(chunk.end(), payload.begin(), payload.end());
+		return chunk;
+	}
+
+	std::vector<uint8_t> MakeType3ExtendedChunk(uint32_t extended_timestamp_delta, uint8_t chunk_stream_id = 3U)
+	{
+		return {
+			static_cast<uint8_t>(0xC0 | chunk_stream_id),
+			static_cast<uint8_t>((extended_timestamp_delta >> 24) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp_delta >> 16) & 0xFF),
+			static_cast<uint8_t>((extended_timestamp_delta >> 8) & 0xFF),
+			static_cast<uint8_t>(extended_timestamp_delta & 0xFF),
+		};
+	}
+
+	TEST(RtmpChunkParser, ResolveExtendedPositiveDeltaAsUnsigned)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0x00010000U,
+			true);
+
+		ASSERT_TRUE(resolved_timestamp.has_value());
+		EXPECT_EQ(resolved_timestamp.value(), 3000 + 0x00010000LL);
+	}
+
+	TEST(RtmpChunkParser, ResolveSmallNegativeExtendedDeltaAsSignedCompatibilityPath)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0xFFFFFFF3U,
+			true);
+
+		ASSERT_TRUE(resolved_timestamp.has_value());
+		EXPECT_EQ(resolved_timestamp.value(), 2987);
+	}
+
+	TEST(RtmpChunkParser, RejectNegativeResolvedTimestampFromSignedCompatibilityPath)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0xFFFFEC78U,
+			true);
+
+		EXPECT_FALSE(resolved_timestamp.has_value());
+	}
+
+	TEST(RtmpChunkParser, ResolveWrappedType0TimestampForward)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			4294967000LL,
+			1000);
+
+		EXPECT_EQ(resolved_timestamp, 4294968296LL);
+	}
+
+	TEST(RtmpChunkParser, KeepBackwardType0TimestampBackward)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			3000,
+			2000);
+
+		EXPECT_EQ(resolved_timestamp, 2000);
+	}
+
+	TEST(RtmpChunkParser, ResolveType0TimestampAsBackwardAtHalfRangeBoundary)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			0,
+			0x80000000ULL);
+
+		EXPECT_EQ(resolved_timestamp, -0x80000000LL);
+	}
+
+	TEST(RtmpChunkParser, KeepType0TimestampForwardWithinHalfRangeInCurrentEpoch)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			1000,
+			0x800003E6ULL);
+
+		EXPECT_EQ(resolved_timestamp, 0x800003E6LL);
+	}
+
+	TEST(RtmpChunkParser, RollWrappedType0TimestampForwardWhenBackwardDistanceExceedsHalfRange)
+	{
+		RtmpChunkParser parser(128);
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			0x80000001LL,
+			0);
+
+		EXPECT_EQ(resolved_timestamp, 0x100000000LL);
+	}
+
+	TEST(RtmpChunkParser, ParseType1ExtendedSignedDeltaCompatibilityPath)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(3000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType0ExtendedChunk(3000).size());
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType1ExtendedChunk(0xFFFFFFF3U).size());
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2987);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParser, ParseType1ExtendedSignedDeltaRejectsNegativeAbsoluteTimestamp)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(3000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunk(0xFFFFEC78U), bytes_used), RtmpChunkParser::ParseResult::Error);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParser, ParseType1ExtendedTimestampReturnsNeedMoreDataWhenExtendedFieldIsIncomplete)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(3000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type1 = {
+			0x43,
+			0xFF,
+			0xFF,
+			0xFF,
+			0x00,
+			0x00,
+			0x00,
+			static_cast<uint8_t>(ov::ToUnderlyingType(RtmpMessageTypeID::Amf0Command)),
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunk(parser, partial_type1, bytes_used), RtmpChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParser, ParseType1ExtendedTimestampRecoversAfterNeedMoreData)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(3000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type1 = {
+			0x43,
+			0xFF,
+			0xFF,
+			0xFF,
+			0x00,
+			0x00,
+			0x00,
+			static_cast<uint8_t>(ov::ToUnderlyingType(RtmpMessageTypeID::Amf0Command)),
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunk(parser, partial_type1, bytes_used), RtmpChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType1ExtendedChunk(0xFFFFFFF3U).size());
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2987);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParser, ParseType3ExtendedSignedDeltaCompatibilityPath)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(3000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType3ExtendedChunk(0xFFFFFFF3U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2974);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParser, ParseType0RejectsNegativeAbsoluteTimestampAfterBackwardResolution)
+	{
+		RtmpChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(1000), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(0xFFFFFF00U), bytes_used), RtmpChunkParser::ParseResult::Error);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParser, ParseType3ContinuationDoesNotApplyDeltaTwice)
+	{
+		RtmpChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(100), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}).size());
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[0], 0x11);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[1], 0x22);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParser, ParseType3ContinuationIgnoresMismatchedExtendedField)
+	{
+		RtmpChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(100), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA5, 0x33, 0x44}, bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParser, ParseType3ContinuationRecoversAfterNeedMoreData)
+	{
+		RtmpChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(100), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type3 = {
+			0xC3,
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunk(parser, partial_type3, bytes_used), RtmpChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+
+		EXPECT_EQ(ParseChunk(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParser, ParseType3ContinuationFromPendingMessageDoesNotApplyDeltaTwice)
+	{
+		RtmpChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.UpdateNamePath(info::NamePath(TEST_APP_STREAM_NAME));
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(100), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}, 3U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}, 3U).size());
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunk(parser, MakeType0ExtendedChunk(200, 1U, 4U), bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		const auto interleaved_message = parser.GetMessage();
+		ASSERT_NE(interleaved_message, nullptr);
+		EXPECT_EQ(interleaved_message->header->basic_header.chunk_stream_id, 4U);
+		EXPECT_EQ(interleaved_message->header->completed.timestamp, 200);
+
+		EXPECT_EQ(ParseChunk(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto resumed_message = parser.GetMessage();
+		ASSERT_NE(resumed_message, nullptr);
+		EXPECT_EQ(resumed_message->header->basic_header.chunk_stream_id, 3U);
+		EXPECT_EQ(resumed_message->header->completed.timestamp, 10);
+		EXPECT_EQ(resumed_message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(resumed_message->payload->GetLength(), 4U);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[0], 0x11);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[1], 0x22);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+}  // namespace

--- a/src/projects/providers/rtmp/rtmp_test.cpp
+++ b/src/projects/providers/rtmp/rtmp_test.cpp
@@ -2,6 +2,7 @@
 
 #define private public
 #include "../../modules/rtmp/chunk/rtmp_chunk_parser.h"
+#include "../../modules/rtmp_v2/chunk/rtmp_chunk_parser.h"
 #undef private
 
 #include <vector>
@@ -16,6 +17,11 @@ namespace
 	}
 
 	RtmpChunkParser::ParseResult ParseChunk(RtmpChunkParser &parser, const std::vector<uint8_t> &bytes, size_t &bytes_used)
+	{
+		return parser.Parse(ToData(bytes), &bytes_used);
+	}
+
+	modules::rtmp::ChunkParser::ParseResult ParseChunkV2(modules::rtmp::ChunkParser &parser, const std::vector<uint8_t> &bytes, size_t &bytes_used)
 	{
 		return parser.Parse(ToData(bytes), &bytes_used);
 	}
@@ -444,6 +450,379 @@ namespace
 		EXPECT_EQ(interleaved_message->header->completed.timestamp, 200);
 
 		EXPECT_EQ(ParseChunk(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), RtmpChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto resumed_message = parser.GetMessage();
+		ASSERT_NE(resumed_message, nullptr);
+		EXPECT_EQ(resumed_message->header->basic_header.chunk_stream_id, 3U);
+		EXPECT_EQ(resumed_message->header->completed.timestamp, 10);
+		EXPECT_EQ(resumed_message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(resumed_message->payload->GetLength(), 4U);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[0], 0x11);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[1], 0x22);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(resumed_message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParserV2, ResolveExtendedPositiveDeltaAsUnsigned)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0x00010000U,
+			true);
+
+		ASSERT_TRUE(resolved_timestamp.has_value());
+		EXPECT_EQ(resolved_timestamp.value(), 3000 + 0x00010000LL);
+	}
+
+	TEST(RtmpChunkParserV2, ResolveSmallNegativeExtendedDeltaAsSignedCompatibilityPath)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0xFFFFFFF3U,
+			true);
+
+		ASSERT_TRUE(resolved_timestamp.has_value());
+		EXPECT_EQ(resolved_timestamp.value(), 2987);
+	}
+
+	TEST(RtmpChunkParserV2, RejectNegativeResolvedTimestampFromSignedCompatibilityPath)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.ResolveTimestampDelta(
+			1U,
+			3000,
+			0xFFFFEC78U,
+			true);
+
+		EXPECT_FALSE(resolved_timestamp.has_value());
+	}
+
+	TEST(RtmpChunkParserV2, ResolveWrappedType0TimestampForward)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			4294967000LL,
+			1000);
+
+		EXPECT_EQ(resolved_timestamp, 4294968296LL);
+	}
+
+	TEST(RtmpChunkParserV2, KeepBackwardType0TimestampBackward)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			3000,
+			2000);
+
+		EXPECT_EQ(resolved_timestamp, 2000);
+	}
+
+	TEST(RtmpChunkParserV2, ResolveType0TimestampAsBackwardAtHalfRangeBoundary)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			0,
+			0x80000000ULL);
+
+		EXPECT_EQ(resolved_timestamp, -0x80000000LL);
+	}
+
+	TEST(RtmpChunkParserV2, KeepType0TimestampForwardWithinHalfRangeInCurrentEpoch)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			1000,
+			0x800003E6ULL);
+
+		EXPECT_EQ(resolved_timestamp, 0x800003E6LL);
+	}
+
+	TEST(RtmpChunkParserV2, RollWrappedType0TimestampForwardWhenBackwardDistanceExceedsHalfRange)
+	{
+		modules::rtmp::ChunkParser parser(128);
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		const auto resolved_timestamp = parser.CalculateRolledTimestamp(
+			1U,
+			0x80000001LL,
+			0);
+
+		EXPECT_EQ(resolved_timestamp, 0x100000000LL);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType1ExtendedSignedDeltaCompatibilityPath)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(3000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType0ExtendedChunk(3000).size());
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType1ExtendedChunk(0xFFFFFFF3U).size());
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2987);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType1ExtendedSignedDeltaRejectsNegativeAbsoluteTimestamp)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(3000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunk(0xFFFFEC78U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Error);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType1ExtendedTimestampReturnsNeedMoreDataWhenExtendedFieldIsIncomplete)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(3000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type1 = {
+			0x43,
+			0xFF,
+			0xFF,
+			0xFF,
+			0x00,
+			0x00,
+			0x00,
+			static_cast<uint8_t>(ov::ToUnderlyingType(modules::rtmp::MessageTypeID::Amf0Command)),
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunkV2(parser, partial_type1, bytes_used), modules::rtmp::ChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType1ExtendedTimestampRecoversAfterNeedMoreData)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(3000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type1 = {
+			0x43,
+			0xFF,
+			0xFF,
+			0xFF,
+			0x00,
+			0x00,
+			0x00,
+			static_cast<uint8_t>(ov::ToUnderlyingType(modules::rtmp::MessageTypeID::Amf0Command)),
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunkV2(parser, partial_type1, bytes_used), modules::rtmp::ChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_EQ(bytes_used, MakeType1ExtendedChunk(0xFFFFFFF3U).size());
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2987);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType3ExtendedSignedDeltaCompatibilityPath)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(3000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunk(0xFFFFFFF3U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType3ExtendedChunk(0xFFFFFFF3U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 2974);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFF3U);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType0RejectsNegativeAbsoluteTimestampAfterBackwardResolution)
+	{
+		modules::rtmp::ChunkParser parser(128);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(1000), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(0xFFFFFF00U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Error);
+		EXPECT_EQ(bytes_used, 0UL);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType3ContinuationDoesNotApplyDeltaTwice)
+	{
+		modules::rtmp::ChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(100), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}).size());
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[0], 0x11);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[1], 0x22);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType3ContinuationIgnoresMismatchedExtendedField)
+	{
+		modules::rtmp::ChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(100), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA5, 0x33, 0x44}, bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType3ContinuationRecoversAfterNeedMoreData)
+	{
+		modules::rtmp::ChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(100), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		const std::vector<uint8_t> partial_type3 = {
+			0xC3,
+			0xFF,
+			0xFF,
+		};
+
+		EXPECT_EQ(ParseChunkV2(parser, partial_type3, bytes_used), modules::rtmp::ChunkParser::ParseResult::NeedMoreData);
+		EXPECT_EQ(bytes_used, 0UL);
+
+		EXPECT_EQ(ParseChunkV2(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, 7UL);
+
+		const auto message = parser.GetMessage();
+		ASSERT_NE(message, nullptr);
+		EXPECT_EQ(message->header->completed.timestamp, 10);
+		EXPECT_EQ(message->header->completed.timestamp_delta, 0xFFFFFFA6U);
+		ASSERT_EQ(message->payload->GetLength(), 4U);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[2], 0x33);
+		EXPECT_EQ(message->payload->GetDataAs<uint8_t>()[3], 0x44);
+	}
+
+	TEST(RtmpChunkParserV2, ParseType3ContinuationFromPendingMessageDoesNotApplyDeltaTwice)
+	{
+		modules::rtmp::ChunkParser parser(2);
+		size_t bytes_used = 0;
+
+		parser.SetMessageQueueAlias(TEST_APP_STREAM_NAME);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(100), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		ASSERT_NE(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}, 3U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		EXPECT_EQ(bytes_used, MakeType1ExtendedChunkWithMessageLengthAndPayload(0xFFFFFFA6U, 4U, {0x11, 0x22}, 3U).size());
+		EXPECT_EQ(parser.GetMessage(), nullptr);
+
+		EXPECT_EQ(ParseChunkV2(parser, MakeType0ExtendedChunk(200, 1U, 4U), bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
+		const auto interleaved_message = parser.GetMessage();
+		ASSERT_NE(interleaved_message, nullptr);
+		EXPECT_EQ(interleaved_message->header->basic_header.chunk_stream_id, 4U);
+		EXPECT_EQ(interleaved_message->header->completed.timestamp, 200);
+
+		EXPECT_EQ(ParseChunkV2(parser, std::vector<uint8_t>{0xC3, 0xFF, 0xFF, 0xFF, 0xA6, 0x33, 0x44}, bytes_used), modules::rtmp::ChunkParser::ParseResult::Parsed);
 		EXPECT_EQ(bytes_used, 7UL);
 
 		const auto resumed_message = parser.GetMessage();


### PR DESCRIPTION
## Summary

This PR adds support for negative extended timestamp deltas seen from some RTMP senders.
To keep timestamp handling consistent, it also updates related resolution paths around continuation chunks, absolute timestamp rollover handling, and validation for invalid negative resolved timestamps.

## What Changed

- added compatibility handling for small negative extended timestamp deltas from non-standard RTMP senders
- kept timestamp-delta handling on the delta path for Type 1/2 chunk headers
- updated Type 3 handling so continuation chunks preserve the timestamp that was already resolved for the message
- reject chunk headers that resolve to a negative absolute timestamp
- updated Type 0 absolute timestamp rollover resolution to keep timestamp interpretation consistent with the new delta handling
- aligned parser behavior, comments, and logging across the RTMP paths
- added regression tests for the affected timestamp parsing cases

## Tests

Added parser regression tests covering:

- positive extended timestamp delta
- small negative extended timestamp delta compatibility path
- rejection of invalid negative resolved absolute timestamps
- Type 0 rollover and backward-resolution edge cases
- NeedMoreData recovery for incomplete extended timestamp fields
- Type 3 delta reuse and continuation handling
- interleaved pending-message continuation handling
- tolerant handling of mismatched repeated extended timestamp fields on continuation chunks
