### PR TITLE
feat(mpegts): add MP2 audio ingest support

### DIFF
--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -457,8 +457,8 @@ set(_FFMPEG_CONFIGURE_CMD
     "${_FFMPEG_ADDI_LICENSE}"
     "${_FFMPEG_ADDI_LIBS}"
     "--enable-encoder=libvpx_vp8,libopus,libfdk_aac,libopenh264,mjpeg,png,libwebp${_FFMPEG_ADDI_ENCODER}"
-    "--enable-decoder=aac,aac_latm,aac_fixed,mp3float,mp3,h264,hevc,opus,vp8,mjpeg,png${_FFMPEG_ADDI_DECODER}"
-    "--enable-parser=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8,png,jpg"
+    "--enable-decoder=aac,aac_latm,aac_fixed,mp2,mp2float,mp3float,mp3,h264,hevc,opus,vp8,mjpeg,png${_FFMPEG_ADDI_DECODER}"
+    "--enable-parser=aac,aac_latm,aac_fixed,h264,hevc,mpegaudio,opus,vp8,png,jpg"
     "--enable-protocol=tcp,udp,rtp,file,rtmp,tls,rtmps,libsrt"
     "--enable-demuxer=rtsp,flv,live_flv,mp4,mp3,image2"
     "--enable-muxer=mp4,webm,mpegts,flv,mpjpeg"
@@ -587,7 +587,7 @@ endif()
 if(DEFINED TARGET)
     if("${TARGET}" STREQUAL "ffmpeg")
         # ffmpeg depends on codec libs; install them first in case they are missing
-        set(_ffmpeg_deps nasm libopus libvpx libwebp libopenh264 fdk_aac)
+        set(_ffmpeg_deps nasm openssl libsrt libopus libvpx libwebp libopenh264 fdk_aac)
         if(ENABLE_X264)
             list(APPEND _ffmpeg_deps libx264)
         endif()

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -368,8 +368,8 @@ install_ffmpeg()
     --enable-shared --enable-zlib --enable-libopus --enable-libvpx --enable-libfdk_aac --enable-libopenh264 --enable-openssl --enable-network --enable-libsrt --enable-dct --enable-rdft --enable-libwebp ${ADDI_LIBS} \
     ${ADDI_HWACCEL} \
     --enable-encoder=libvpx_vp8,libopus,libfdk_aac,libopenh264,mjpeg,png,libwebp${ADDI_ENCODER} \
-    --enable-decoder=aac,aac_latm,aac_fixed,mp3float,mp3,h264,hevc,opus,vp8,mjpeg,png${ADDI_DECODER} \
-    --enable-parser=aac,aac_latm,aac_fixed,h264,hevc,opus,vp8,png,jpg \
+    --enable-decoder=aac,aac_latm,aac_fixed,mp2,mp2float,mp3float,mp3,h264,hevc,opus,vp8,mjpeg,png${ADDI_DECODER} \
+    --enable-parser=aac,aac_latm,aac_fixed,h264,hevc,mpegaudio,opus,vp8,png,jpg \
     --enable-protocol=tcp,udp,rtp,file,rtmp,tls,rtmps,libsrt \
     --enable-demuxer=rtsp,flv,live_flv,mp4,mp3,image2 \
     --enable-muxer=mp4,webm,mpegts,flv,mpjpeg \

--- a/src/projects/base/info/media_track.cpp
+++ b/src/projects/base/info/media_track.cpp
@@ -570,6 +570,7 @@ bool MediaTrack::IsValid()
 			}
 		}
 		break;
+		case MediaCodecId::Mp2:
 		case MediaCodecId::Mp3: {
 			if (IsValidTimeBase() && IsValidChannel())
 			{

--- a/src/projects/base/mediarouter/media_type.h
+++ b/src/projects/base/mediarouter/media_type.h
@@ -59,7 +59,8 @@ namespace cmn
 		AMF,	 // AMF0
 		SEI,	 // H.264/H.265 SEI
 		SCTE35,	 // SCTE35
-		WebVTT	 // WebVTT (Web Video Text Tracks)
+		WebVTT,	 // WebVTT (Web Video Text Tracks)
+		MP2
 	};
 
 	enum class PacketType : int8_t
@@ -108,7 +109,8 @@ namespace cmn
 		Png,
 		Webp,
 		WebVTT,
-		Whisper
+		Whisper,
+		Mp2
 	};
 
 	// DeviceId is used to identify a hwardware accelerator device.
@@ -269,6 +271,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, true);
 
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, false);
 
@@ -296,6 +299,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, false);
 
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, false);
 
@@ -323,6 +327,7 @@ namespace cmn
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, false);
 
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, true);
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, true);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, true);
 
@@ -390,6 +395,7 @@ namespace cmn
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_MPEG4_GENERIC);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_ADTS);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, AAC_LATM);
+			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, MP2);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, MP3);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, OPUS);
 			OV_CASE_RETURN_ENUM_STRING(BitstreamFormat, OPUS_RTP_RFC_7587);
@@ -526,6 +532,7 @@ namespace cmn
 			OV_CASE_RETURN(MediaCodecId::Webp, "WEBP");
 			// Audio codecs
 			OV_CASE_RETURN(MediaCodecId::Aac, "AAC");
+			OV_CASE_RETURN(MediaCodecId::Mp2, "MP2");
 			OV_CASE_RETURN(MediaCodecId::Mp3, "MP3");
 			OV_CASE_RETURN(MediaCodecId::Opus, "OPUS");
 			// Subtitle codecs
@@ -578,6 +585,10 @@ namespace cmn
 		else if (name.HasPrefix("AAC"))
 		{
 			return cmn::MediaCodecId::Aac;
+		}
+		else if (name.HasPrefix("MP2"))
+		{
+			return cmn::MediaCodecId::Mp2;
 		}
 		else if (name.HasPrefix("MP3"))
 		{

--- a/src/projects/mediarouter/mediarouter_nomalize.cpp
+++ b/src/projects/mediarouter/mediarouter_nomalize.cpp
@@ -88,6 +88,7 @@ bool MediaRouterNormalize::NormalizeMediaPacket(const std::shared_ptr<info::Stre
 		case cmn::BitstreamFormat::OPUS:
 			result = media_packet->GetData() != nullptr && ProcessOPUSStream(stream_info, media_track, media_packet);
 			break;
+		case cmn::BitstreamFormat::MP2:
 		case cmn::BitstreamFormat::MP3:
 			result = media_packet->GetData() != nullptr && ProcessMP3Stream(stream_info, media_track, media_packet);
 			break;

--- a/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
+++ b/src/projects/modules/containers/mpegts/mpegts_depacketizer.cpp
@@ -583,6 +583,15 @@ namespace mpegts
 					track->SetTimeBase(1, TIMEBASE);
 					break;
 
+				case static_cast<uint8_t>(WellKnownStreamTypes::MPEG1_AUDIO):
+				case static_cast<uint8_t>(WellKnownStreamTypes::MPEG2_AUDIO):
+					track->SetId(pid);
+					track->SetMediaType(cmn::MediaType::Audio);
+					track->SetCodecId(cmn::MediaCodecId::Mp2);
+					track->SetOriginBitstream(cmn::BitstreamFormat::MP2);
+					track->SetTimeBase(1, TIMEBASE);
+					break;
+
 				case static_cast<uint8_t>(WellKnownStreamTypes::SCTE35):
 					// SCTE-35 StreamType is used to Data Track in OvenMediaEngine.  Data track is created elsewhere for common use, so track is not created here.
 					continue;

--- a/src/projects/modules/containers/mpegts/mpegts_section.h
+++ b/src/projects/modules/containers/mpegts/mpegts_section.h
@@ -77,6 +77,8 @@ namespace mpegts
 	enum class WellKnownStreamTypes : uint8_t
 	{
 		None = 0x00,
+		MPEG1_AUDIO = 0x03,
+		MPEG2_AUDIO = 0x04,
 		H264 = 0x1B, // 27
 		H265 = 0x24, // 36
 		AAC = 0x0F, // 15 AAC ADTS

--- a/src/projects/modules/ffmpeg/compat.cpp
+++ b/src/projects/modules/ffmpeg/compat.cpp
@@ -51,6 +51,7 @@ namespace ffmpeg
 			OV_CASE_RETURN(AV_CODEC_ID_VP9, cmn::MediaCodecId::Vp9);
 			OV_CASE_RETURN(AV_CODEC_ID_FLV1, cmn::MediaCodecId::Flv);
 			OV_CASE_RETURN(AV_CODEC_ID_AAC, cmn::MediaCodecId::Aac);
+			OV_CASE_RETURN(AV_CODEC_ID_MP2, cmn::MediaCodecId::Mp2);
 			OV_CASE_RETURN(AV_CODEC_ID_MP3, cmn::MediaCodecId::Mp3);
 			OV_CASE_RETURN(AV_CODEC_ID_OPUS, cmn::MediaCodecId::Opus);
 			OV_CASE_RETURN(AV_CODEC_ID_MJPEG, cmn::MediaCodecId::Jpeg);
@@ -75,6 +76,7 @@ namespace ffmpeg
 			OV_CASE_RETURN(cmn::MediaCodecId::Av1, AV_CODEC_ID_AV1);
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, AV_CODEC_ID_FLV1);
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, AV_CODEC_ID_AAC);
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, AV_CODEC_ID_MP2);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, AV_CODEC_ID_MP3);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, AV_CODEC_ID_OPUS);
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_MJPEG);

--- a/src/projects/modules/ffmpeg/compat.h
+++ b/src/projects/modules/ffmpeg/compat.h
@@ -172,6 +172,7 @@ namespace ffmpeg
 				case cmn::MediaCodecId::Vp8:
 				case cmn::MediaCodecId::Vp9:
 				case cmn::MediaCodecId::Flv:
+				case cmn::MediaCodecId::Mp2:
 				case cmn::MediaCodecId::Mp3:
 				case cmn::MediaCodecId::Jpeg:
 				case cmn::MediaCodecId::Png:
@@ -611,6 +612,7 @@ namespace ffmpeg
 					codec_id == cmn::MediaCodecId::Vp8 ||
 					codec_id == cmn::MediaCodecId::Vp9 ||
 					codec_id == cmn::MediaCodecId::Aac ||
+					codec_id == cmn::MediaCodecId::Mp2 ||
 					codec_id == cmn::MediaCodecId::Mp3 ||
 					codec_id == cmn::MediaCodecId::Opus)
 				{

--- a/src/projects/modules/segment_writer/writer.cpp
+++ b/src/projects/modules/segment_writer/writer.cpp
@@ -144,6 +144,7 @@ static AVCodecID AvCodecIdFromMediaCodecId(cmn::MediaCodecId codec_id)
 		WRITER_CASE(cmn::MediaCodecId::Flv, AV_CODEC_ID_FLV1)
 		WRITER_CASE(cmn::MediaCodecId::Aac, AV_CODEC_ID_AAC)
 		WRITER_CASE(cmn::MediaCodecId::Mp3, AV_CODEC_ID_MP3)
+		WRITER_CASE(cmn::MediaCodecId::Mp2, AV_CODEC_ID_MP2)
 		WRITER_CASE(cmn::MediaCodecId::Opus, AV_CODEC_ID_OPUS)
 		WRITER_CASE(cmn::MediaCodecId::Jpeg, AV_CODEC_ID_JPEG2000)
 		WRITER_CASE(cmn::MediaCodecId::Png, AV_CODEC_ID_PNG)
@@ -868,6 +869,8 @@ bool Writer::WritePacket(const std::shared_ptr<const MediaPacket> &packet)
 		case cmn::BitstreamFormat::ID3v2:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::MP3:
+			[[fallthrough]];
+		case cmn::BitstreamFormat::MP2:
 			[[fallthrough]];
 		case cmn::BitstreamFormat::OVEN_EVENT:
 			[[fallthrough]];

--- a/src/projects/providers/mpegts/mpegts_stream.cpp
+++ b/src/projects/providers/mpegts/mpegts_stream.cpp
@@ -171,7 +171,7 @@ namespace pvd
 																	  dts,
 																	  -1LL,
 																	  MediaPacketFlag::Unknown,
-																	  cmn::BitstreamFormat::AAC_ADTS,
+																	  track->GetOriginBitstream(),
 																	  cmn::PacketType::RAW);
 					SendFrame(media_packet);
 				}

--- a/src/projects/providers/mpegts/mpegts_test.cpp
+++ b/src/projects/providers/mpegts/mpegts_test.cpp
@@ -1,2 +1,25 @@
-// Placeholder — add tests here.
 #include <gtest/gtest.h>
+
+#include <base/mediarouter/media_type.h>
+#include <modules/containers/mpegts/mpegts_section.h>
+#include <modules/ffmpeg/compat.h>
+
+TEST(MpegTsAudioSupport, RecognizesMpegAudioStreamTypes)
+{
+	EXPECT_EQ(static_cast<uint8_t>(mpegts::WellKnownStreamTypes::MPEG1_AUDIO), 0x03);
+	EXPECT_EQ(static_cast<uint8_t>(mpegts::WellKnownStreamTypes::MPEG2_AUDIO), 0x04);
+}
+
+TEST(MpegTsAudioSupport, MapsMp2CodecAndBitstream)
+{
+	EXPECT_TRUE(cmn::IsAudioCodec(cmn::MediaCodecId::Mp2));
+	EXPECT_STREQ(cmn::GetCodecIdString(cmn::MediaCodecId::Mp2), "MP2");
+	EXPECT_STREQ(cmn::GetBitstreamFormatString(cmn::BitstreamFormat::MP2), "MP2");
+	EXPECT_EQ(cmn::GetCodecIdByName("mp2"), cmn::MediaCodecId::Mp2);
+}
+
+TEST(MpegTsAudioSupport, MapsMp2ToFfmpegCodecId)
+{
+	EXPECT_EQ(ffmpeg::compat::ToCodecId(AV_CODEC_ID_MP2), cmn::MediaCodecId::Mp2);
+	EXPECT_EQ(ffmpeg::compat::ToAVCodecId(cmn::MediaCodecId::Mp2), AV_CODEC_ID_MP2);
+}

--- a/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
+++ b/src/projects/providers/rtmp/handlers/rtmp_chunk_handler.cpp
@@ -102,6 +102,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Vp9, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Av1, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, false);
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, false);
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, false);

--- a/src/projects/providers/rtmp/tracks/rtmp_track.cpp
+++ b/src/projects/providers/rtmp/tracks/rtmp_track.cpp
@@ -28,6 +28,7 @@ namespace pvd::rtmp
 			OV_CASE_RETURN(cmn::MediaCodecId::Av1, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Flv, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Aac, std::make_shared<RtmpAacTrack>(stream, track_id, from_ex_header));
+			OV_CASE_RETURN(cmn::MediaCodecId::Mp2, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Mp3, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Opus, nullptr);
 			OV_CASE_RETURN(cmn::MediaCodecId::Jpeg, nullptr);

--- a/src/projects/transcoder/codec/decoder/decoder_mp2.h
+++ b/src/projects/transcoder/codec/decoder/decoder_mp2.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Transcode
+//
+//  Created by Kwon Keuk Han
+//  Copyright (c) 2018 AirenSoft. All rights reserved.
+//
+//==============================================================================
+#pragma once
+
+#include "decoder_mp3.h"
+
+class DecoderMP2 : public DecoderMP3
+{
+public:
+	DecoderMP2(const info::Stream &stream_info)
+		: DecoderMP3(stream_info)
+	{
+	}
+
+	cmn::MediaCodecId GetCodecID() const noexcept override
+	{
+		return cmn::MediaCodecId::Mp2;
+	}
+};

--- a/src/projects/transcoder/transcoder_decoder.cpp
+++ b/src/projects/transcoder/transcoder_decoder.cpp
@@ -19,6 +19,7 @@
 #include "codec/decoder/decoder_hevc_nv.h"
 #include "codec/decoder/decoder_hevc_qsv.h"
 #include "codec/decoder/decoder_hevc_xma.h"
+#include "codec/decoder/decoder_mp2.h"
 #include "codec/decoder/decoder_mp3.h"
 #include "codec/decoder/decoder_opus.h"
 #include "codec/decoder/decoder_vp8.h"
@@ -235,6 +236,15 @@ std::shared_ptr<TranscodeDecoder> TranscodeDecoder::Create(
 			{
 				default:
 					CASE_CREATE_CODEC_IFNEED(DEFAULT, DecoderOPUS)
+					break;
+			}
+		}
+		else if (candidate->GetCodecId() == cmn::MediaCodecId::Mp2)
+		{
+			switch (candidate->GetModuleId())
+			{
+				default:
+					CASE_CREATE_CODEC_IFNEED(DEFAULT, DecoderMP2)
 					break;
 			}
 		}

--- a/src/projects/transcoder/transcoder_modules.cpp
+++ b/src/projects/transcoder/transcoder_modules.cpp
@@ -43,7 +43,7 @@ namespace tc
 		// Audio Codecs
 		// --------------------------------------------------------------------------
 		Register(info::CodecModule("FFmpeg Audio Codecs", cmn::MediaType::Audio, cmn::MediaCodecModuleId::DEFAULT, 0, "-",
-						   {cmn::MediaCodecId::Aac, cmn::MediaCodecId::Opus},
+						   {cmn::MediaCodecId::Aac, cmn::MediaCodecId::Mp2, cmn::MediaCodecId::Opus},
 						   true, true, false, false));
 
 		Register(info::CodecModule("Fraunhofer FDK AAC", cmn::MediaType::Audio, cmn::MediaCodecModuleId::FDKAAC, 0, "-",

--- a/src/projects/transcoder/transcoder_stream_internal.cpp
+++ b/src/projects/transcoder/transcoder_stream_internal.cpp
@@ -123,6 +123,7 @@ cmn::Timebase TranscoderStreamInternal::GetDefaultTimebaseByCodecId(cmn::MediaCo
 			timebase.SetDen(90000);
 			break;
 		case cmn::MediaCodecId::Aac:
+		case cmn::MediaCodecId::Mp2:
 		case cmn::MediaCodecId::Mp3:
 		case cmn::MediaCodecId::Opus:
 			timebase.SetNum(1);


### PR DESCRIPTION
## Summary

Add MP2 audio support for MPEG-TS ingest by mapping MPEG-1/2 audio stream types
to OME's media codec/bitstream model and FFmpeg `AV_CODEC_ID_MP2`.

## Changes

- recognize MPEG-TS stream types `0x03` and `0x04` as MP2 audio
- add MP2 codec/bitstream and FFmpeg mappings
- allow MP2 packets through the existing audio decode/transcode path

## Test

- `ome_test_providers_mpegts`
- built Docker image and verified MP2 MPEG-TS ingest locally