### PR TITLE
fix: prevent warning logs for queue exceed caused by buffering delay setting

### DIFF
--- a/src/projects/base/info/managed_queue.h
+++ b/src/projects/base/info/managed_queue.h
@@ -51,6 +51,25 @@ namespace info
 				- mngq:v=#default#app:p=pub:n=appworker
 		*/
 	public:
+		enum class ThresholdMode : uint8_t
+		{
+			CountBased = 0,
+			TimeBased  = 1
+		};
+
+		const char *GetThresholdModeString() const
+		{
+			switch (_threshold_mode)
+			{
+			case ThresholdMode::CountBased:
+				return "CountBased";
+			case ThresholdMode::TimeBased:
+				return "TimeBased";
+			default:
+				return "Unknown";
+			}
+		}
+
 		class URN
 		{
 		public:
@@ -133,7 +152,10 @@ namespace info
 			: _peak(0),
 			  _size(0),
 			  _threshold(threshold),
+			  _threshold_mode(ThresholdMode::CountBased),
+			  _threshold_value(threshold),
 			  _threshold_exceeded_time_in_us(0),
+			  _buffering_delay(0),
 			  _input_message_count(0),
 			  _output_message_count(0),
 			  _input_message_per_second(0),
@@ -156,21 +178,45 @@ namespace info
 			return _type_name;
 		}
 
+		// Set threshold in count-based mode.
 		void SetThreshold(size_t threshold)
 		{
 			auto lock_guard = std::lock_guard(_name_mutex);
 
+			_threshold_mode = ThresholdMode::CountBased;
+			_threshold_value = threshold;
+
 			_threshold = threshold;
+		}
+
+		// Set threshold in time-base mode. (millisecond)
+		// Effective count is estimated from input_message_per_second * time_ms 
+		void SetThresholdByTime(size_t time_ms)
+		{
+			auto lock_guard = std::lock_guard(_name_mutex);
+
+			_threshold_mode = ThresholdMode::TimeBased;
+			_threshold_value = time_ms;
+
+			_threshold = 0;
+		}
+
+		ThresholdMode GetThresholdMode() const
+		{
+			return _threshold_mode;
+		}
+
+		// Get user-configured threshold value. The unit depends on the threshold mode.
+		//   CountBased mode → count
+		//   TimeBased  mode → milliseconds
+		size_t GetThresholdValue() const
+		{
+			return _threshold_value;
 		}
 
 		size_t GetThreshold() const
 		{
 			return _threshold;
-		}
-
-		bool IsThresholdExceeded() const
-		{
-			return _size > _threshold;
 		}
 
 		size_t GetPeak() const
@@ -255,11 +301,21 @@ namespace info
 		// Current size of the queue
 		size_t _size = 0;
 
-		// Threshold of the queue
+		// Threshold value computed according to the Threshold Mode.
+		// 0 : No threshold
 		size_t _threshold = 0;
 
+		// Threshold mode
+		ThresholdMode _threshold_mode = ThresholdMode::CountBased;
+
+		// Threshold value: count (CountBased) or milliseconds (TimeBased)
+		size_t _threshold_value = 0;
+
 		// threshold_exceeded_time increases from the point the queue is exceeded
-		int64_t _threshold_exceeded_time_in_us;
+		int64_t _threshold_exceeded_time_in_us = 0;
+
+		// Buffering delay (milliseconds).
+		int _buffering_delay = 0;
 
 		// Input Message Count
 		int64_t _input_message_count = 0;

--- a/src/projects/mediarouter/mediarouter_application.cpp
+++ b/src/projects/mediarouter/mediarouter_application.cpp
@@ -62,7 +62,7 @@ MediaRouteApplication::MediaRouteApplication(const info::Application &applicatio
 		{
 			auto urn = std::make_shared<info::ManagedQueue::URN>(_application_info.GetVHostAppName(), nullptr, "omr", ov::String::FormatString("aw_%d", worker_id));
 			auto stream_data = std::make_shared<ov::ManagedQueue<std::weak_ptr<MediaRouteStream>>>(urn, 1000);
-			stream_data->SetBufferingDelay(delay_buffer_time_ms);
+			stream_data->SetBufferingDelay(delay_buffer_time_ms);	
 			_outbound_stream_indicator.push_back(stream_data);
 		}
 	}
@@ -443,7 +443,14 @@ std::shared_ptr<MediaRouteStream> MediaRouteApplication::CreateOutboundStream(co
 	{
 		return nullptr;
 	}
-	
+
+	// Set buffer retention duration for outbound stream
+	int delay_buffer_time_ms = _application_info.GetConfig().GetPublishers().GetDelayBufferTimeMs();
+	if (delay_buffer_time_ms > 0)
+	{
+		new_stream->SetBufferRetentionDuration(delay_buffer_time_ms);
+	}
+
 	_outbound_streams.insert(std::make_pair(out_stream_info->GetId(), new_stream));
 
 	return new_stream;

--- a/src/projects/mediarouter/mediarouter_stream.cpp
+++ b/src/projects/mediarouter/mediarouter_stream.cpp
@@ -64,8 +64,22 @@ void MediaRouteStream::SetType(cmn::MediaRouterStreamType type)
 		_stream->GetApplicationInfo().GetVHostAppName(),
 		_stream->GetName(),
 		(_type == cmn::MediaRouterStreamType::INBOUND) ? "imr" : "omr",
-		"streamworker");
+		"stream");
 	_packets_queue.SetUrn(urn);
+}
+
+void MediaRouteStream::SetBufferRetentionDuration(int delay_ms)
+{
+	if (delay_ms <= 0)
+	{
+		logtw("%s Invalid buffer retention duration value: %d ms", _stream->GetUri().CStr(), delay_ms);
+		return;
+	}
+
+	// If buffer retention duration is set, the control is performed in the queue of MediaRouterApplication,
+	// so only the threshold is set to prevent warnings in this queue.
+	// Add a buffer of 1 second to prevent spikes.
+	_packets_queue.SetThresholdByTime(delay_ms + 1000); 
 }
 
 void MediaRouteStream::OnStreamPrepared(bool completed)

--- a/src/projects/mediarouter/mediarouter_stream.h
+++ b/src/projects/mediarouter/mediarouter_stream.h
@@ -33,6 +33,7 @@ public:
 
 	// Inout Stream Type
 	void SetType(cmn::MediaRouterStreamType type);
+	void SetBufferRetentionDuration(int delay_ms);
 	bool IsInbound() { return _type == cmn::MediaRouterStreamType::INBOUND; }
 	bool IsOutbound() { return _type == cmn::MediaRouterStreamType::OUTBOUND; }
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -360,14 +360,13 @@ namespace ov
 		{
 			auto shared_lock = std::shared_lock(_name_mutex);
 
-			const char* urn_string = (_urn != nullptr) ? _urn->ToString().CStr() : "NoUrn";
-
+			ov::String urn_str = (_urn != nullptr) ? _urn->ToString() : ov::String("NoUrn");
 			return ov::String::FormatString(
 				"ManagedQueue [Id: %u, Size: %zu, Threshold: %zu (%s %zu%s + delay %dms), Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
 				GetId(), _size, _threshold,
 				GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? " ms" : "", _buffering_delay,
 				_peak, _input_message_per_second, _output_message_per_second, _exceed_threshold_and_wait_enabled ? "On" : "Off",
-				urn_string);
+				urn_str.CStr());
 		}
 
 	private:

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -99,7 +99,16 @@ namespace ov
 		{
 			info::ManagedQueue::SetThreshold(threshold);
 
-			MonitorInstance->OnQueueUpdated(*this, true);
+			MonitorInstance->OnQueueUpdated(*this);
+		}
+
+		// Set threshold in time-base mode.
+		// The effective item count is estimated as: input_message_per_second * time_ms / 1000.
+		void SetThresholdByTime(int time_ms)
+		{
+			info::ManagedQueue::SetThresholdByTime(time_ms);
+
+			MonitorInstance->OnQueueUpdated(*this);
 		}				
 
 		// Urgent item will be inserted at the front of the queue
@@ -360,6 +369,18 @@ namespace ov
 			_buffering_delay = delay_ms;
 		}
 
+		ov::String GetInfoString()
+		{
+			auto shared_lock = std::shared_lock(_name_mutex);
+
+			return ov::String::FormatString(
+				"ManagedQueue [Id: %u, Size: %zu, Threshold: %zu (%s %ld%s + delay %dms), Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
+				GetId(), _size, _threshold,
+				GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? " ms" : "", _buffering_delay,
+				_peak, _input_message_per_second, _output_message_per_second, _exceed_threshold_and_wait_enabled ? "On" : "Off",
+				_urn->ToString().CStr());
+		}
+
 	private:
 
 		int32_t GetBufferedTimeMsInternal()
@@ -496,7 +517,7 @@ namespace ov
 			{
 				std::chrono::system_clock::time_point expire = (timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
-					return (_size  < _threshold);
+					return (!IsThresholdExceeded());
 				});
 				if (!result || _stop)
 				{
@@ -581,23 +602,9 @@ namespace ov
 				_last_input_message_count = _input_message_count;
 				_last_output_message_count = _output_message_count;
 	
-				int adjusted_size = _size;
+				UpdateThreshold();
 
-				if (_buffering_delay > 0)
-				{
-					// excluding the estimated intended buffer size
-					int intended_buffer_size = (double)_input_message_per_second * ((double)_buffering_delay / 1000.0);
-					adjusted_size -= intended_buffer_size;
-
-					// logi("DEBUG", "intended buffer size: %d, input_message_count: %d, input_message_per_second: %d, buffering_delay: %d, size: %d, adjusted_size: %d", intended_buffer_size, _input_message_count, _input_message_per_second, _buffering_delay, _size, adjusted_size);
-					
-					if (adjusted_size < 0)
-					{
-						adjusted_size = 0;
-					}
-				}
-
-				if ((_threshold > 0) && ((size_t)adjusted_size >= _threshold))
+				if (IsThresholdExceeded())
 				{
 					_threshold_exceeded_time_in_us += _stats_metric_interval;
 
@@ -608,7 +615,7 @@ namespace ov
 						_last_logging_time = 0;
 
 						auto shared_lock = std::shared_lock(_name_mutex);
-						logw(LOG_TAG, "[%u] %s has exceeded the threshold and increased peak. size: %zu, threshold: %zu, peak: %zu, imps: %zu, omps: %zu", GetId(), _urn->ToString().CStr(), _size, _threshold, _peak, _input_message_per_second, _output_message_per_second);
+						logw(LOG_TAG, "Exceeded. %s", GetInfoString().CStr());
 
 						_last_logged_peak = _peak;
 					}
@@ -616,6 +623,8 @@ namespace ov
 				else
 				{
 					_threshold_exceeded_time_in_us = 0;
+
+					logt(LOG_TAG, "Stable. %s", GetInfoString().CStr());
 				}
 
 				MonitorInstance->OnQueueUpdated(*this);
@@ -635,6 +644,38 @@ namespace ov
 		}
 
 	private:
+
+		// Check if the queue has exceeded the threshold.
+		// _threshold == 0 means no threshold.
+		bool IsThresholdExceeded() const
+		{
+			if (_threshold == 0) return false;
+			return _size >= _threshold;
+		}
+
+		// Compute the threshold
+		void UpdateThreshold()
+		{
+			// Compute the delay buffer count 
+			size_t delay_buffer_count = 0;
+			if (_buffering_delay > 0 && _input_message_per_second > 0)
+			{
+				delay_buffer_count = static_cast<size_t>(static_cast<double>(_input_message_per_second) * (static_cast<double>(_buffering_delay) / 1000.0));
+			}
+
+			// For time-based threshold, compute the effective count from the input message rate + delay buffer
+			if (_threshold_mode == ThresholdMode::TimeBased && _input_message_per_second > 0)
+			{
+				size_t base_count = std::max(static_cast<size_t>(1), static_cast<size_t>(static_cast<double>(_input_message_per_second) * (static_cast<double>(_threshold_value) / 1000.0)));
+				_threshold = base_count + delay_buffer_count;
+			}
+			// For count-based threshold + delay buffer
+			else if (_threshold_mode == ThresholdMode::CountBased && _threshold_value > 0)
+			{
+				_threshold = static_cast<size_t>(_threshold_value) + delay_buffer_count;
+			}
+		}
+
 		StopWatch _timer;
 
 		int _stats_metric_interval = 0;
@@ -667,9 +708,6 @@ namespace ov
 		// Prevent exceed threshold. If true, the queue will not exceed the threshold
 		// Wait until the queue falls below the threshold
 		bool _exceed_threshold_and_wait_enabled = false;
-
-		// Delay
-		int _buffering_delay = 0;
 	};
 
 }  // namespace ov

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -22,11 +22,6 @@
 #define MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 1000
 #define MANAGED_QUEUE_LOG_INTERVAL_IN_MSEC 5000
 
-// Deactivated as it is no longer used
-#define SKIP_MESSAGE_ENABLED false
-#define SKIP_MESSAGE_CHECK_INTERVAL 500					 // 0.5 sec
-#define SKIP_MESSAGE_STABLE_FOR_RETRIEVE_INTERVAL 10000	 // 10 sec
-#define SKIP_MESSAGE_LOG_INTERVAL 5000					 // 1 sec
 
 namespace ov
 {
@@ -62,8 +57,7 @@ namespace ov
 			  _log_interval(log_interval_in_msec),
 			  _front_node(nullptr),
 			  _rear_node(nullptr),
-			  _stop(false),
-			  _skip_message_enabled(false)
+			  _stop(false)
 		{
 			info::ManagedQueue::SetUrn(urn, Demangle(typeid(T).name()).CStr());
 
@@ -345,14 +339,6 @@ namespace ov
 			return _stop;
 		}
 
-		// Skip message for performance failure recovery
-		// If the queue size increases due to insufficient performance, the problem is avoided by dropping the message.
-		// * Warning: This should only be used where dropping a message will not affect the operation. example) video encoder, video scaler
-		void SetSkipMessageEnable(bool enable)
-		{
-			_skip_message_enabled = enable;
-		}
-
 		void SetExceedWaitEnable(bool enable)
 		{
 			_exceed_threshold_and_wait_enabled = enable;
@@ -421,96 +407,6 @@ namespace ov
 
 			// Update statistics of input message count
 			_input_message_count++;
-
-#if SKIP_MESSAGE_ENABLED
-			if (_skip_message_enabled == true)
-			{
-				auto curr_time = ov::Time::GetTimestampInMs();
-				auto elapsed_check_time = curr_time - _skip_messages_last_check_time;
-				auto elapsed_stable_time = curr_time - _skip_messages_last_changed_time;
-
-				if (elapsed_check_time > SKIP_MESSAGE_CHECK_INTERVAL)
-				{
-					_skip_messages_last_check_time = curr_time;
-
-					if ((_size > _threshold / 10) &&				   // It exceeded 10% of the threshold
-						(_size >= _skip_message_previous_queue_size))  // The queue size has increased compared to before
-					{
-						if (_skip_message_count < 10)  // Maximum skip count is 10
-						{
-							_skip_message_count++;
-						}
-
-						_skip_message_previous_queue_size = _size;
-						_skip_messages_last_changed_time = curr_time;
-
-						auto shared_lock = std::shared_lock(_name_mutex);
-						logw(LOG_TAG, "[%s] Managed queue is unstable. q.size(%d), q.threshold(%d) q.imps(%d), q.omps(%d), skip(%d)", _urn->ToString().CStr(),
-							 GetSize(), GetThreshold(), _input_message_per_second, _output_message_per_second, _skip_message_count);
-					}
-					// If the queue is stable, slowly decrease the number of skip frames.
-					else if ((_skip_message_count > 0) &&										   // Skip Message is operating
-							 (elapsed_stable_time > SKIP_MESSAGE_STABLE_FOR_RETRIEVE_INTERVAL) &&  // It appears to be in a stable state.
-							 (_size <= 1))														   // The queue size is 1 or less.
-					{
-						if (--_skip_message_count < 0)
-						{
-							_skip_message_count = 0;
-						}
-
-						_skip_message_previous_queue_size = _size;
-						_skip_messages_last_changed_time = curr_time;
-
-						auto shared_lock = std::shared_lock(_name_mutex);
-						logi(LOG_TAG, "[%s] Managed queue is stable. q.size(%d), q.threshold(%d) q.imps(%d), q.omps(%d), skip(%d)", _urn->ToString().CStr(),
-							 GetSize(), GetThreshold(), _input_message_per_second, _output_message_per_second, _skip_message_count);
-					}
-				}
-
-				if ((_skip_message_count > 0) && (_input_message_count % (_skip_message_count + 1) != 0))
-				{
-					if (curr_time - _skip_messages_last_log_time > SKIP_MESSAGE_LOG_INTERVAL)
-					{
-						_skip_messages_last_log_time = curr_time;
-
-						auto shared_lock = std::shared_lock(_name_mutex);
-						logw(LOG_TAG, "[%s] Drop a message by message skip. q.size(%d), q.threshold(%d) q.imps(%d), q.omps(%d), skip(%d)", _urn->ToString().CStr(),
-							 GetSize(), GetThreshold(), _input_message_per_second, _output_message_per_second, _skip_message_count);
-					}
-
-					_drop_message_count++;
-
-					delete node;
-
-					_condition.notify_all();
-
-					return;
-				}
-
-				// If the queue exceeds the threshold, drop the frame.
-				if (IsThresholdExceeded() == true)
-				{
-					if (curr_time - _skip_messages_last_log_time > SKIP_MESSAGE_LOG_INTERVAL)
-					{
-						_skip_messages_last_log_time = curr_time;
-
-						auto shared_lock = std::shared_lock(_name_mutex);
-						logw(LOG_TAG, "[%s] Managed queue is exceed. drop message. q.size(%d), q.threshold(%d) q.imps(%d), q.omps(%d), skip(%d)", _urn->ToString().CStr(),
-							 GetSize(), GetThreshold(), _input_message_per_second, _output_message_per_second, _skip_message_count);
-					}
-
-					_drop_message_count++;
-					
-					delete node;
-
-					_condition.notify_all();
-
-					return;
-				}
-
-				// logi(LOG_TAG, "q.size(%d), q.imps(%d), q.omps(%d), skip(%d), stable(%d)", _size,  _skip_message_count, elapsed_stable_time);
-			}
-#endif
 
 			// Wait until the queue size is less than threshold
 			if(_exceed_threshold_and_wait_enabled == true)
@@ -696,14 +592,6 @@ namespace ov
 
 		// Use to print logs when the peak value of the queue is increased.
 		size_t _last_logged_peak = 0;
-
-		// Message Skip for lack of performance
-		bool _skip_message_enabled = false;
-		int64_t _skip_messages_last_check_time = ov::Time::GetTimestampInMs();
-		int64_t _skip_messages_last_changed_time = ov::Time::GetTimestampInMs();
-		int64_t _skip_messages_last_log_time = 0;
-		int32_t _skip_message_count = 0;
-		size_t _skip_message_previous_queue_size = 0;
 
 		// Prevent exceed threshold. If true, the queue will not exceed the threshold
 		// Wait until the queue falls below the threshold

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -98,9 +98,10 @@ namespace ov
 
 		// Set threshold in time-base mode.
 		// The effective item count is estimated as: input_message_per_second * time_ms / 1000.
-		void SetThresholdByTime(int time_ms)
+		void SetThresholdByTime(size_t time_ms)
 		{
-			info::ManagedQueue::SetThresholdByTime(time_ms);
+			const size_t validated_time_ms = (time_ms < 0) ? 0U : time_ms;
+			info::ManagedQueue::SetThresholdByTime(validated_time_ms);
 
 			MonitorInstance->OnQueueUpdated(*this);
 		}				
@@ -359,12 +360,14 @@ namespace ov
 		{
 			auto shared_lock = std::shared_lock(_name_mutex);
 
+			const char* urn_string = (_urn != nullptr) ? _urn->ToString().CStr() : "NoUrn";
+
 			return ov::String::FormatString(
-				"ManagedQueue [Id: %u, Size: %zu, Threshold: %zu (%s %ld%s + delay %dms), Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
+				"ManagedQueue [Id: %u, Size: %zu, Threshold: %zu (%s %zu%s + delay %dms), Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
 				GetId(), _size, _threshold,
 				GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? " ms" : "", _buffering_delay,
 				_peak, _input_message_per_second, _output_message_per_second, _exceed_threshold_and_wait_enabled ? "On" : "Off",
-				_urn->ToString().CStr());
+				urn_string);
 		}
 
 	private:
@@ -519,8 +522,9 @@ namespace ov
 				else
 				{
 					_threshold_exceeded_time_in_us = 0;
-
+#if DEBUG
 					logt(LOG_TAG, "Stable. %s", GetInfoString().CStr());
+#endif					
 				}
 
 				MonitorInstance->OnQueueUpdated(*this);
@@ -552,7 +556,7 @@ namespace ov
 		// Compute the threshold
 		void UpdateThreshold()
 		{
-			// Compute the delay buffer count 
+			// Compute the delay buffer count
 			size_t delay_buffer_count = 0;
 			if (_buffering_delay > 0 && _input_message_per_second > 0)
 			{
@@ -560,15 +564,24 @@ namespace ov
 			}
 
 			// For time-based threshold, compute the effective count from the input message rate + delay buffer
-			if (_threshold_mode == ThresholdMode::TimeBased && _input_message_per_second > 0)
+			if (_threshold_mode == ThresholdMode::TimeBased)
 			{
-				size_t base_count = std::max(static_cast<size_t>(1), static_cast<size_t>(static_cast<double>(_input_message_per_second) * (static_cast<double>(_threshold_value) / 1000.0)));
+				size_t base_count = 0;
+				if (_threshold_value > 0 && _input_message_per_second > 0)
+				{
+					base_count = std::max(static_cast<size_t>(1), static_cast<size_t>(static_cast<double>(_input_message_per_second) * (static_cast<double>(_threshold_value) / 1000.0)));
+				}
 				_threshold = base_count + delay_buffer_count;
 			}
 			// For count-based threshold + delay buffer
-			else if (_threshold_mode == ThresholdMode::CountBased && _threshold_value > 0)
+			else if (_threshold_mode == ThresholdMode::CountBased)
 			{
-				_threshold = static_cast<size_t>(_threshold_value) + delay_buffer_count;
+				size_t base_count = 0;
+				if (_threshold_value > 0)
+				{
+					base_count = _threshold_value;
+				}
+				_threshold = base_count + delay_buffer_count;
 			}
 		}
 

--- a/src/projects/monitoring/queue_metrics.h
+++ b/src/projects/monitoring/queue_metrics.h
@@ -48,13 +48,13 @@ namespace mon
 		{
 			_urn	   = info.GetUrn();
 			_type_name = info.GetTypeName();
-			_threshold = info.GetThreshold();
 		}
 
 		void UpdateMetrics(const info::ManagedQueue &info)
 		{
 			_peak					   = info.GetPeak();
 			_size					   = info.GetSize();
+			_threshold				   = info.GetThreshold();
 			_input_message_per_second  = info.GetInputMessagePerSecond();
 			_output_message_per_second = info.GetOutputMessagePerSecond();
 			_drop_count				   = info.GetDropCount();


### PR DESCRIPTION
### Summary
When `DelayBuffer `is configured, the MediaRouter outbound stream queue intentionally retains packets for the specified duration. The existing count-based threshold had no awareness of this, causing false-positive Warning logs even though the packet accumulation was expected behavior.

Fix: Extended ManagedQueue to support a` time-based threshold` mode (`SetThresholdByTime`). The effective count is computed dynamically from the input rate (imps × time_ms), and the buffering delay portion is included so that delay-held packets never trigger threshold warnings.

When `DelayBuffer` is set, `SetBufferRetentionDuration(delay_ms + 1000)` is called on the outbound stream queue 
(extra 1 second absorbs transient spikes.)

### Changes
- info::ManagedQueue — Added ThresholdMode enum, SetThresholdByTime(), and _threshold_value (user-configured raw value). _threshold always holds the computed effective count limit.
- ov::ManagedQueue — Added SetThresholdByTime(), UpdateThreshold() (recalculates _threshold, IsThresholdExceeded(), 

- MediaRouteStream — Added SetBufferRetentionDuration() which sets a time-based threshold on the packets queue.
- MediaRouteApplication — Calls SetBufferRetentionDuration() on outbound streams when DelayBufferTime is configured.

- queue_metrics.h — _threshold moved to UpdateMetrics() to always reflect the latest computed value.

### Chore
- Removed deprecated skip message related code