### PR TITLE
build: push Docker images to both ovenmedialabs and airensoft registries

### DIFF
--- a/.github/workflows/docker-image-dev-multi.yml
+++ b/.github/workflows/docker-image-dev-multi.yml
@@ -19,7 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: airensoft/ovenmediaengine
+  IMAGE_NAME: ovenmedialabs/ovenmediaengine
+  MIRROR_IMAGE_NAME: airensoft/ovenmediaengine
   SLACK_WEBHOOK_URL: ${{ secrets.ACTION_STATE_NOTIFICATION_SLACK_WEBHOOK_URL }}
 
 jobs:
@@ -85,6 +86,12 @@ jobs:
             --tag ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-amd64 \
             .
 
+      - name: Copy amd64 image to airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-amd64 \
+            ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-amd64
+
       - name: Notify Done (amd64)
         if: always()
         uses: slackapi/slack-github-action@v1.26.0
@@ -134,6 +141,12 @@ jobs:
             --tag ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-arm64 \
             .
 
+      - name: Copy arm64 image to airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-arm64 \
+            ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-arm64
+
       - name: Notify Done (arm64)
         if: always()
         uses: slackapi/slack-github-action@v1.26.0
@@ -177,6 +190,13 @@ jobs:
             --tag ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }} \
             ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-amd64 \
             ${{ env.IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-arm64
+
+      - name: Create and push manifest for airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }} \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-amd64 \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ needs.set-vars.outputs.tag }}-arm64
 
       - name: Notify Done (manifest)
         if: always()

--- a/.github/workflows/docker-image-release-multi.yml
+++ b/.github/workflows/docker-image-release-multi.yml
@@ -11,7 +11,8 @@ on:
         type: string
 
 env:
-  IMAGE_NAME: airensoft/ovenmediaengine
+  IMAGE_NAME: ovenmedialabs/ovenmediaengine
+  MIRROR_IMAGE_NAME: airensoft/ovenmediaengine
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
 
 jobs:
@@ -51,6 +52,12 @@ jobs:
             --output=type=image,push=true \
             --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64 \
             .
+
+      - name: Copy amd64 image to airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-amd64 \
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
 
       - name: Notify Done (amd64)
         if: always()
@@ -102,6 +109,12 @@ jobs:
             --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64 \
             .
 
+      - name: Copy arm64 image to airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-arm64 \
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
+
       - name: Notify Done (arm64)
         if: always()
         uses: slackapi/slack-github-action@v1.26.0
@@ -152,7 +165,19 @@ jobs:
             --tag ${{ env.IMAGE_NAME }}:latest \
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64 \
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
-            
+
+      - name: Create and push manifest for airensoft
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }} \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-amd64 \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-arm64
+
+          docker buildx imagetools create \
+            --tag ${{ env.MIRROR_IMAGE_NAME }}:latest \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-amd64 \
+            ${{ env.MIRROR_IMAGE_NAME }}:${{ env.VERSION }}-arm64
+
       - name: Notify Done (manifest)
         if: always()
         uses: slackapi/slack-github-action@v1.26.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   origin:
     build:
       context: .
-    image: airensoft/ovenmediaengine:latest
+    image: ovenmedialabs/ovenmediaengine:latest
     ports:
     - "9000:9000/tcp" # OVT(Origin)
     - "1935:1935/tcp" # RTMP Provider
@@ -34,7 +34,7 @@ services:
   edge:
     build:
       context: .
-    image: airensoft/ovenmediaengine:latest
+    image: ovenmedialabs/ovenmediaengine:latest
     ports:
     - "4333:3333/tcp" # WebRTC Signaling / LLHLS
     - "3479:3479/tcp" # WebRTC TURN

--- a/misc/ome_docker_launcher.sh
+++ b/misc/ome_docker_launcher.sh
@@ -137,7 +137,7 @@ banner()
 }
 
 # Configurations
-IMAGE_NAME=airensoft/ovenmediaengine:latest
+IMAGE_NAME=ovenmedialabs/ovenmediaengine:latest
 CONTAINER_NAME=${CONTAINER_NAME:-ovenmediaengine}
 PREFIX=${PREFIX:-/usr/share/ovenmediaengine/}
 


### PR DESCRIPTION
push docker images to both `ovenmedialabs/ovenmediaengine` (main) and `airensoft/ovenmediaengine` (mirror) registries simultaneously.

- set `ovenmedialabs/ovenmediaengine` as the primary image name (`IMAGE_NAME`)
- set `airensoft/ovenmediaengine` as the mirror image name (`MIRROR_IMAGE_NAME`)
- after each arch build, copy the image to the mirror registry using `docker buildx imagetools create`
- after manifest merge, create and push the manifest to the mirror registry as well
- applies to both dev and release multi-arch workflows