### PR TITLE
feat(webrtc): Implement AP (Aggregation Packets) support for H.264/H.265 RTP packetizer

### DIFF
--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -122,7 +122,7 @@ bool RtpPacketizerH264::IsAggregationPossible(size_t fragment_index) const
 
 	// First fragment: NAL header (1) + length field (2) + data.
 	const size_t first_needed = kNalHeaderSize + kLengthFieldSize + _input_fragments[fragment_index].length;
-	if (first_needed >= space_left)
+	if (first_needed > space_left)
 	{
 		return false;
 	}
@@ -313,21 +313,27 @@ void RtpPacketizerH264::NextSingleUnitPacket(RtpPacket* rtp_packet)
 //  +---------------+
 //  |F|NRI| Type(24)|
 //  +---------------+
-//    F   = forbidden_zero_bit (from highest priority NALU)
-//    NRI = max nal_ref_idc among aggregated NALUs
+//    F   = forbidden_zero_bit 
+//    NRI = max of all NRI values in the aggregated NAL units
 //    Type = 24 (kStapA)
 void RtpPacketizerH264::NextAggregatePacket(RtpPacket* rtp_packet, bool last) 
 {
 	uint8_t* buffer = rtp_packet->AllocatePayload(last ? _max_payload_len - _last_packet_reduction_len : _max_payload_len);
 	PacketUnit* packet = &_packets.front();
 
-	// STAP-A NALU header.
-	buffer[0] = (packet->header & (kFBit | kNriMask)) | NaluType::kStapA;
+	uint8_t stap_f   = 0;
+	uint8_t stap_nri = 0;
 	size_t index = kNalHeaderSize;
 	bool is_last_fragment = packet->last_fragment;
 	
 	while (packet->aggregated) 
 	{
+		// F = OR of all aggregated F bits; 
+		// NRI = max of all aggregated NRI values.
+		stap_f   |= (packet->header & kFBit);
+		uint8_t cur_nri = packet->header & kNriMask;
+		if (cur_nri > stap_nri) stap_nri = cur_nri;
+
 		const Fragment& fragment = packet->source_fragment;
 		// Add NAL unit length field.
 		ByteWriter<uint16_t>::WriteBigEndian(&buffer[index], fragment.length);
@@ -337,7 +343,6 @@ void RtpPacketizerH264::NextAggregatePacket(RtpPacket* rtp_packet, bool last)
 		index += fragment.length;
 
 		_packets.pop();
-
 		_input_fragments.pop_front();
 
 		if (is_last_fragment)
@@ -347,6 +352,10 @@ void RtpPacketizerH264::NextAggregatePacket(RtpPacket* rtp_packet, bool last)
 		packet = &_packets.front();
 		is_last_fragment = packet->last_fragment;
 	}
+
+	// Write STAP-A NAL header with aggregated F and NRI.
+	buffer[0] = stap_f | stap_nri | NaluType::kStapA;
+
 	rtp_packet->SetPayloadSize(index);
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -97,11 +97,15 @@ bool RtpPacketizerH264::GeneratePackets()
 					PacketizeFuA(i);
 					++i;
 				} 
-				else 
+				// Try to aggregate into STAP-A if possible
+				else if (fragment_len + kNalHeaderSize + kLengthFieldSize <= _max_payload_len) 
+				{
+					i = PacketizeStapA(i); 
+				}
+				else
 				{
 					PacketizeSingleNalu(i);
 					++i;
-					//i = PacketizeStapA(i);
 				}
 				break;
 		}
@@ -141,13 +145,17 @@ void RtpPacketizerH264::PacketizeFuA(size_t fragment_index)
 			}
 		}
 		_packets.push(PacketUnit(Fragment(fragment.buffer + offset, packet_length),
-		                         offset - kNalHeaderSize == 0,
-		                         payload_left == packet_length, false,
+		                         offset - kNalHeaderSize == 0 /* first */, 
+		                         payload_left == packet_length /* last */, false /* aggregated */,
 		                         fragment.buffer[0]));
 		offset += packet_length;
 		payload_left -= packet_length;
 		--num_packets;
 	}
+
+#if DEBUG
+	logt("RtpPacketizerH264", "Packetized one fragment into %zu FU-A packets, total size: %zu", _num_packets_left, fragment.length);
+#endif
 }
 
 size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index) 
@@ -159,21 +167,18 @@ size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index)
 	const Fragment* fragment = &_input_fragments[fragment_index];
 	++_num_packets_left;
 
+	// The header size for the first fragment is  (NAL header size +  length field size),
+	// and for subsequent fragments, only the (length field size) is added.
+	fragment_headers_length = kNalHeaderSize + kLengthFieldSize;
+
 	while (payload_size_left >= fragment->length + fragment_headers_length &&
-	       (fragment_index + 1 < _input_fragments.size() ||
-	        payload_size_left >= fragment->length + fragment_headers_length + _last_packet_reduction_len)) 
+	       (fragment_index + 1 < _input_fragments.size() ||													// Not last fragment
+	        payload_size_left >= fragment->length + fragment_headers_length + _last_packet_reduction_len))  // Last fragment with reduction
 	{
-		_packets.push(PacketUnit(*fragment, aggregated_fragments == 0, false, true, fragment->buffer[0]));
+		_packets.push(PacketUnit(*fragment, aggregated_fragments == 0 /* first */, false /* last */, true /* aggregated */, fragment->buffer[0]));
 		payload_size_left -= fragment->length;
 		payload_size_left -= fragment_headers_length;
-
-		fragment_headers_length = kLengthFieldSize;
-
-		if (aggregated_fragments == 0)
-		{	
-			fragment_headers_length += kNalHeaderSize + kLengthFieldSize;
-		}
-		++aggregated_fragments;
+		++aggregated_fragments;		
 
 		// Next fragment.
 		++fragment_index;
@@ -182,8 +187,14 @@ size_t RtpPacketizerH264::PacketizeStapA(size_t fragment_index)
 			break;
 		}
 		fragment = &_input_fragments[fragment_index];
+		fragment_headers_length = kLengthFieldSize;
 	}
 	_packets.back().last_fragment = true;
+
+#if DEBUG	
+	logt("RtpPacketizerH264", "Packetized %d fragments into STAP-A packet, total size: %zu", aggregated_fragments, _max_payload_len - payload_size_left);
+#endif
+
 	return fragment_index;
 }
 
@@ -204,6 +215,10 @@ bool RtpPacketizerH264::PacketizeSingleNalu(size_t fragment_index)
 	
 	_packets.push(PacketUnit(*fragment, true /* first */, true /* last */, false /* aggregated */, fragment->buffer[0]));
 	++_num_packets_left;
+
+#if DEBUG
+	logt("RtpPacketizerH264", "Packetized one fragment into one single NALU packet, total size: %zu", fragment->length);
+#endif	
 	return true;
 }
 
@@ -216,20 +231,18 @@ bool RtpPacketizerH264::NextPacket(RtpPacket* rtp_packet)
 
 	PacketUnit packet = _packets.front();
 	
+	// Single NAL unit packet.
 	if (packet.first_fragment && packet.last_fragment) 
 	{
-		// Single NAL unit packet.
-		size_t bytes_to_send = packet.source_fragment.length;
-		uint8_t* buffer = rtp_packet->AllocatePayload(bytes_to_send);
-		memcpy(buffer, packet.source_fragment.buffer, bytes_to_send);
-		_packets.pop();
-		_input_fragments.pop_front();
+		NextSingleUnitPacket(rtp_packet);
 	} 
+	// Aggregated packet (STAP-A).
 	else if (packet.aggregated) 
 	{
 		bool is_last_packet = _num_packets_left == 1;
 		NextAggregatePacket(rtp_packet, is_last_packet);
 	} 
+	// NAL unit fragmented over multiple packets (FU).
 	else 
 	{
 		NextFragmentPacket(rtp_packet);
@@ -241,7 +254,35 @@ bool RtpPacketizerH264::NextPacket(RtpPacket* rtp_packet)
 	return true;
 }
 
-// [kStapA][Len][Fragment][Len][Fragment]...
+void RtpPacketizerH264::NextSingleUnitPacket(RtpPacket* rtp_packet)
+{
+	PacketUnit& packet = _packets.front();
+	size_t bytes_to_send = packet.source_fragment.length;
+	uint8_t* buffer = rtp_packet->AllocatePayload(bytes_to_send);
+	memcpy(buffer, packet.source_fragment.buffer, bytes_to_send);
+	_packets.pop();
+	_input_fragments.pop_front();
+}
+
+// H.264 STAP-A (Single-Time Aggregation Packet Type A) structure [RFC 6184]
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | STAP-A HDR(24)|  NALU 1 Size (16bit, big-endian)              |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |           NALU 1 Data (NAL header + RBSP) ...                 |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  NALU 2 Size (16bit)          |  NALU 2 Data ...              |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// STAP-A NAL Header (1 byte):
+//  +---------------+
+//  |F|NRI| Type(24)|
+//  +---------------+
+//    F   = forbidden_zero_bit (from highest priority NALU)
+//    NRI = max nal_ref_idc among aggregated NALUs
+//    Type = 24 (kStapA)
 void RtpPacketizerH264::NextAggregatePacket(RtpPacket* rtp_packet, bool last) 
 {
 	uint8_t* buffer = rtp_packet->AllocatePayload(last ? _max_payload_len - _last_packet_reduction_len : _max_payload_len);

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -97,7 +97,7 @@ bool RtpPacketizerH264::GeneratePackets()
 					PacketizeFuA(i);
 					++i;
 				} 
-				else if (fragment_len + kNalHeaderSize + kLengthFieldSize <= _max_payload_len) 
+				else if (IsAggregationPossible(i))
 				{
 					i = PacketizeStapA(i); 
 				}
@@ -112,6 +112,34 @@ bool RtpPacketizerH264::GeneratePackets()
 	return true;
 }
 
+bool RtpPacketizerH264::IsAggregationPossible(size_t fragment_index) const
+{
+	if (fragment_index + 1 >= _input_fragments.size())
+	{
+		return false;
+	}
+	size_t space_left = _max_payload_len;
+
+	// First fragment: NAL header (1) + length field (2) + data.
+	const size_t first_needed = kNalHeaderSize + kLengthFieldSize + _input_fragments[fragment_index].length;
+	if (first_needed >= space_left)
+	{
+		return false;
+	}
+	space_left -= first_needed;
+
+	// Second fragment: length field (2) + data.
+	const size_t next_fragment_index = fragment_index + 1;
+	size_t next_needed = kLengthFieldSize + _input_fragments[next_fragment_index].length;
+	
+	// If Last fragment, also calculate for _last_packet_reduction_len.
+	if ((next_fragment_index + 1) == _input_fragments.size())
+	{
+		next_needed += _last_packet_reduction_len;
+	}
+
+	return space_left >= next_needed;
+}
 
 void RtpPacketizerH264::PacketizeFuA(size_t fragment_index) 
 {

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -120,7 +120,7 @@ bool RtpPacketizerH264::IsAggregationPossible(size_t fragment_index) const
 	}
 	size_t space_left = _max_payload_len;
 
-	// First fragment: NAL header (1) + length field (2) + data.
+	// First fragment: Payload Header(1) + Length Field(2) + Data
 	const size_t first_needed = kNalHeaderSize + kLengthFieldSize + _input_fragments[fragment_index].length;
 	if (first_needed > space_left)
 	{
@@ -128,7 +128,7 @@ bool RtpPacketizerH264::IsAggregationPossible(size_t fragment_index) const
 	}
 	space_left -= first_needed;
 
-	// Second fragment: length field (2) + data.
+	// Second fragment: Length Field(2) + Data
 	const size_t next_fragment_index = fragment_index + 1;
 	size_t next_needed = kLengthFieldSize + _input_fragments[next_fragment_index].length;
 	

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -97,7 +97,6 @@ bool RtpPacketizerH264::GeneratePackets()
 					PacketizeFuA(i);
 					++i;
 				} 
-				// Try to aggregate into STAP-A if possible
 				else if (fragment_len + kNalHeaderSize + kLengthFieldSize <= _max_payload_len) 
 				{
 					i = PacketizeStapA(i); 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.cpp
@@ -127,7 +127,9 @@ void RtpPacketizerH264::PacketizeFuA(size_t fragment_index)
 	size_t num_packets = (payload_left + extra_len + (per_packet_capacity - 1)) / per_packet_capacity;
 	size_t payload_per_packet = (payload_left + extra_len) / num_packets;
 	size_t num_larger_packets = (payload_left + extra_len) % num_packets;
-
+#if DEBUG
+	size_t fragmented_packets = 0;
+#endif	
 	_num_packets_left += num_packets;
 	while (payload_left > 0) 
 	{
@@ -151,10 +153,14 @@ void RtpPacketizerH264::PacketizeFuA(size_t fragment_index)
 		offset += packet_length;
 		payload_left -= packet_length;
 		--num_packets;
+
+#if DEBUG		
+		++fragmented_packets;
+#endif		
 	}
 
 #if DEBUG
-	logt("RtpPacketizerH264", "Packetized one fragment into %zu FU-A packets, total size: %zu", _num_packets_left, fragment.length);
+	logt("RtpPacketizerH264", "Packetized one fragment into %zu FU-A packets, total size: %zu", fragmented_packets, fragment.length);
 #endif
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
@@ -101,7 +101,7 @@ private:
 	bool GeneratePackets();
 	void PacketizeFuA(size_t fragment_index);
 	size_t PacketizeStapA(size_t fragment_index);
-	bool IsAggregationPossible(size_t fragment_index) const;	
+	bool IsAggregationPossible(size_t fragment_index) const;
 	bool PacketizeSingleNalu(size_t fragment_index);
 	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
@@ -102,6 +102,7 @@ private:
 	void PacketizeFuA(size_t fragment_index);
 	size_t PacketizeStapA(size_t fragment_index);
 	bool PacketizeSingleNalu(size_t fragment_index);
+	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);
 	void NextFragmentPacket(RtpPacket* rtp_packet);
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h264.h
@@ -101,6 +101,7 @@ private:
 	bool GeneratePackets();
 	void PacketizeFuA(size_t fragment_index);
 	size_t PacketizeStapA(size_t fragment_index);
+	bool IsAggregationPossible(size_t fragment_index) const;	
 	bool PacketizeSingleNalu(size_t fragment_index);
 	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -284,25 +284,32 @@ void RtpPacketizerH265::NextSingleUnitPacket(RtpPacket* rtp_packet)
 //  |F| Type(6bit)  |LayerID(6bit)|TID(3bit)|
 //  +---------------+-----------------------+
 //    Type = 48 (kHevcAp)
+//    F = OR of all F bits in the aggregated NAL units
+//    LayerID = min of all LayerID values in the aggregated NAL units
+//    TID = min of all TID values in the aggregated NAL units
 void RtpPacketizerH265::NextAggregatePacket(RtpPacket* rtp_packet, bool last) 
 {
 	uint8_t* buffer = rtp_packet->AllocatePayload(last ? _max_payload_len - _last_packet_reduction_len : _max_payload_len);
 	PacketUnit* packet = &_packets.front();
 
-	uint8_t payload_hdr_h = packet->header >> 8;
-	uint8_t payload_hdr_l = packet->header & 0xFF;
-	uint8_t layer_id_h = payload_hdr_h & kHevcLayerIDHMask;
-
-	payload_hdr_h = (payload_hdr_h & kHevcTypeMaskN) | (kHevcAp << 1) | layer_id_h;
-
-	buffer[0] = payload_hdr_h;
-	buffer[1] = payload_hdr_l;
+	uint8_t ap_f        = 0;
+	uint8_t ap_layer_id = 0x3F;  // 6-bit max, replaced by min
+	uint8_t ap_tid      = 0x07;  // 3-bit max, replaced by min
 
 	size_t index = H265_NAL_HEADER_SIZE;
 	bool is_last_fragment = packet->last_fragment;
 	
 	while (packet->aggregated) 
 	{
+		// Accumulate F (OR), LayerID (min), TID (min).
+		uint8_t hdr_h = packet->header >> 8;
+		uint8_t hdr_l = packet->header & 0xFF;
+		ap_f |= (hdr_h & 0x80);
+		uint8_t cur_layer_id = ((hdr_h & kHevcLayerIDHMask) << 5) | (hdr_l >> 3);
+		uint8_t cur_tid      = hdr_l & 0x07;
+		if (cur_layer_id < ap_layer_id) ap_layer_id = cur_layer_id;
+		if (cur_tid      < ap_tid)      ap_tid      = cur_tid;
+
 		const Fragment& fragment = packet->source_fragment;
 		// Add NAL unit length field.
 		ByteWriter<uint16_t>::WriteBigEndian(&buffer[index], fragment.length);
@@ -312,7 +319,6 @@ void RtpPacketizerH265::NextAggregatePacket(RtpPacket* rtp_packet, bool last)
 		index += fragment.length;
 
 		_packets.pop();
-
 		_input_fragments.pop_front();
 
 		if (is_last_fragment)
@@ -322,6 +328,12 @@ void RtpPacketizerH265::NextAggregatePacket(RtpPacket* rtp_packet, bool last)
 		packet = &_packets.front();
 		is_last_fragment = packet->last_fragment;
 	}
+
+	// Write AP PayloadHdr with aggregated F, LayerID, TID.
+	// byte0: F(1) | Type=kHevcAp(6) | LayerID_high(1)
+	// byte1: LayerID_low(5) | TID(3)
+	buffer[0] = ap_f | (kHevcAp << 1) | (ap_layer_id >> 5);
+	buffer[1] = ((ap_layer_id & 0x1F) << 3) | ap_tid;
 	rtp_packet->SetPayloadSize(index);
 }
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -62,7 +62,7 @@ bool RtpPacketizerH265::GeneratePackets()
 					PacketizeFuA(i);
 					++i;
 				} 
-				else if (fragment_len + H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE <= _max_payload_len)
+				else if (IsAggregationPossible(i))
 				{
 					i = PacketizeStapA(i);
 				}
@@ -77,6 +77,36 @@ bool RtpPacketizerH265::GeneratePackets()
 	return true;
 }
 
+bool RtpPacketizerH265::IsAggregationPossible(size_t fragment_index) const
+{
+	if (fragment_index + 1 >= _input_fragments.size())
+	{
+		return false;
+	}
+
+	size_t space_left = _max_payload_len;
+	
+	// First fragment: NAL header (2) + length field (2) + data.
+	const size_t first_needed = H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE + _input_fragments[fragment_index].length;
+
+	if (first_needed > space_left)
+	{
+		return false;
+	}
+	space_left -= first_needed;
+
+	// Second fragment: length field (2) + data.
+	const size_t next_fragment_index = fragment_index + 1;
+	size_t next_needed = H265_LENGTH_FIELD_SIZE + _input_fragments[next_fragment_index].length;
+
+	// If Last fragment, also calculate for _last_packet_reduction_len.
+	if ((next_fragment_index + 1) == _input_fragments.size())
+	{
+		next_needed += _last_packet_reduction_len;
+	}
+
+	return space_left >= next_needed;
+}
 
 void RtpPacketizerH265::PacketizeFuA(size_t fragment_index) 
 {

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -91,6 +91,9 @@ void RtpPacketizerH265::PacketizeFuA(size_t fragment_index)
 	size_t num_packets = (payload_left + extra_len + (per_packet_capacity - 1)) / per_packet_capacity;
 	size_t payload_per_packet = (payload_left + extra_len) / num_packets;
 	size_t num_larger_packets = (payload_left + extra_len) % num_packets;
+#if DEBUG	
+	size_t fragmented_packets = 0;
+#endif
 
 	_num_packets_left += num_packets;
 	while (payload_left > 0) 
@@ -118,16 +121,19 @@ void RtpPacketizerH265::PacketizeFuA(size_t fragment_index)
 		offset += packet_length;
 		payload_left -= packet_length;
 		--num_packets;
+#if DEBUG
+		++fragmented_packets;
+#endif
 	}
 
 #if DEBUG
-	logt("RtpPacketizerH265", "Packetized one fragment into %zu FU-A packets, total size: %zu", _num_packets_left, fragment.length);
+	logt("RtpPacketizerH265", "Packetized one fragment into %zu FU-A packets, total size: %zu", fragmented_packets, fragment.length);
 #endif
 }
 
 size_t RtpPacketizerH265::PacketizeStapA(size_t fragment_index) 
 {
-	// Aggregate fragments into one packet (STAP-A).
+	// Aggregate fragments into one packet (AP).
 	size_t payload_size_left = _max_payload_len;
 	int aggregated_fragments = 0;
 	size_t fragment_headers_length = 0;
@@ -181,7 +187,8 @@ bool RtpPacketizerH265::PacketizeSingleNalu(size_t fragment_index)
 		return false;
 	}
 	
-	_packets.push(PacketUnit(*fragment, true /* first */, true /* last */, false /* aggregated */, fragment->buffer[0]));
+	uint16_t header = (fragment->buffer[0] << 8) | fragment->buffer[1];
+	_packets.push(PacketUnit(*fragment, true /* first */, true /* last */, false /* aggregated */, header));
 	++_num_packets_left;
 
 #if DEBUG

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -62,7 +62,11 @@ bool RtpPacketizerH265::GeneratePackets()
 					PacketizeFuA(i);
 					++i;
 				} 
-				else 
+				else if (fragment_len + H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE <= _max_payload_len)
+				{
+					i = PacketizeStapA(i);
+				}
+				else
 				{
 					PacketizeSingleNalu(i);
 					++i;
@@ -108,13 +112,17 @@ void RtpPacketizerH265::PacketizeFuA(size_t fragment_index)
 		// NAL Header
 		uint16_t header = (fragment.buffer[0] << 8) | fragment.buffer[1];
 		_packets.push(PacketUnit(Fragment(fragment.buffer + offset, packet_length),
-		                         offset - H265_NAL_HEADER_SIZE == 0,
-		                         payload_left == packet_length, 
-								 false, header));
+		                         offset - H265_NAL_HEADER_SIZE == 0 /* first */,
+		                         payload_left == packet_length /* last */, 
+								 false /* aggregated */, header));
 		offset += packet_length;
 		payload_left -= packet_length;
 		--num_packets;
 	}
+
+#if DEBUG
+	logt("RtpPacketizerH265", "Packetized one fragment into %zu FU-A packets, total size: %zu", _num_packets_left, fragment.length);
+#endif
 }
 
 size_t RtpPacketizerH265::PacketizeStapA(size_t fragment_index) 
@@ -126,20 +134,18 @@ size_t RtpPacketizerH265::PacketizeStapA(size_t fragment_index)
 	const Fragment* fragment = &_input_fragments[fragment_index];
 	++_num_packets_left;
 
+	// The header size for the first fragment is  (NAL header size +  length field size),
+	// and for subsequent fragments, only the (length field size) is added.
+	fragment_headers_length = H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE;
+
 	while (payload_size_left >= fragment->length + fragment_headers_length &&
 	       (fragment_index + 1 < _input_fragments.size() ||
 	        payload_size_left >= fragment->length + fragment_headers_length + _last_packet_reduction_len)) 
 	{
-		_packets.push(PacketUnit(*fragment, aggregated_fragments == 0, false, true, fragment->buffer[0]));
+		uint16_t header = (fragment->buffer[0] << 8) | fragment->buffer[1];
+		_packets.push(PacketUnit(*fragment, aggregated_fragments == 0 /* first */, false /* last */, true /* aggregated */, header));
 		payload_size_left -= fragment->length;
 		payload_size_left -= fragment_headers_length;
-
-		fragment_headers_length = H265_LENGTH_FIELD_SIZE;
-
-		if (aggregated_fragments == 0)
-		{	
-			fragment_headers_length += H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE;
-		}
 		++aggregated_fragments;
 
 		// Next fragment.
@@ -149,8 +155,14 @@ size_t RtpPacketizerH265::PacketizeStapA(size_t fragment_index)
 			break;
 		}
 		fragment = &_input_fragments[fragment_index];
+		fragment_headers_length = H265_LENGTH_FIELD_SIZE;
 	}
 	_packets.back().last_fragment = true;
+
+#if DEBUG
+	logt("RtpPacketizerH265", "Packetized %d fragments into AP packet, total size: %zu", aggregated_fragments, _max_payload_len - payload_size_left);
+#endif
+
 	return fragment_index;
 }
 
@@ -171,6 +183,11 @@ bool RtpPacketizerH265::PacketizeSingleNalu(size_t fragment_index)
 	
 	_packets.push(PacketUnit(*fragment, true /* first */, true /* last */, false /* aggregated */, fragment->buffer[0]));
 	++_num_packets_left;
+
+#if DEBUG
+	logt("RtpPacketizerH265", "Packetized one fragment into one single NALU packet, total size: %zu", fragment->length);
+#endif
+
 	return true;
 }
 
@@ -185,12 +202,7 @@ bool RtpPacketizerH265::NextPacket(RtpPacket* rtp_packet)
 	
 	if (packet.first_fragment && packet.last_fragment) 
 	{
-		// Single NAL unit packet.
-		size_t bytes_to_send = packet.source_fragment.length;
-		uint8_t* buffer = rtp_packet->AllocatePayload(bytes_to_send);
-		memcpy(buffer, packet.source_fragment.buffer, bytes_to_send);
-		_packets.pop();
-		_input_fragments.pop_front();
+		NextSingleUnitPacket(rtp_packet);
 	} 
 	else if (packet.aggregated) 
 	{
@@ -208,6 +220,33 @@ bool RtpPacketizerH265::NextPacket(RtpPacket* rtp_packet)
 	return true;
 }
 
+void RtpPacketizerH265::NextSingleUnitPacket(RtpPacket* rtp_packet)
+{
+	PacketUnit& packet = _packets.front();
+	size_t bytes_to_send = packet.source_fragment.length;
+	uint8_t* buffer = rtp_packet->AllocatePayload(bytes_to_send);
+	memcpy(buffer, packet.source_fragment.buffer, bytes_to_send);
+	_packets.pop();
+	_input_fragments.pop_front();
+}
+
+// H.265 AP (Aggregation Packet) structure [RFC 7798]
+//
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      PayloadHdr (Type=48)     |      NALU 1 Size (16bit)      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |           NALU 1 Data (NAL header + RBSP) ...                 |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      NALU 2 Size (16bit)      |  NALU 2 Data ...              |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// PayloadHdr (2 bytes):
+//  +---------------+-----------------------+
+//  |F| Type(6bit)  |LayerID(6bit)|TID(3bit)|
+//  +---------------+-----------------------+
+//    Type = 48 (kHevcAp)
 void RtpPacketizerH265::NextAggregatePacket(RtpPacket* rtp_packet, bool last) 
 {
 	uint8_t* buffer = rtp_packet->AllocatePayload(last ? _max_payload_len - _last_packet_reduction_len : _max_payload_len);

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -47,8 +47,15 @@ bool RtpPacketizerH265::GeneratePackets()
 	{
 		switch (_packetization_mode) 
 		{
-			// For HEVC, doesn't support signle nal unit mode at present.
+			// TODO: Need to check if SingleNALUnit mode is used in H.265
+			// for now, only use PacketizeSingleNalu for H.265, similar to H.264
 			case H26XPacketizationMode::SingleNalUnit:
+				if(!PacketizeSingleNalu(i))
+				{
+					return false;
+				}
+				++i;
+				break;
 			case H26XPacketizationMode::NonInterleaved:
 				size_t fragment_len = _input_fragments[i].length;
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.cpp
@@ -71,7 +71,7 @@ bool RtpPacketizerH265::GeneratePackets()
 				} 
 				else if (IsAggregationPossible(i))
 				{
-					i = PacketizeStapA(i);
+					i = PacketizeAp(i);
 				}
 				else
 				{
@@ -93,7 +93,7 @@ bool RtpPacketizerH265::IsAggregationPossible(size_t fragment_index) const
 
 	size_t space_left = _max_payload_len;
 	
-	// First fragment: NAL header (2) + length field (2) + data.
+	// First fragment: Payload Header(2) + Length Field(2) + Data
 	const size_t first_needed = H265_NAL_HEADER_SIZE + H265_LENGTH_FIELD_SIZE + _input_fragments[fragment_index].length;
 
 	if (first_needed > space_left)
@@ -102,7 +102,7 @@ bool RtpPacketizerH265::IsAggregationPossible(size_t fragment_index) const
 	}
 	space_left -= first_needed;
 
-	// Second fragment: length field (2) + data.
+	// Second fragment: Length field(2) + Data
 	const size_t next_fragment_index = fragment_index + 1;
 	size_t next_needed = H265_LENGTH_FIELD_SIZE + _input_fragments[next_fragment_index].length;
 
@@ -168,7 +168,7 @@ void RtpPacketizerH265::PacketizeFuA(size_t fragment_index)
 #endif
 }
 
-size_t RtpPacketizerH265::PacketizeStapA(size_t fragment_index) 
+size_t RtpPacketizerH265::PacketizeAp(size_t fragment_index) 
 {
 	// Aggregate fragments into one packet (AP).
 	size_t payload_size_left = _max_payload_len;

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
@@ -92,6 +92,7 @@ private:
 	void PacketizeFuA(size_t fragment_index);
 	size_t PacketizeStapA(size_t fragment_index);
 	bool PacketizeSingleNalu(size_t fragment_index);
+	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);
 	void NextFragmentPacket(RtpPacket* rtp_packet);
 

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
@@ -90,11 +90,14 @@ private:
 
 	bool GeneratePackets();
 	void PacketizeFuA(size_t fragment_index);
-	size_t PacketizeStapA(size_t fragment_index);
+	size_t PacketizeStapA(size_t fragment_index);	
+	bool IsAggregationPossible(size_t fragment_index) const;	
 	bool PacketizeSingleNalu(size_t fragment_index);
 	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);
 	void NextFragmentPacket(RtpPacket* rtp_packet);
+
+	
 
 	size_t _max_payload_len;
 	size_t _last_packet_reduction_len;

--- a/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
+++ b/src/projects/modules/rtp_rtcp/rtp_packetizer_h265.h
@@ -90,14 +90,12 @@ private:
 
 	bool GeneratePackets();
 	void PacketizeFuA(size_t fragment_index);
-	size_t PacketizeStapA(size_t fragment_index);	
+	size_t PacketizeAp(size_t fragment_index);	
 	bool IsAggregationPossible(size_t fragment_index) const;	
 	bool PacketizeSingleNalu(size_t fragment_index);
 	void NextSingleUnitPacket(RtpPacket* rtp_packet);
 	void NextAggregatePacket(RtpPacket* rtp_packet, bool last);
 	void NextFragmentPacket(RtpPacket* rtp_packet);
-
-	
 
 	size_t _max_payload_len;
 	size_t _last_packet_reduction_len;


### PR DESCRIPTION
### Summary

Adds support for Aggregation Packets (AP) to the H.264 and H.265 RTP packetizer.
Before, NAL units larger than the MTU were split into FU-A packets, and all others were sent as Single NAL Units.
With this change, multiple NAL units can be combined into one RTP packet. 
This reduces the number of packets and header overhead.

- H.264: STAP-A (RFC 6184, NAL type 24)
- H.265: AP (RFC 7798, NAL type 48)

### Changes
- `GeneratePackets():` Added STAP-A/AP logic : only used when at least two NAL units can be aggregated
- `IsAggregationPossible():` New function to check if multiple fragments can fit into one packet
- `PacketizeStapA():` Fixed a bug in fragment_headers_length initialization (includes H.265 16-bit NAL header handling)
- `NextPacket()`: Moved Single NAL unit logic into a separate function NextSingleUnitPacket()