### PR TITLE
build(cmake): fix ffnvcodec auto-install regression

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -330,7 +330,7 @@ ome_find_pkg(PKG_LIBAVUTIL      libavutil       OME_VER_LIBAVUTIL       REINSTAL
 
 # NVIDIA CUDA/NVML 
 if(OME_HWACCEL_NVIDIA)
-    ome_find_pkg(PKG_FFNVCODEC  ffnvcodec       OME_VER_NVCC_HDR        REINSTALL_TARGET ffnvcodec)
+    ome_find_pkg(PKG_FFNVCODEC  ffnvcodec       OME_VER_NVCC_HDR        REINSTALL_TARGET ffmpeg)
 
     set(_CUDA_ROOT "/usr/local/cuda")
     find_library(_NV_CUDA_LIB   cuda       HINTS ${_CUDA_ROOT}/lib64 ${_CUDA_ROOT}/lib64/stubs /usr/lib/x86_64-linux-gnu)

--- a/cmake/InstallPrerequisites.cmake
+++ b/cmake/InstallPrerequisites.cmake
@@ -364,7 +364,7 @@ make ${_J} && sudo make install && rm -rf ${TEMP_PATH}/x264
 ")
 
 # ---- nv-codec-headers (optional) ----
-set(_install_nvcc_hdr "
+set(_install_ffnvcodec "
 mkdir -p ${TEMP_PATH}/nvcc-hdr && cd ${TEMP_PATH}/nvcc-hdr &&
 curl -sSLf ${NVCC_HDR_SOURCE_URL} | tar -xz --strip-components=1 &&
 sudo make PREFIX=${PREFIX} LIBDIR=lib install
@@ -580,7 +580,7 @@ if(ENABLE_X264)
 endif()
 
 if(ENABLE_NVIDIA)
-    list(APPEND _targets nvcc_hdr)
+    list(APPEND _targets ffnvcodec)
 endif()
 
 # Override with single target if requested
@@ -592,7 +592,7 @@ if(DEFINED TARGET)
             list(APPEND _ffmpeg_deps libx264)
         endif()
         if(ENABLE_NVIDIA)
-            list(APPEND _ffmpeg_deps nvcc_hdr)
+            list(APPEND _ffmpeg_deps ffnvcodec)
         endif()
         set(_targets ${_ffmpeg_deps} ffmpeg)
     elseif("${TARGET}" STREQUAL "libvpx")

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -88,7 +88,7 @@ Available targets:
 ```
 nasm        openssl     libsrtp     libsrt      libopus     libopenh264
 libvpx      libwebp     fdk_aac     libx264     ffmpeg      stubs
-jemalloc    libpcre2    hiredis     spdlog      whisper     nvcc_hdr
+jemalloc    libpcre2    hiredis     spdlog      whisper     ffnvcodec
 ```
 
 Available `-D` options:


### PR DESCRIPTION
## Problem
#2099 changed `PKG_FFNVCODEC`'s `REINSTALL_TARGET` from `nvcc_hdr`
to `ffnvcodec`, but the install map key in `InstallPrerequisites.cmake`
stayed as `_install_nvcc_hdr`. The lookup misses and silently no-ops,
so configure fails with `ffnvcodec - not found` whenever FFmpeg is
already installed but `ffnvcodec` is not. Clean installs dodge this
path because `TARGET=ffmpeg` provisions `ffnvcodec` first.

Also, just installing `ffnvcodec` headers does not add NVIDIA
encoders to an existing FFmpeg binary, so the reinstall has to
rebuild FFmpeg.

## Solution
- Rename `_install_nvcc_hdr` to `_install_ffnvcodec` to match the
  pkg-config module name.
- Change `PKG_FFNVCODEC`'s `REINSTALL_TARGET` to `ffmpeg` so the
  reinstall pulls in `ffnvcodec` via `_ffmpeg_deps` and rebuilds
  FFmpeg with NVIDIA support.