### PR TITLE
build(cmake): fix stubs install and improve NVIDIA linking condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ set(OME_NILOGAN_PATCH_PATH          "" CACHE PATH   "Path to Netint NiLogan FFmp
 set(OME_NILOGAN_XCODER_COMPILE_PATH "" CACHE PATH   "Path to xcoder_logan source directory to compile (optional)")
 option(OME_ENABLE_X264              "Enable libx264 encoder support"                     ON)
 option(OME_ENABLE_JEMALLOC          "Enable jemalloc memory allocator"                  OFF)
-option(OME_BUILD_STUBS              "Build GPU stub libraries"                           OFF)
 option(OME_SKIP_DEPENDENCY_CHECK    "Skip auto-install of missing/wrong-version packages" OFF)
 option(OME_SANITIZE_THREAD          "Enable ThreadSanitizer (TSan) - Debug only"         OFF)
 option(OME_BUILD_TESTS              "Build unit tests (requires GTest)"                  OFF)
@@ -126,14 +125,6 @@ endif()
 
 add_subdirectory(src)
 
-# Auto-enable stubs when GPU acceleration is active
-if(OME_HWACCEL_NVIDIA OR OME_HWACCEL_XMA)
-    set(OME_BUILD_STUBS ON)
-endif()
-
-if(OME_BUILD_STUBS)
-    add_subdirectory(misc/stubs)
-endif()
 
 # ==============================================================================
 # Install rules

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -330,6 +330,8 @@ ome_find_pkg(PKG_LIBAVUTIL      libavutil       OME_VER_LIBAVUTIL       REINSTAL
 
 # NVIDIA CUDA/NVML 
 if(OME_HWACCEL_NVIDIA)
+    ome_find_pkg(PKG_FFNVCODEC  ffnvcodec       OME_VER_NVCC_HDR        REINSTALL_TARGET ffnvcodec)
+
     set(_CUDA_ROOT "/usr/local/cuda")
     find_library(_NV_CUDA_LIB   cuda       HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
     find_library(_NV_CUDART_LIB cudart     HINTS ${_CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
@@ -392,6 +394,26 @@ if(OME_HWACCEL_NILOGAN)
     endif()
 endif()
 
+# Stubs 
+# - Stubs lack pkg-config entries, so check for the stubs directory and install if missing.
+if(OME_HWACCEL_NVIDIA OR OME_HWACCEL_XMA OR OME_HWACCEL_NILOGAN)
+    if(NOT IS_DIRECTORY "${OME_DEP_PREFIX}/lib/stubs")
+        message(STATUS "[OME] ${OME_DEP_PREFIX}/lib/stubs not found - installing stubs libraries ...")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND}
+                -DOME_DEP_PREFIX=${OME_DEP_PREFIX}
+                -DTARGET=stubs
+                -P "${CMAKE_SOURCE_DIR}/cmake/InstallPrerequisites.cmake"
+            RESULT_VARIABLE _stubs_ret
+        )
+        if(NOT _stubs_ret EQUAL 0)
+            message(FATAL_ERROR "[OME] Failed to install stubs.")
+        endif()
+        unset(_stubs_ret)
+    endif()
+endif()
+
+
 # jemalloc - required for Release builds, optional for Debug (can be forced with OME_ENABLE_JEMALLOC=ON)
 # Note: when built with --enable-prof, jemalloc reports its pkg-config version as "<ver>_0"
 # (e.g. "5.3.0_0"), so we use >= instead of = to avoid a false version mismatch.
@@ -438,24 +460,6 @@ if(OME_ENABLE_X264)
     endif()
 else()
     message(STATUS "[OME] libx264: disabled by OME_ENABLE_X264=OFF")
-endif()
-
-# ==============================================================================
-# Stubs (GPU stub .so files) are installed unconditionally, regardless of hardware support.
-# ==============================================================================
-if(NOT IS_DIRECTORY "${OME_DEP_PREFIX}/lib/stubs")
-    message(STATUS "[OME] ${OME_DEP_PREFIX}/lib/stubs not found - installing stubs libraries ...")
-    execute_process(
-        COMMAND ${CMAKE_COMMAND}
-            -DOME_DEP_PREFIX=${OME_DEP_PREFIX}
-            -DTARGET=stubs
-            -P "${CMAKE_SOURCE_DIR}/cmake/InstallPrerequisites.cmake"
-        RESULT_VARIABLE _stubs_ret
-    )
-    if(NOT _stubs_ret EQUAL 0)
-        message(FATAL_ERROR "[OME] Failed to install stubs.")
-    endif()
-    unset(_stubs_ret)
 endif()
 
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -328,37 +328,33 @@ ome_find_pkg(PKG_LIBAVUTIL      libavutil       OME_VER_LIBAVUTIL       REINSTAL
 # Optional / hardware-accelerated dependencies
 # ==============================================================================
 
-# NVIDIA NVENC/NVDEC
+# NVIDIA CUDA/NVML 
 if(OME_HWACCEL_NVIDIA)
-    pkg_check_modules(PKG_FFNVCODEC QUIET IMPORTED_TARGET ffnvcodec)
-    if(NOT PKG_FFNVCODEC_FOUND)
-        # Auto-install nv-codec-headers with NVIDIA flag forwarded
-        message(STATUS "[OME] ffnvcodec not found - installing nv-codec-headers ...")
-        execute_process(
-            COMMAND ${CMAKE_COMMAND}
-                -DOME_DEP_PREFIX=${OME_DEP_PREFIX}
-                -DOME_HWACCEL_NVIDIA=ON
-                -DTARGET=nvcc_hdr
-                -P "${CMAKE_SOURCE_DIR}/cmake/InstallPrerequisites.cmake"
-            RESULT_VARIABLE _ret
-        )
-        if(_ret EQUAL 0)
-            pkg_check_modules(PKG_FFNVCODEC IMPORTED_TARGET ffnvcodec)
-        endif()
-    endif()
-    if(PKG_FFNVCODEC_FOUND)
+    set(_CUDA_ROOT "/usr/local/cuda")
+    find_library(_NV_CUDA_LIB   cuda       HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_library(_NV_CUDART_LIB cudart     HINTS ${_CUDA_ROOT}/lib64 /usr/lib/x86_64-linux-gnu)
+    find_library(_NV_ML_LIB     nvidia-ml  HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)
+    find_program(_NV_NVCC       nvcc       HINTS ${_CUDA_ROOT}/bin)
+
+    if(_NV_CUDA_LIB AND _NV_CUDART_LIB AND _NV_ML_LIB AND _NV_NVCC)
         message(STATUS "[OME] NVIDIA hardware acceleration: ENABLED")
         add_compile_definitions(HWACCELS_NVIDIA_ENABLED)
-        include_directories(/usr/local/cuda/include)
-        link_directories(/usr/local/cuda/lib64 /usr/local/cuda/lib64/stubs)
+        include_directories(${_CUDA_ROOT}/include)
+        link_directories(${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs)
         set(OME_NVIDIA_LIBS cuda cudart nvidia-ml)
     else()
-        message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but ffnvcodec still not found - disabling")
+        message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but required NVIDIA libraries/tools not found - disabling")
         set(OME_HWACCEL_NVIDIA OFF)
     endif()
+
+    unset(_NV_CUDA_LIB CACHE)
+    unset(_NV_CUDART_LIB CACHE)
+    unset(_NV_ML_LIB CACHE)
+    unset(_NV_NVCC CACHE)
+    unset(_CUDA_ROOT)
 endif()
 
-# Intel QSV
+# Intel QSV (Deprecated)
 if(OME_HWACCEL_QSV)
     pkg_check_modules(PKG_LIBMFX IMPORTED_TARGET libmfx)
     if(PKG_LIBMFX_FOUND)
@@ -375,7 +371,7 @@ if(OME_HWACCEL_XMA)
     ome_find_pkg(PKG_LIBXMA2API libxma2api OPTIONAL)
     ome_find_pkg(PKG_XVBM       xvbm       OPTIONAL)
     ome_find_pkg(PKG_LIBXRM     libxrm     OPTIONAL)
-    if(PKG_LIBXMA2API_FOUND AND PKG_LIBXRM_FOUND)
+    if(PKG_LIBXMA2API_FOUND AND PKG_LIBXRM_FOUND AND PKG_XVBM_FOUND)
         message(STATUS "[OME] Xilinx XMA hardware acceleration: ENABLED")
         add_compile_definitions(HWACCELS_XMA_ENABLED)
     else()
@@ -443,6 +439,25 @@ if(OME_ENABLE_X264)
 else()
     message(STATUS "[OME] libx264: disabled by OME_ENABLE_X264=OFF")
 endif()
+
+# ==============================================================================
+# Stubs (GPU stub .so files) are installed unconditionally, regardless of hardware support.
+# ==============================================================================
+if(NOT IS_DIRECTORY "${OME_DEP_PREFIX}/lib/stubs")
+    message(STATUS "[OME] ${OME_DEP_PREFIX}/lib/stubs not found - installing stubs libraries ...")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND}
+            -DOME_DEP_PREFIX=${OME_DEP_PREFIX}
+            -DTARGET=stubs
+            -P "${CMAKE_SOURCE_DIR}/cmake/InstallPrerequisites.cmake"
+        RESULT_VARIABLE _stubs_ret
+    )
+    if(NOT _stubs_ret EQUAL 0)
+        message(FATAL_ERROR "[OME] Failed to install stubs.")
+    endif()
+    unset(_stubs_ret)
+endif()
+
 
 # uuid (system library, not pkg-config)
 find_library(UUID_LIB uuid REQUIRED)

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -474,12 +474,12 @@ make ${_J} && sudo make install && sudo rm -rf ${PREFIX}/share && rm -rf ${TEMP_
 ")
 
 # ---- stubs ----
-# Built via CMake (misc/stubs/CMakeLists.txt) instead of the legacy Makefile.
-set(_STUB_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+set(_STUB_DIR "${CMAKE_CURRENT_LIST_DIR}/../misc/stubs")
 set(_install_stubs "
-cmake -S ${_STUB_DIR} -B ${_STUB_DIR}/build/stubs -DOME_BUILD_STUBS=ON -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 &&
-cmake --build ${_STUB_DIR}/build/stubs --target stubs -j$(nproc) &&
-sudo cmake --install ${_STUB_DIR}/build/stubs --component stubs
+cmake -S ${_STUB_DIR} -B ${_STUB_DIR}/build -DCMAKE_INSTALL_PREFIX=${PREFIX} &&
+cmake --build ${_STUB_DIR}/build --target stubs -j$(nproc) &&
+sudo cmake --install ${_STUB_DIR}/build --component stubs && 
+rm -rf ${_STUB_DIR}/build
 ")
 
 # ---- jemalloc ----

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -36,16 +36,15 @@ cmake --build build/Release
 | `OME_DEP_PREFIX` | `/opt/ovenmediaengine` | Installation prefix for external dependencies |
 | `OME_SANITIZE_THREAD` | OFF | Enable ThreadSanitizer (TSan). Debug builds only |
 | `OME_SKIP_DEPENDENCY_CHECK` | OFF | Skip auto-install of missing/wrong-version packages. Useful for CI or offline builds |
-| `OME_HWACCEL_NVIDIA` | OFF | Enable NVIDIA GPU acceleration. Enables `OME_BUILD_STUBS` automatically |
+| `OME_HWACCEL_NVIDIA` | OFF | Enable NVIDIA GPU acceleration. |
 | `OME_HWACCEL_QSV` | OFF | Enable Intel QSV acceleration. Requires Intel driver (`libmfx`) installed separately |
-| `OME_HWACCEL_XMA` | OFF | Enable Xilinx XMA acceleration. Enables `OME_BUILD_STUBS` automatically |
+| `OME_HWACCEL_XMA` | OFF | Enable Xilinx XMA acceleration. |
 | `OME_HWACCEL_NILOGAN` | OFF | Enable Netint NiLogan acceleration. Requires `OME_NILOGAN_PATCH_PATH` |
 | `OME_NILOGAN_PATCH_PATH` | `""` | Path to the NiLogan FFmpeg patch file. Required when `OME_HWACCEL_NILOGAN=ON` |
 | `OME_NILOGAN_XCODER_COMPILE_PATH` | `""` | Path to `xcoder_logan` source directory to compile (optional) |
 | `OME_ENABLE_X264` | ON | Enable libx264 encoder support |
 | `OME_ENABLE_JEMALLOC` | OFF/ON | Enable jemalloc allocator. Always ON in Release, OFF by default in Debug |
 | `OME_USE_JEMALLOC_PROFILE` | OFF | Enable jemalloc heap profiling (`OME_USE_JEMALLOC_PROFILE` compile definition). Requires `OME_ENABLE_JEMALLOC=ON` |
-| `OME_BUILD_STUBS` | OFF/AUTO | Build GPU stub `.so` libraries. Auto-enabled when NVIDIA or XMA is ON |
 | `OME_BUILD_TESTS` | OFF | Build unit tests (requires internet access to fetch GTest v1.14.0) |
 
 ---

--- a/misc/stubs/CMakeLists.txt
+++ b/misc/stubs/CMakeLists.txt
@@ -1,11 +1,8 @@
+cmake_minimum_required(VERSION 3.24)
+project(OMEStubs DESCRIPTION "Stub Libraries for OvenMediaEngine" LANGUAGES C)
+
 # ==============================================================================
 # GPU / Accelerator Stub Shared Libraries
-#
-# These are thin stub .so files that provide the required symbols for NVIDIA
-# (CUDA/cuBLAS/nvidia-ml) and Xilinx (XMA/XRM/XRT) drivers so that
-# OvenMediaEngine can be run on machines that do not have the vendor drivers
-# installed at build time — the real driver .so is loaded at runtime via
-# LD_LIBRARY_PATH / ldconfig.
 #
 # Each stub is built with:
 #   gcc -shared -fPIC -Wl,-soname,<soname> -Wl,--version-script=<map> -o <out> <src.c>

--- a/src/projects/main/CMakeLists.txt
+++ b/src/projects/main/CMakeLists.txt
@@ -72,11 +72,9 @@ target_link_libraries(OvenMediaEngine PRIVATE
 # ==============================================================================
 # Optional hardware acceleration libs
 # ==============================================================================
-if(OME_HWACCEL_NVIDIA AND PKG_FFNVCODEC_FOUND)
-    target_link_libraries(OvenMediaEngine PRIVATE
-        PkgConfig::PKG_FFNVCODEC
-        ${OME_NVIDIA_LIBS}
-    )
+if(OME_HWACCEL_NVIDIA)
+    target_link_libraries(OvenMediaEngine PRIVATE ${OME_NVIDIA_LIBS})
+    target_link_libraries(OvenMediaEngine PRIVATE PkgConfig::PKG_FFNVCODEC)
 endif()
 
 if(OME_HWACCEL_XMA AND PKG_LIBXMA2API_FOUND)


### PR DESCRIPTION
### Summary

Fixes GPU stub libraries not being installed and improves NVIDIA hardware detection during cmake configuration.

### Changes:

- NVIDIA driver link condition — Replaced PKG_FFNVCODEC_FOUND flag check with explicit file existence `checks for libcuda.so, libcudart.so, libnvidia-ml.so, and nvcc`


- nv-codec-headers (ffnvcodec) install condition - used `ome_find_pkg `instead of `pkg_check_modules`

- GPU stubs install timing — Moved stubs installation from build phase to CMake configure phase stubs are installed automatically via InstallPrerequisites.cmake when` ${OME_DEP_PREFIX}/lib/stubs `directory is absent. The `OME_BUILD_STUBS `option is removed. 