### PR TITLE
chore: Install NVIDIA driver using DKMS on RHEL 8/9

### DIFF
--- a/misc/install_nvidia_driver.sh
+++ b/misc/install_nvidia_driver.sh
@@ -211,7 +211,7 @@ find_nearest_higher_nvidia_driver_rocky() {
     require_cmd dnf
 
     dnf module list nvidia-driver --all 2>/dev/null \
-        | awk '$1 == "nvidia-driver" && $2 ~ /^[0-9]+$/ {print $2}' \
+        | awk '$1 == "nvidia-driver" && $2 ~ /^[0-9]+-dkms$/ {print $2}' \
         | sort -Vu \
         | select_equal_or_nearest_higher_version "${current_version}"
 }


### PR DESCRIPTION
## Improved driver selection logic

- Updated the awk pattern in find_nearest_higher_nvidia_driver_rocky() to select only NVIDIA driver modules that end with` -dkms` (DKMS-based drivers only).