### PR TITLE
fix(webrtc): tighten ICE/STUN/DTLS authentication checks

### DIFF
--- a/src/projects/modules/dtls_srtp/dtls_transport.cpp
+++ b/src/projects/modules/dtls_srtp/dtls_transport.cpp
@@ -72,18 +72,8 @@ void DtlsTransport::SetPeerFingerprint(ov::String algorithm, ov::String fingerpr
 }
 
 // Start DTLS
-bool DtlsTransport::StartDTLS()
+bool DtlsTransport::InitializeTlsLocked()
 {
-	std::lock_guard<std::mutex> lock(_tls_lock);
-
-	/*
-	if(_ice_port->GetState() != IcePortConnectionState::Completed)
-	{
-		_state = SSL_WAIT;
-		return false;
-	}
-	*/
-
 	ov::TlsBioCallback tls_bio_callback =
 		{
 			.read_callback = std::bind(&DtlsTransport::Read, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
@@ -112,6 +102,25 @@ bool DtlsTransport::StartDTLS()
 	}
 
 	_state = SSL_CONNECTING;
+	return true;
+}
+
+bool DtlsTransport::StartDTLS()
+{
+	std::lock_guard<std::mutex> lock(_tls_lock);
+
+	/*
+	if(_ice_port->GetState() != IcePortConnectionState::Completed)
+	{
+		_state = SSL_WAIT;
+		return false;
+	}
+	*/
+
+	if (InitializeTlsLocked() == false)
+	{
+		return false;
+	}
 
 	ContinueSSL();
 
@@ -125,21 +134,27 @@ bool DtlsTransport::ContinueSSL()
 
 	if (error == SSL_ERROR_NONE)
 	{
-		_state = SSL_CONNECTED;
-
 		_peer_certificate = _tls.GetPeerCertificate();
 
 		if (_peer_certificate == nullptr)
 		{
+			_state = SSL_ERROR;
 			return false;
 		}
 
+		// A peer-certificate verification failure means either the legitimate
+		// client is misconfigured (its SDP fingerprint disagrees with its cert)
+		// or an attacker who knows the SDP is racing the ICE bind. Either way,
+		// retrying with the same DTLS context cannot succeed, so terminate the
+		// session and let the client re-negotiate via signaling.
 		if (VerifyPeerCertificate() == false)
 		{
 			logte("Session could not verify peer certificate");
+			_state = SSL_ERROR;
 			return false;
 		}
 
+		_state = SSL_CONNECTED;
 		_peer_certificate->Print();
 
 		return MakeSrtpKey();
@@ -177,8 +192,39 @@ bool DtlsTransport::MakeSrtpKey()
 
 bool DtlsTransport::VerifyPeerCertificate()
 {
-	// TODO(Getroot): Compare and verify the digest received from the PEER CERTIFICATE and SDP.
-	logtt("Accepted peer certificate");
+	// RFC 8122: The DTLS peer certificate fingerprint must match the
+	// fingerprint conveyed via SDP (a=fingerprint).
+	if (_peer_fingerprint_algorithm.IsEmpty() || _peer_fingerprint_value.IsEmpty())
+	{
+		logte("Peer fingerprint is not set; cannot verify DTLS peer certificate");
+		return false;
+	}
+
+	if (_peer_certificate == nullptr)
+	{
+		logte("Peer certificate is missing; cannot verify DTLS peer fingerprint");
+		return false;
+	}
+
+	ov::String computed = _peer_certificate->GetFingerprint(_peer_fingerprint_algorithm);
+	if (computed.IsEmpty())
+	{
+		logte("Failed to compute peer certificate fingerprint with algorithm: %s", _peer_fingerprint_algorithm.CStr());
+		return false;
+	}
+
+	ov::String expected = _peer_fingerprint_value;
+	expected.MakeUpper();
+	computed.MakeUpper();
+
+	if (expected != computed)
+	{
+		logte("DTLS peer certificate fingerprint mismatch (algorithm: %s, expected: %s, actual: %s)",
+			  _peer_fingerprint_algorithm.CStr(), expected.CStr(), computed.CStr());
+		return false;
+	}
+
+	logti("DTLS peer certificate verified (%s)", _peer_fingerprint_algorithm.CStr());
 	_peer_certificate_verified = true;
 	return true;
 }

--- a/src/projects/modules/dtls_srtp/dtls_transport.h
+++ b/src/projects/modules/dtls_srtp/dtls_transport.h
@@ -56,6 +56,9 @@ protected:
 
 private:
 	bool ContinueSSL();
+	// Initializes the underlying TLS session and BIO and transitions to
+	// SSL_CONNECTING. Caller MUST hold _tls_lock.
+	bool InitializeTlsLocked();
 	bool IsDtlsPacket(const std::shared_ptr<const ov::Data> data);
 	bool IsRtpPacket(const std::shared_ptr<const ov::Data> data);
 	bool SaveDtlsPacket(const std::shared_ptr<const ov::Data> data);

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -947,17 +947,19 @@ bool IcePort::OnReceivedStunBindingRequest(const std::shared_ptr<ov::Socket> &re
 
 	if (ice_session->GetPeerSdp()->GetIceUfrag() != peer_ufrag)
 	{
-		logtw("Mismatched ufrag: %s (ufrag in peer SDP: %s)", peer_ufrag.CStr(), ice_session->GetPeerSdp()->GetIceUfrag().CStr());
+		logtw("Rejecting STUN binding request from %s: peer ufrag mismatch (received: %s, expected: %s)",
+			  address_pair.ToString().CStr(), peer_ufrag.CStr(), ice_session->GetPeerSdp()->GetIceUfrag().CStr());
+		return false;
 	}
 
 	if (message.CheckIntegrity(ice_session->GetLocalSdp()->GetIcePwd()) == false)
 	{
-		logtw("Failed to check integrity");
-
-		ice_session->SetState(IceConnectionState::Failed);
-		NotifyIceSessionStateChanged(ice_session);
-		RemoveSession(ice_session->GetSessionID());
-
+		// RFC 8445 §7.3 / RFC 5389 §10.1.2: a request that fails integrity
+		// verification MUST be silently discarded. Tearing down the legitimate
+		// session here would let an off-path attacker who only knows the public
+		// ufrag (e.g. via STUN sniffing) DoS the victim by sending a forged
+		// request with a bad MESSAGE-INTEGRITY.
+		logtw("Failed to check integrity for STUN binding request from %s (silently dropped)", address_pair.ToString().CStr());
 		return false;
 	}
 
@@ -1135,9 +1137,13 @@ bool IcePort::OnReceivedStunBindingResponse(const std::shared_ptr<ov::Socket> &r
 
 	logtt("Receive stun binding response from %s, table size(%zu)", address_pair.ToString().CStr(), _binding_requests_with_transaction_id.size());
 
-	if (message.CheckIntegrity(ice_session->GetLocalSdp()->GetIcePwd()) == false)
+	// The binding response is signed by the peer with the same password the
+	// request was signed with (RFC 5389 §10.1.2). OME signs outgoing binding
+	// requests with the peer's ICE password (see SendStunBindingRequest), so
+	// verify the response with the peer's password.
+	if (message.CheckIntegrity(ice_session->GetPeerSdp()->GetIcePwd()) == false)
 	{
-		logtw("Failed to check integrity");
+		logtw("Failed to check integrity for STUN binding response from %s", address_pair.ToString().CStr());
 		return false;
 	}
 

--- a/src/projects/modules/ice/stun/stun_message.cpp
+++ b/src/projects/modules/ice/stun/stun_message.cpp
@@ -36,8 +36,6 @@ bool StunMessage::Parse(ov::ByteStream &stream)
 {
 	_parsed = true;
 
-	ov::ByteStream copied_stream(stream);
-
 	// Capture the start of the STUN message (works for both writable and
 	// read-only byte streams) so we can replay the raw bytes later when
 	// verifying MESSAGE-INTEGRITY.
@@ -57,6 +55,8 @@ bool StunMessage::Parse(ov::ByteStream &stream)
 		}
 	}
 
+	// FINGERPRINT pre-check is intentionally disabled — magic cookie already
+	// distinguishes STUN from non-STUN traffic.
 	// _parsed = _parsed && ValidateFingerprint(copied_stream);
 
 	_parsed = _parsed && ParseAttributes(stream, message_start_offset);
@@ -185,12 +185,10 @@ bool StunMessage::ParseAttributes(ov::ByteStream &stream, off_t message_start_of
 			return false;
 		}
 
-		// Track the position of MESSAGE-INTEGRITY so it can be re-verified later.
-		// MESSAGE-INTEGRITY may appear only once per RFC 5389/8489.
+		// Record first MESSAGE-INTEGRITY position for HMAC verification.
 		if (attribute->GetType() == StunAttributeType::MessageIntegrity && _integrity_attribute_offset < 0)
 		{
 			_integrity_attribute_offset = attribute_start - message_start_offset;
-			_integrity_attribute = attribute;
 		}
 
 		_attributes.push_back(std::move(attribute));
@@ -479,18 +477,18 @@ bool StunMessage::IsValid() const
 
 bool StunMessage::CheckIntegrity(const ov::String &password) const
 {
-	// RFC 5389/8489, Section 15.4 (MESSAGE-INTEGRITY)
-	// HMAC-SHA-1 covers the STUN message starting from the header (with the
-	// Message Length field adjusted to indicate the length up to and including
-	// MESSAGE-INTEGRITY) up to but not including the MESSAGE-INTEGRITY attribute itself.
-
-	// Detailed reasons are logged at trace level only — the caller already logs
-	// the rejected packet with full context (peer address, ufrag) at warn level,
-	// so emitting another warn here would just duplicate noise on every attack
-	// packet without adding identifying information.
-	if (_integrity_attribute == nullptr || _integrity_attribute_offset < 0)
+	// RFC 5389 §15.4: MESSAGE-INTEGRITY HMAC-SHA1 verification.
+	// Logs trace-only; the caller logs with full context.
+	if (_integrity_attribute_offset < 0)
 	{
 		logtt("STUN message has no MESSAGE-INTEGRITY attribute");
+		return false;
+	}
+
+	const auto *mi_attribute = GetAttribute<StunMessageIntegrityAttribute>(StunAttributeType::MessageIntegrity);
+	if (mi_attribute == nullptr)
+	{
+		logtt("MESSAGE-INTEGRITY attribute lookup failed");
 		return false;
 	}
 
@@ -506,7 +504,6 @@ bool StunMessage::CheckIntegrity(const ov::String &password) const
 		return false;
 	}
 
-	const auto *mi_attribute = static_cast<const StunMessageIntegrityAttribute *>(_integrity_attribute.get());
 	const size_t header_length = static_cast<size_t>(DefaultHeaderLength());
 	const size_t hmac_input_length = static_cast<size_t>(_integrity_attribute_offset);
 
@@ -520,9 +517,7 @@ bool StunMessage::CheckIntegrity(const ov::String &password) const
 	// Make a mutable copy of the bytes that need to be HMAC'd.
 	auto hmac_input = std::make_shared<ov::Data>(_raw_message->GetData(), hmac_input_length);
 
-	// Patch the Message Length field so it reflects the byte count up to and
-	// including the MESSAGE-INTEGRITY attribute (header + hash). This matches
-	// what the sender used when computing the HMAC.
+	// Patch the Message Length to include MI (matches sender's HMAC input).
 	const size_t mi_length_with_header = static_cast<size_t>(mi_attribute->GetLength(true, true));
 	const size_t adjusted_length = (hmac_input_length - header_length) + mi_length_with_header;
 	if (adjusted_length > 0xFFFF)

--- a/src/projects/modules/ice/stun/stun_message.cpp
+++ b/src/projects/modules/ice/stun/stun_message.cpp
@@ -8,11 +8,14 @@
 //==============================================================================
 #include "stun_message.h"
 
+#include <openssl/crypto.h>
+
 #include <base/ovcrypto/ovcrypto.h>
 #include <base/ovlibrary/ovlibrary.h>
 
 #include "modules/ice/ice.h"
 #include "modules/ice/stun/attributes/stun_fingerprint_attribute.h"
+#include "modules/ice/stun/attributes/stun_message_integrity_attribute.h"
 #include "stun_private.h"
 
 StunMessage::StunMessage()
@@ -33,17 +36,30 @@ bool StunMessage::Parse(ov::ByteStream &stream)
 {
 	_parsed = true;
 
-	// Fingerprint를 처리하는 과정에서 stream의 offset이 변경되므로, 별도의 stream 생성
 	ov::ByteStream copied_stream(stream);
 
-	// 헤더 길이 정보 분석 및 헤더를 먼저 읽음
+	// Capture the start of the STUN message (works for both writable and
+	// read-only byte streams) so we can replay the raw bytes later when
+	// verifying MESSAGE-INTEGRITY.
+	off_t message_start_offset = stream.GetOffset();
+	const uint8_t *raw_message_ptr = stream.CurrentBuffer<uint8_t>();
+	size_t available_bytes = stream.Remained();
+
 	_parsed = _parsed && ParseHeader(stream);
 
-	// STUN 패킷인지를 빠르게 판단하기 위해, finger print를 먼저 계산해봄 (CRC는 stream의 뒷 부분을 탐색하여 계산하기 때문에, 복사해놓음 stream을 사용함)
-	//_parsed = _parsed && ValidateFingerprint(copied_stream);
+	if (_parsed)
+	{
+		// Snapshot the raw STUN message (header + attributes) for MESSAGE-INTEGRITY verification.
+		size_t total_size = static_cast<size_t>(DefaultHeaderLength()) + _message_length;
+		if (raw_message_ptr != nullptr && total_size <= available_bytes)
+		{
+			_raw_message = std::make_shared<ov::Data>(raw_message_ptr, total_size);
+		}
+	}
 
-	// 나머지 attribute들 파싱
-	_parsed = _parsed && ParseAttributes(stream);
+	// _parsed = _parsed && ValidateFingerprint(copied_stream);
+
+	_parsed = _parsed && ParseAttributes(stream, message_start_offset);
 
 	return _parsed;
 }
@@ -147,7 +163,7 @@ bool StunMessage::ParseHeader(ov::ByteStream &stream)
 	return true;
 }
 
-bool StunMessage::ParseAttributes(ov::ByteStream &stream)
+bool StunMessage::ParseAttributes(ov::ByteStream &stream, off_t message_start_offset)
 {
 	// Under normal circumstances, fingerprint attribute must be parsed.
 	// OV_ASSERT2(_fingerprint_attribute != nullptr);
@@ -159,12 +175,22 @@ bool StunMessage::ParseAttributes(ov::ByteStream &stream)
 	// Parsing starts when the minimum data is found
 	while (stream.Remained() >= minimum_length)
 	{
+		off_t attribute_start = stream.GetOffset();
+
 		std::shared_ptr<StunAttribute> attribute = StunAttribute::CreateAttribute(this, stream);
 
 		if (attribute == nullptr)
 		{
 			logtw("Could not parse attribute");
 			return false;
+		}
+
+		// Track the position of MESSAGE-INTEGRITY so it can be re-verified later.
+		// MESSAGE-INTEGRITY may appear only once per RFC 5389/8489.
+		if (attribute->GetType() == StunAttributeType::MessageIntegrity && _integrity_attribute_offset < 0)
+		{
+			_integrity_attribute_offset = attribute_start - message_start_offset;
+			_integrity_attribute = attribute;
 		}
 
 		_attributes.push_back(std::move(attribute));
@@ -453,7 +479,84 @@ bool StunMessage::IsValid() const
 
 bool StunMessage::CheckIntegrity(const ov::String &password) const
 {
-	// RFC 5389, section 15.4 참고
+	// RFC 5389/8489, Section 15.4 (MESSAGE-INTEGRITY)
+	// HMAC-SHA-1 covers the STUN message starting from the header (with the
+	// Message Length field adjusted to indicate the length up to and including
+	// MESSAGE-INTEGRITY) up to but not including the MESSAGE-INTEGRITY attribute itself.
+
+	// Detailed reasons are logged at trace level only — the caller already logs
+	// the rejected packet with full context (peer address, ufrag) at warn level,
+	// so emitting another warn here would just duplicate noise on every attack
+	// packet without adding identifying information.
+	if (_integrity_attribute == nullptr || _integrity_attribute_offset < 0)
+	{
+		logtt("STUN message has no MESSAGE-INTEGRITY attribute");
+		return false;
+	}
+
+	if (_raw_message == nullptr)
+	{
+		logtt("Raw STUN message is not available for MESSAGE-INTEGRITY verification");
+		return false;
+	}
+
+	if (password.IsEmpty())
+	{
+		logtt("Empty password provided for STUN MESSAGE-INTEGRITY verification");
+		return false;
+	}
+
+	const auto *mi_attribute = static_cast<const StunMessageIntegrityAttribute *>(_integrity_attribute.get());
+	const size_t header_length = static_cast<size_t>(DefaultHeaderLength());
+	const size_t hmac_input_length = static_cast<size_t>(_integrity_attribute_offset);
+
+	if (hmac_input_length < header_length || hmac_input_length > _raw_message->GetLength())
+	{
+		logtt("Invalid MESSAGE-INTEGRITY position in STUN message: offset=%jd, raw_size=%zu",
+			  static_cast<intmax_t>(_integrity_attribute_offset), _raw_message->GetLength());
+		return false;
+	}
+
+	// Make a mutable copy of the bytes that need to be HMAC'd.
+	auto hmac_input = std::make_shared<ov::Data>(_raw_message->GetData(), hmac_input_length);
+
+	// Patch the Message Length field so it reflects the byte count up to and
+	// including the MESSAGE-INTEGRITY attribute (header + hash). This matches
+	// what the sender used when computing the HMAC.
+	const size_t mi_length_with_header = static_cast<size_t>(mi_attribute->GetLength(true, true));
+	const size_t adjusted_length = (hmac_input_length - header_length) + mi_length_with_header;
+	if (adjusted_length > 0xFFFF)
+	{
+		logtt("Adjusted STUN message length is too large: %zu", adjusted_length);
+		return false;
+	}
+
+	auto *buffer = hmac_input->GetWritableDataAs<uint8_t>();
+	auto *length_field = reinterpret_cast<uint16_t *>(buffer + sizeof(uint16_t));
+	*length_field = ov::HostToNetwork16(static_cast<uint16_t>(adjusted_length));
+
+	auto integrity_key = password.ToData(false);
+	if (integrity_key == nullptr)
+	{
+		return false;
+	}
+
+	uint8_t computed_hash[OV_STUN_HASH_LENGTH];
+	if (ov::MessageDigest::ComputeHmac(ov::CryptoAlgorithm::Sha1,
+									   integrity_key->GetData(), integrity_key->GetLength(),
+									   hmac_input->GetData(), hmac_input->GetLength(),
+									   computed_hash, OV_STUN_HASH_LENGTH) == false)
+	{
+		logtt("Failed to compute HMAC-SHA1 for STUN MESSAGE-INTEGRITY verification");
+		return false;
+	}
+
+	if (::CRYPTO_memcmp(computed_hash, mi_attribute->GetHash(), OV_STUN_HASH_LENGTH) != 0)
+	{
+		logtt("STUN MESSAGE-INTEGRITY mismatch");
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/projects/modules/ice/stun/stun_message.h
+++ b/src/projects/modules/ice/stun/stun_message.h
@@ -105,7 +105,7 @@ public:
 
 protected:
 	
-	bool ParseAttributes(ov::ByteStream &stream);
+	bool ParseAttributes(ov::ByteStream &stream, off_t message_start_offset = 0);
 	std::shared_ptr<StunAttribute> ParseFingerprintAttribute(ov::ByteStream &stream);
 
 	bool WriteHeader(ov::ByteStream &stream);
@@ -129,6 +129,11 @@ protected:
 
 	std::shared_ptr<StunAttribute> _integrity_attribute;
 	std::shared_ptr<StunAttribute> _fingerprint_attribute;
+
+	// Raw STUN message bytes captured during Parse() for MESSAGE-INTEGRITY verification.
+	std::shared_ptr<ov::Data> _raw_message;
+	// Offset of MESSAGE-INTEGRITY attribute (from the beginning of the STUN header) within _raw_message; -1 if not present.
+	off_t _integrity_attribute_offset = -1;
 
 	// Last error codes
 	LastErrorCode	_last_error_code = NOT_USED;

--- a/src/projects/providers/webrtc/webrtc_stream.cpp
+++ b/src/projects/providers/webrtc/webrtc_stream.cpp
@@ -110,6 +110,18 @@ namespace pvd
 		_srtp_transport = std::make_shared<SrtpTransport>();
 		_dtls_transport = std::make_shared<DtlsTransport>();
 		_dtls_transport->SetLocalCertificate(_certificate);
+
+		// Bind the peer fingerprint advertised in the remote SDP so that the
+		// DTLS handshake refuses any peer whose certificate digest does not match.
+		ov::String peer_fingerprint_algorithm = _remote_sdp->GetFingerprintAlgorithm();
+		ov::String peer_fingerprint_value = _remote_sdp->GetFingerprintValue();
+		if (peer_fingerprint_algorithm.IsEmpty() || peer_fingerprint_value.IsEmpty())
+		{
+			logte("Remote SDP does not include a DTLS fingerprint; refusing to start DTLS");
+			return false;
+		}
+		_dtls_transport->SetPeerFingerprint(peer_fingerprint_algorithm, peer_fingerprint_value);
+
 		_dtls_transport->StartDTLS();
 
 		// RFC3264

--- a/src/projects/publishers/webrtc/rtc_session.cpp
+++ b/src/projects/publishers/webrtc/rtc_session.cpp
@@ -99,6 +99,18 @@ bool RtcSession::Start()
 	_dtls_transport = std::make_shared<DtlsTransport>();
 	std::shared_ptr<RtcApplication> application = std::static_pointer_cast<RtcApplication>(GetApplication());
 	_dtls_transport->SetLocalCertificate(application->GetCertificate());
+
+	// Bind the peer fingerprint advertised in the remote (player) SDP so the
+	// DTLS handshake refuses any peer whose certificate digest does not match.
+	ov::String peer_fingerprint_algorithm = _peer_sdp->GetFingerprintAlgorithm();
+	ov::String peer_fingerprint_value = _peer_sdp->GetFingerprintValue();
+	if (peer_fingerprint_algorithm.IsEmpty() || peer_fingerprint_value.IsEmpty())
+	{
+		logte("Peer SDP does not include a DTLS fingerprint; refusing to start DTLS");
+		return false;
+	}
+	_dtls_transport->SetPeerFingerprint(peer_fingerprint_algorithm, peer_fingerprint_value);
+
 	_dtls_transport->StartDTLS();
 
 	bool transport_cc_enabled = false;


### PR DESCRIPTION
## Summary
Adds the ICE/STUN/DTLS authentication checks that were partially missing
from the WebRTC ingest path, as reported in #2086.

## Threat model
An attacker who can sniff UDP STUN packets between the victim and OME
(typically requires presence on the same L2 segment) can inject forged
STUN packets to hijack the session and either push their own media in
place of a publisher, or receive the stream OME was sending to a player.

## Changes
- Reject STUN binding requests with a peer ufrag that does not match the SDP (RFC 8445 §7.1.2).
- Verify STUN MESSAGE-INTEGRITY HMAC-SHA1 (RFC 5389 §15.4); failed packets are silently dropped (RFC 8445 §7.3).
- Verify the DTLS peer certificate digest against the SDP `a=fingerprint` (RFC 8122).
- Verify STUN binding responses with the peer's ICE password (RFC 5389 §10.1.2).

Refs #2086