### PR TITLE
refactor(providers/api): prepare stream delete flow for API intent and watcher handoff

### DIFF
--- a/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
+++ b/src/projects/api_server/controllers/v1/vhosts/apps/streams/streams_controller.cpp
@@ -250,7 +250,7 @@ namespace api
 			auto app_name	  = app->GetVHostAppName();
 			auto stream_name  = stream->GetName();
 
-			auto code		  = orchestrator->TerminateStream(app_name, stream_name);
+			auto code		  = orchestrator->TerminateStream(app_name, stream_name, true);
 			auto http_code	  = http::StatusCodeFromCommonError(code);
 			if (http_code != http::StatusCode::OK)
 			{

--- a/src/projects/base/provider/application.cpp
+++ b/src/projects/base/provider/application.cpp
@@ -312,14 +312,19 @@ namespace pvd
 
 	bool Application::DeleteAllStreams()
 	{
-		std::unique_lock<std::shared_mutex> lock(_streams_guard);
-
-		for(auto it = _streams.cbegin(); it != _streams.cend(); )
+		std::vector<std::shared_ptr<Stream>> streams_to_delete;
 		{
-			auto stream = it->second;
-			it = _streams.erase(it);
-			stream->Stop();
+			std::unique_lock<std::shared_mutex> lock(_streams_guard);
+			for (auto it = _streams.cbegin(); it != _streams.cend();)
+			{
+				streams_to_delete.push_back(it->second);
+				it = _streams.erase(it);
+			}
+		}
 
+		for (auto &stream : streams_to_delete)
+		{
+			stream->Stop();
 			NotifyStreamDeleted(stream);
 		}
 

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -660,7 +660,7 @@ namespace ocst
 	}
 
 	/// Delete PullStream
-	CommonErrorCode Orchestrator::TerminateStream(const info::VHostAppName &vhost_app_name, const ov::String &stream_name)
+	CommonErrorCode Orchestrator::TerminateStream(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, [[maybe_unused]] bool api_requested)
 	{
 		auto stream = GetProviderStream(vhost_app_name, stream_name);
 		if (stream == nullptr)

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -211,7 +211,7 @@ namespace ocst
 		}
 		
 		/// Release Pulled Stream
-		CommonErrorCode TerminateStream(const info::VHostAppName &vhost_app_name, const ov::String &stream_name);
+		CommonErrorCode TerminateStream(const info::VHostAppName &vhost_app_name, const ov::String &stream_name, bool api_requested = false);
 
 		/// Find Provider from ProviderType
 		std::shared_ptr<pvd::Provider> GetProviderFromType(const ProviderType type);

--- a/src/projects/providers/multiplex/multiplex_application.cpp
+++ b/src/projects/providers/multiplex/multiplex_application.cpp
@@ -156,7 +156,9 @@ namespace pvd
                     continue;
                 }
 
-                RemoveMultiplex(multiplex_file_info);
+                std::shared_ptr<info::Stream> deleted_stream_info;
+                RemoveMultiplex(multiplex_file_info, &deleted_stream_info);
+
                 logti("Removed multiplex channel : %s/%s (%s)", GetVHostAppName().CStr(), multiplex_file_info._multiplex_profile->GetOutputStreamName().CStr(), multiplex_file_info._file_path.CStr());
 
                 it = _multiplex_file_info_db.erase(it);
@@ -348,7 +350,7 @@ namespace pvd
         return true;
     }
 
-    bool MultiplexApplication::RemoveMultiplex(MultiplexFileInfo &multiplex_file_info)
+    bool MultiplexApplication::RemoveMultiplex(MultiplexFileInfo &multiplex_file_info, [[maybe_unused]] std::shared_ptr<info::Stream> *deleted_stream_info)
     {
         auto stream_name = multiplex_file_info._multiplex_profile->GetOutputStreamName();
 

--- a/src/projects/providers/multiplex/multiplex_application.cpp
+++ b/src/projects/providers/multiplex/multiplex_application.cpp
@@ -157,11 +157,16 @@ namespace pvd
                 }
 
                 std::shared_ptr<info::Stream> deleted_stream_info;
-                RemoveMultiplex(multiplex_file_info, &deleted_stream_info);
+				if (RemoveMultiplex(multiplex_file_info, &deleted_stream_info))
+				{
+					logti("Removed multiplex channel : %s/%s (%s)", GetVHostAppName().CStr(), multiplex_file_info._multiplex_profile->GetOutputStreamName().CStr(), multiplex_file_info._file_path.CStr());
 
-                logti("Removed multiplex channel : %s/%s (%s)", GetVHostAppName().CStr(), multiplex_file_info._multiplex_profile->GetOutputStreamName().CStr(), multiplex_file_info._file_path.CStr());
-
-                it = _multiplex_file_info_db.erase(it);
+					it = _multiplex_file_info_db.erase(it);
+				}
+				else
+				{
+					++it;
+				}
             }
             else
             {

--- a/src/projects/providers/multiplex/multiplex_application.h
+++ b/src/projects/providers/multiplex/multiplex_application.h
@@ -49,7 +49,7 @@ namespace pvd
         bool GetMultiplexFileInfoFromDB(const size_t &hash, MultiplexFileInfo &multiplex_file_info);
         bool AddMultiplex(MultiplexFileInfo &multiplex_file_info);
         bool UpdateMultiplex(MultiplexFileInfo &multiplex_file_info, MultiplexFileInfo &new_multiplex_file_info);
-        bool RemoveMultiplex(MultiplexFileInfo &multiplex_file_info);
+        bool RemoveMultiplex(MultiplexFileInfo &multiplex_file_info, std::shared_ptr<info::Stream> *deleted_stream_info = nullptr);
 
         ov::String _multiplex_files_path;
         ov::Regex _multiplex_file_name_regex;

--- a/src/projects/providers/scheduled/scheduled_application.cpp
+++ b/src/projects/providers/scheduled/scheduled_application.cpp
@@ -101,10 +101,16 @@ namespace pvd
                 }
 
                 std::shared_ptr<info::Stream> deleted_stream_info;
-                RemoveSchedule(schedule_file_info, &deleted_stream_info);
-                logti("Removed schedule channel : %s/%s (%s)", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
+				if (RemoveSchedule(schedule_file_info, &deleted_stream_info) == true)
+				{
+					logti("Removed schedule channel : %s/%s (%s)", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
 
-                it = _schedule_file_info_db.erase(it);
+					it = _schedule_file_info_db.erase(it);
+				}
+				else
+				{
+					++it;
+				}
             }
             else
             {

--- a/src/projects/providers/scheduled/scheduled_application.cpp
+++ b/src/projects/providers/scheduled/scheduled_application.cpp
@@ -100,7 +100,8 @@ namespace pvd
                     continue;
                 }
 
-                RemoveSchedule(schedule_file_info);
+                std::shared_ptr<info::Stream> deleted_stream_info;
+                RemoveSchedule(schedule_file_info, &deleted_stream_info);
                 logti("Removed schedule channel : %s/%s (%s)", GetVHostAppName().CStr(), schedule_file_info._schedule->GetStream()._name.CStr(), schedule_file_info._file_path.CStr());
 
                 it = _schedule_file_info_db.erase(it);
@@ -303,7 +304,7 @@ namespace pvd
         return true;
     }
 
-    bool ScheduledApplication::RemoveSchedule(ScheduleFileInfo &schedule_file_info)
+    bool ScheduledApplication::RemoveSchedule(ScheduleFileInfo &schedule_file_info, std::shared_ptr<info::Stream> *deleted_stream_info)
     {
         auto stream_name = schedule_file_info._schedule->GetStream()._name;
 

--- a/src/projects/providers/scheduled/scheduled_application.h
+++ b/src/projects/providers/scheduled/scheduled_application.h
@@ -49,7 +49,7 @@ namespace pvd
         bool GetScheduleFileInfoFromDB(const size_t &hash, ScheduleFileInfo &schedule_file_info);
         bool AddSchedule(ScheduleFileInfo &schedule_file_info);
         bool UpdateSchedule(ScheduleFileInfo &schedule_file_info, ScheduleFileInfo &new_schedule_file_info);
-        bool RemoveSchedule(ScheduleFileInfo &schedule_file_info);
+        bool RemoveSchedule(ScheduleFileInfo &schedule_file_info, std::shared_ptr<info::Stream> *deleted_stream_info = nullptr);
 
         ov::String _media_root_dir;
         ov::String _schedule_files_path;


### PR DESCRIPTION
## Summary

Prepare shared stream deletion paths for API-requested termination and watcher-side handoff.

## Changes

- add `api_requested` to `Orchestrator::TerminateStream()`
- pass `true` from the stream delete API path
- update scheduled/multiplex watcher delete helpers to carry deleted stream snapshots
- align watcher delete flow so follow-up callbacks can be handled outside the watcher lock scope

## Why

Some stream deletion paths need to preserve the original delete trigger and
handoff deleted stream information through the watcher flow in a consistent way.

This change prepares the shared control flow first so later changes can stay
smaller and avoid repeatedly touching the same watcher and delete-path code.

## Notes

- no intended functional change for existing OSS behavior
- this is primarily a refactoring of shared delete-path plumbing
