### PR TITLE
docs: update all references from AirenSoft to OvenMediaLabs

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -8,7 +8,7 @@ By submitting a Contribution, You accept and agree to the following terms and co
 
 * **"You"** (or **"Your"**): The copyright owner or legal entity authorized by the copyright owner that is making this Agreement.
 * **"Contribution"**: Any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in the software or documentation.
-* **"Project"**: The OvenMediaEngine project managed by AirenSoft Inc.
+* **"Project"**: The OvenMediaEngine project managed by OvenMedia Labs Inc.
 
 **2. Grant of Copyright License**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you!
 And all other contributions that make our project better!
 
 ## Communication
-The first communication channel we use is GitHub Issues. If you have any problem or question using OvenMediaEngine and OvenPlayer, please describe it on AirenSoft GitHub Issues. Our open-source community is lively, so developers who see your inquiry will respond as soon as possible.
+The first communication channel we use is GitHub Issues. If you have any problem or question using OvenMediaEngine and OvenPlayer, please describe it on OvenMediaLabs GitHub Issues. Our open-source community is lively, so developers who see your inquiry will respond as soon as possible.
 Also, if your question helped someone who uses our open-source community, we think it's a great contribution.
 
 ---
@@ -31,27 +31,27 @@ If you have any ideas about technology trends that can advance OvenMediaEngine a
 
 ### Testing
 After the OvenMediaEngine and OvenPlayer updates, we may request you to test as we have responsibility for ensuring stability in more environments. Therefore, we would be very grateful if you could help us run the test.
-- [For OvenMediaEngine](https://github.com/AirenSoft/OvenMediaEngine/issues)
-- [For OvenPlayer](https://github.com/AirenSoft/OvenPlayer/issues)
+- [For OvenMediaEngine](https://github.com/OvenMediaLabs/OvenMediaEngine/issues)
+- [For OvenPlayer](https://github.com/OvenMediaLabs/OvenPlayer/issues)
 
 ---
 ### Improving Documentation
 We are not a perfectly English-speaking team. Therefore, there may be typos, grammatical awkwardness, or incomprehensible sentences in our documents. Please let us know if you find them.
 Or, if you would like to translate our documents into a language other than English, we welcome your work!
-- [OvenMediaEngine GitBook](https://airensoft.gitbook.io/ovenmediaengine/)
-- [OvenPlayer GitBook](https://airensoft.gitbook.io/ovenplayer/)
+- [OvenMediaEngine GitBook](https://docs.ovenmediaengine.com/)
+- [OvenPlayer GitBook](https://docs.ovenplayer.com/)
 
 ---
 ### Spreading & Use Cases
 If you like our open-source project, if you have made something with our open-source, or if our open-source has helped you, please let people know about OvenMediaEngine and OvenPlayer.
 And we are love to hear about your experience and story using OvenMediaEngine and OvenPlayer, like why you chose this, how to use this, and more. You know, the voices of real contributors are of great help to our project.
-- <contact@airensoft.com>
+- <contact@ovenmedialabs.com>
 
 ---
 ### Recurring Donations
 If you want to help us continue developing OvenMediaEngine and OvenPlayer, or if our open-source has helped your business, please support us through GitHub Sponsor or Open Collective.
 Your financial contribution to OvenMediaEngine and OvenPlayer will be used to reward the developer's efforts, cover the cost of servers and hardware that are continuously used, and attend related exhibitions. And these are transparent, publicly visible, and is used to develop our open-source projects.
-- [GitHub Sponsor](https://github.com/AirenSoft)
+- [GitHub Sponsor](https://github.com/OvenMediaLabs)
 - [Open Collective](https://opencollective.com/ovenmediaengine)
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With OvenMediaEngine, you can build your powerful and sub-second latency media s
 ## Demo https://space.ovenplayer.com/
 <img src="dist/05_OvenSpace_230214.png" style="max-width: 100%; height: auto;">
 
-OvenSpace is a sub-second latency streaming demo service using [OvenMediaEngine](https://github.com/AirenSoft/OvenMediaEngine), [OvenPlayer](https://github.com/AirenSoft/OvenPlayer) and [OvenLiveKit](https://github.com/AirenSoft/OvenLiveKit-Web). You can experience OvenMediaEngine in the **[OvenSpace Demo](https://space.ovenplayer.com/)** and see examples of applying in [OvenSpace Repository](https://github.com/AirenSoft/OvenSpace).
+OvenSpace is a sub-second latency streaming demo service using [OvenMediaEngine](https://github.com/OvenMediaLabs/OvenMediaEngine), [OvenPlayer](https://github.com/OvenMediaLabs/OvenPlayer) and [OvenLiveKit](https://github.com/OvenMediaLabs/OvenLiveKit-Web). You can experience OvenMediaEngine in the **[OvenSpace Demo](https://space.ovenplayer.com/)** and see examples of applying in [OvenSpace Repository](https://github.com/OvenMediaLabs/OvenSpace).
 
 ## Features
 * Ingest
@@ -61,7 +61,7 @@ OvenSpace is a sub-second latency streaming demo service using [OvenMediaEngine]
 We have tested OvenMediaEngine on the platforms listed below.
 Although we have tested OvenMediaEngine on the platforms listed below, it may work with other Linux packages as well:
 
-* [Docker](https://hub.docker.com/r/airensoft/ovenmediaengine)
+* [Docker](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine)
 * Ubuntu 18+
 * Rocky Linux 8+
 * AlmaLinux 8+
@@ -69,14 +69,14 @@ Although we have tested OvenMediaEngine on the platforms listed below, it may wo
 
 ## Quick Start
 
-* [Quick Start Guide](https://airensoft.gitbook.io/ovenmediaengine/quick-start)
-* [Manual](https://airensoft.gitbook.io/ovenmediaengine/)
+* [Quick Start Guide](https://docs.ovenmediaengine.com/quick-start)
+* [Manual](https://docs.ovenmediaengine.com/)
 
 ### Docker
 ```bash
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
-airensoft/ovenmediaengine:latest
+ovenmedialabs/ovenmediaengine:latest
 ```
 
 You can also store the configuration files on your host:
@@ -86,7 +86,7 @@ docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
 -v ome-origin-conf:/opt/ovenmediaengine/bin/origin_conf \
 -v ome-edge-conf:/opt/ovenmediaengine/bin/edge_conf \
-airensoft/ovenmediaengine:latest
+ovenmedialabs/ovenmediaengine:latest
 ```
 
 The configuration files are now accessible under `/var/lib/docker/volumes/<volume_name>/_data`.
@@ -99,7 +99,7 @@ ln -s /var/lib/docker/volumes/ome-origin-conf/_data/ /my/new/path/to/ome-origin-
 && ln -s /var/lib/docker/volumes/ome-edge-conf/_data/ /my/new/path/to/ome-edge-conf
 ```
 
-Please read the [Getting Started](https://airensoft.gitbook.io/ovenmediaengine/getting-started) for more information.
+Please read the [Getting Started](https://docs.ovenmediaengine.com/getting-started) for more information.
 
 ### WebRTC Live Encoder for Testing
 * https://demo.ovenplayer.com/demo_input.html
@@ -114,41 +114,41 @@ Thank you so much for being so interested in OvenMediaEngine.
 We need your help to keep and develop our open-source project, and we want to tell you that you can contribute in many ways.
 For more information on how to contribute, please see our [Guidelines](CONTRIBUTING.md), [Rules](CODE_OF_CONDUCT.md), and [Contribute](https://www.ovenmediaengine.com/contribute).
 
-- [Finding Bugs](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#finding-bugs)
-- [Reviewing Code](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#reviewing-code)
-- [Sharing Ideas](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#sharing-ideas)
-- [Testing](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#testing)
-- [Improving Documentation](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#improving-documentation)
-- [Spreading & Use Cases](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#spreading--use-cases)
-- [Recurring Donations](https://github.com/AirenSoft/OvenMediaEngine/blob/master/CONTRIBUTING.md#recurring-donations)
+- [Finding Bugs](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#finding-bugs)
+- [Reviewing Code](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#reviewing-code)
+- [Sharing Ideas](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#sharing-ideas)
+- [Testing](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#testing)
+- [Improving Documentation](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#improving-documentation)
+- [Spreading & Use Cases](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#spreading--use-cases)
+- [Recurring Donations](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#recurring-donations)
 
 We always hope that OvenMediaEngine will give you good inspiration.
 
 ## For more information
-* [AirenSoft Website](https://airensoft.com) 
+* [OvenMedia Labs Website](https://ovenmedialabs.com) 
   * About OvenMediaEngine, OvenMediaEngine Enterprise, OvenVideo, AirenBlog and more
-* [OvenMediaEngine Getting Started](https://airensoft.gitbook.io/ovenmediaengine/)
+* [OvenMediaEngine Getting Started](https://docs.ovenmediaengine.com/)
   * User guide for OvenMediaEngine Configuration, ABR, Clustering, and more
-* [OvenMediaEngine Docker Hub](https://hub.docker.com/r/airensoft/ovenmediaengine)
+* [OvenMediaEngine Docker Hub](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine)
   * Install and use OvenMeidaEngine easily using Docker
-* [OvenPlayer GitHub](https://github.com/AirenSoft/OvenPlayer)
+* [OvenPlayer GitHub](https://github.com/OvenMediaLabs/OvenPlayer)
   * JavaScript-based Player with LLHLS and WebRTC
-* [OvenPlayer Getting Started](https://airensoft.gitbook.io/ovenplayer)
+* [OvenPlayer Getting Started](https://docs.ovenplayer.com)
   * User guide for OvenPlayer UI Customize, API Reference, Examples, and more
-* [OvenLiveKit](https://github.com/AirenSoft/OvenLiveKit-Web)
+* [OvenLiveKit](https://github.com/OvenMediaLabs/OvenLiveKit-Web)
   * JavaScript-based Live Streaming Encoder for OvenMediaEngine
 * [OvenSpace Demo](https://space.ovenplayer.com/)
   * Sub-Second Latency Streaming Demo Service
 
 ## License
 OvenMediaEngine is licensed under the [AGPL-3.0-only](LICENSE).
-However, if you need another license, please feel free to email us at [contact@airensoft.com](mailto:contact@airensoft.com).
+However, if you need another license, please feel free to email us at [contact@ovenmedialabs.com](mailto:contact@ovenmedialabs.com).
 
-## About AirenSoft
-AirenSoft aims to make it easier for you to build a stable broadcasting/streaming service with Sub-Second Latency.
+## About OvenMedia Labs
+OvenMedia Labs aims to make it easier for you to build a stable broadcasting/streaming service with Sub-Second Latency.
 Therefore, we will continue developing and providing the most optimized tools for smooth Sub-Second Latency Streaming.
 
 Would you please click on each link below for details:
-* ["JavaScript-based Live Streaming Encoder" **OvenLiveKit**](https://github.com/AirenSoft/OvenLiveKit-Web)
-* ["Sub-Second Latency Streaming Server with LLHLS and WebRTC" **OvenMediaEngine**](https://github.com/AirenSoft/OvenMediaEngine)
-* ["JavaScript-based Player with LLHLS and WebRTC" **OvenPlayer**](https://github.com/AirenSoft/OvenPlayer)
+* ["JavaScript-based Live Streaming Encoder" **OvenLiveKit**](https://github.com/OvenMediaLabs/OvenLiveKit-Web)
+* ["Sub-Second Latency Streaming Server with LLHLS and WebRTC" **OvenMediaEngine**](https://github.com/OvenMediaLabs/OvenMediaEngine)
+* ["JavaScript-based Player with LLHLS and WebRTC" **OvenPlayer**](https://github.com/OvenMediaLabs/OvenPlayer)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,11 @@
 
 ## What is OvenMediaEngine?
 
-[**OvenMediaEngine**](https://github.com/AirenSoft/OvenMediaEngine) (OME) is a **Sub**-**Second Latency Live Streaming Server** with **Large**-**Scale** and **High**-**Definition**. With OME, you can create platforms/services/systems that transmit high-definition video to hundreds-thousand viewers with sub-second latency and be scalable, depending on the number of concurrent viewers.
+[**OvenMediaEngine**](https://github.com/OvenMediaLabs/OvenMediaEngine) (OME) is a **Sub**-**Second Latency Live Streaming Server** with **Large**-**Scale** and **High**-**Definition**. With OME, you can create platforms/services/systems that transmit high-definition video to hundreds-thousand viewers with sub-second latency and be scalable, depending on the number of concurrent viewers.
 
 <figure><img src=".gitbook/assets/OME_LLHLS_220610.png" alt=""><figcaption></figcaption></figure>
 
-OvenMediaEngine can receive a video/audio, video, or audio source from encoders and cameras such as [OvenLiveKit](https://www.ovenmediaengine.com/olk), OBS, XSplit, and more, to WebRTC, SRT, RTMP, MPEG-2 TS, and RTSP as Input. Then, OME transmits this source using **LLHLS** (Low Latency HLS) and **WebRTC** as output. Also, we provide [OvenPlayer](https://github.com/AirenSoft/OvenPlayer), an Open-Source and JavaScript-based WebRTC/LLHLS Player for OvenMediaEngine.
+OvenMediaEngine can receive a video/audio, video, or audio source from encoders and cameras such as [OvenLiveKit](https://www.ovenmediaengine.com/olk), OBS, XSplit, and more, to WebRTC, SRT, RTMP, MPEG-2 TS, and RTSP as Input. Then, OME transmits this source using **LLHLS** (Low Latency HLS) and **WebRTC** as output. Also, we provide [OvenPlayer](https://github.com/OvenMediaLabs/OvenPlayer), an Open-Source and JavaScript-based WebRTC/LLHLS Player for OvenMediaEngine.
 
 Our goal is to make it easier for you to build a stable broadcasting/streaming service with sub-second latency.
 
@@ -59,7 +59,7 @@ Our goal is to make it easier for you to build a stable broadcasting/streaming s
 
 We have tested OvenMediaEngine on platforms, listed below. However, we think it can work with other Linux packages as well:
 
-* Docker ([https://hub.docker.com/r/airensoft/ovenmediaengine](https://hub.docker.com/r/airensoft/ovenmediaengine))
+* Docker ([https://hub.docker.com/r/ovenmedialabs/ovenmediaengine](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine))
 * Ubuntu 18+
 * Rocky Linux 8+
 * AlmaLinux 8+
@@ -87,15 +87,15 @@ We always hope that OvenMediaEngine will give you good inspiration.
 
 ## For more information
 
-* [OvenMediaEngine GitHub](https://github.com/AirenSoft/OvenMediaEngine)
+* [OvenMediaEngine GitHub](https://github.com/OvenMediaLabs/OvenMediaEngine)
 * [OvenMediaEngine Website](https://ovenmediaengine.com)
-* [OvenMediaEngine Tutorial Source](https://github.com/AirenSoft/OvenMediaEngineDocs)
+* [OvenMediaEngine Tutorial Source](https://github.com/OvenMediaLabs/OvenMediaEngineDocs)
 * Test Player
   * _Without TLS:_ [_http://demo.ovenplayer.com_](http://demo.ovenplayer.com)
   * _With TLS:_ [_https://demo.ovenplayer.com_](https://demo.ovenplayer.com)
-* [OvenPlayer Github](https://github.com/AirenSoft/OvenPlayer)
-* [AirenSoft Website](https://www.airensoft.com)
+* [OvenPlayer Github](https://github.com/OvenMediaLabs/OvenPlayer)
+* [OvenMedia Labs Website](https://www.ovenmedialabs.com)
 
 ## License
 
-OvenMediaEngine is licensed under the [AGPL-3.0-only](../LICENSE/). However, if you need another license, please feel free to email us at [contact@airensoft.com](mailto:contact@airensoft.com).
+OvenMediaEngine is licensed under the [AGPL-3.0-only](../LICENSE/). However, if you need another license, please feel free to email us at [contact@ovenmedialabs.com](mailto:contact@ovenmedialabs.com).

--- a/docs/access-control/admission-webhooks.md
+++ b/docs/access-control/admission-webhooks.md
@@ -106,7 +106,7 @@ As shown below, the trigger condition of request is different for each protocol.
 | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | WebRTC   | When a client requests Offer SDP                                                                                         |
 | RTMP     | When a client sends a publish message                                                                                    |
-| SRT      | When a client send a [streamid](https://airensoft.gitbook.io/ovenmediaengine/live-source/srt-beta#encoders-and-streamid) |
+| SRT      | When a client send a [streamid](https://docs.ovenmediaengine.com/live-source/srt-beta#encoders-and-streamid) |
 | LLHLS    | When a client requests a playlist (llhls.m3u8)                                                                           |
 
 ## Response for closing status

--- a/docs/access-control/signedpolicy.md
+++ b/docs/access-control/signedpolicy.md
@@ -132,7 +132,7 @@ For example, you can use it like this:
 ## Make SignedPolicy URL manually
 
 {% hint style="success" %}
-We hope to provide SignedPolicy URL Generator Library in various languages. If you have created the SignedPolicy URL Generator Library in another language, please send a Pull Request to our [GITHUB](https://github.com/AirenSoft/OvenMediaEngine/pulls). Thank you for your open source contributions.
+We hope to provide SignedPolicy URL Generator Library in various languages. If you have created the SignedPolicy URL Generator Library in another language, please send a Pull Request to our [GITHUB](https://github.com/OvenMediaLabs/OvenMediaEngine/pulls). Thank you for your open source contributions.
 {% endhint %}
 
 ### Encoding policy

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -120,7 +120,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -157,7 +157,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -226,9 +226,9 @@ The Domain has `<Names>` and `<TLS>`. `<Names>` can be either a domain or an IP 
             <!--
                 You can specify domain names/IP addresses
 
-                <Name>stream1.airensoft.com</Name>
-                <Name>stream2.airensoft.com</Name>
-                <Name>*.sub.airensoft.com</Name>
+                <Name>stream1.ovenmedialabs.com</Name>
+                <Name>stream2.ovenmedialabs.com</Name>
+                <Name>*.sub.ovenmedialabs.com</Name>
                 <Name>192.168.0.160</Name>
             -->
             <Name>*</Name>
@@ -503,7 +503,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -543,7 +543,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -579,9 +579,9 @@ Finally, `Server.xml` is configured as follows:
             <AccessToken>ome-access-token</AccessToken>
 
             <CrossDomains>
-                <Url>*.airensoft.com</Url>
-                <Url>http://*.sub-domain.airensoft.com</Url>
-                <Url>http?://airensoft.*</Url>
+                <Url>*.ovenmedialabs.com</Url>
+                <Url>http://*.sub-domain.ovenmedialabs.com</Url>
+                <Url>http?://ovenmedialabs.*</Url>
             </CrossDomains>
         </API>
     </Managers>
@@ -602,9 +602,9 @@ Finally, `Server.xml` is configured as follows:
             <Host>
                 <Names>
                     <!-- Host names
-                        <Name>stream1.airensoft.com</Name>
-                        <Name>stream2.airensoft.com</Name>
-                        <Name>*.sub.airensoft.com</Name>
+                        <Name>stream1.ovenmedialabs.com</Name>
+                        <Name>stream2.ovenmedialabs.com</Name>
+                        <Name>*.sub.ovenmedialabs.com</Name>
                         <Name>192.168.0.1</Name>
                     -->
                     <Name>*</Name>
@@ -619,7 +619,7 @@ Finally, `Server.xml` is configured as follows:
             </Host>
 
             <!--
-                Refer to https://airensoft.gitbook.io/ovenmediaengine/signedpolicy
+                Refer to https://docs.ovenmediaengine.com/signedpolicy
             -->
             <!--
             <SignedPolicy>

--- a/docs/configuration/tls-encryption.md
+++ b/docs/configuration/tls-encryption.md
@@ -76,9 +76,9 @@ Add your certificate files to as follows:
                 <Name>*</Name>
             </Names>
             <TLS>
-                <CertPath>/etc/pki/airensoft.com/_airensoft_com.crt</CertPath>
-                <KeyPath>/etc/pki/airensoft.com/_airensoft_com.key</KeyPath>
-                <ChainCertPath>/etc/pki/airensoft.com/_airensoft_com.ca-bundle</ChainCertPath>
+                <CertPath>/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.crt</CertPath>
+                <KeyPath>/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.key</KeyPath>
+                <ChainCertPath>/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.ca-bundle</ChainCertPath>
             </TLS>
         </Host>
         ...

--- a/docs/crossdomains.md
+++ b/docs/crossdomains.md
@@ -7,7 +7,7 @@ CrossDomain settings are available for HTTP-based APIs, HLS, LLHLS and Thumbnail
 ```xml
 <CrossDomains>
     <Url>*</Url>
-    <Url>*.airensoft.com</Url>
+    <Url>*.ovenmedialabs.com</Url>
     <Url>http://*.ovenplayer.com</Url>
     <Url>https://demo.ovenplayer.com</Url>
     <Header>
@@ -16,7 +16,7 @@ CrossDomain settings are available for HTTP-based APIs, HLS, LLHLS and Thumbnail
     </Header>
     <Header>
         <Key>custom-header</Key>
-        <Value>airensoft</Value>
+        <Value>ovenmedialabs</Value>
     </Header>
 </CrossDomains>
 ```

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started with Docker Image
 
-OvenMediaEngine provides Docker images from AirenSoft's Docker Hub (airensoft/ovenmediaengine) repository. You can easily use OvenMediaEngine server by using Docker image. See [Getting Started with Docker](getting-started-with-docker.md) for details.
+OvenMediaEngine provides Docker images from OvenMedia Labs Docker Hub (ovenmedialabs/ovenmediaengine) repository. You can easily use OvenMediaEngine server by using Docker image. See [Getting Started with Docker](getting-started-with-docker.md) for details.
 
 ## Getting Started with Source Code
 
@@ -11,7 +11,7 @@ OvenMediaEngine provides Docker images from AirenSoft's Docker Hub (airensoft/ov
 OvenMediaEngine can work with a variety of open-sources and libraries. First, install them on your clean Linux machine as described below. We think that OME can support most Linux packages, but the tested platforms we use are Ubuntu 18+, Fedora 28+, Rocky Linux 8+, and AlmaLinux 8+.
 
 ```bash
-curl -LOJ https://github.com/AirenSoft/OvenMediaEngine/archive/master.tar.gz && \
+curl -LOJ https://github.com/OvenMediaLabs/OvenMediaEngine/archive/master.tar.gz && \
 tar xvfz OvenMediaEngine-master.tar.gz && \
 OvenMediaEngine-master/misc/prerequisites.sh
 ```

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -2,12 +2,12 @@
 
 ## Getting Started with default settings
 
-OvenMediaEngine provides the Docker image from [AirenSoft's Docker Hub](https://hub.docker.com/r/airensoft/ovenmediaengine) (**airensoft/ovenmediaengine)** repository. After installing [Docker](https://www.docker.com), you can simply run the following command:
+OvenMediaEngine provides the Docker image from [OvenMedia Labs Docker Hub](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine) (**ovenmedialabs/ovenmediaengine)** repository. After installing [Docker](https://www.docker.com), you can simply run the following command:
 
 ```sh
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
-airensoft/ovenmediaengine:latest
+ovenmedialabs/ovenmediaengine:latest
 ```
 
 {% hint style="warning" %}
@@ -70,7 +70,7 @@ echo "export OME_DOCKER_HOME=/opt/ovenmediaengine" >> ~/.profile
 #### Copy the default configurations from Docker container
 
 ```sh
-docker run -d --name tmp-ome airensoft/ovenmediaengine:latest
+docker run -d --name tmp-ome ovenmedialabs/ovenmediaengine:latest
 docker cp tmp-ome:/opt/ovenmediaengine/bin/origin_conf/Server.xml $OME_DOCKER_HOME/conf
 docker cp tmp-ome:/opt/ovenmediaengine/bin/origin_conf/Logger.xml $OME_DOCKER_HOME/conf
 docker rm -f tmp-ome
@@ -105,7 +105,7 @@ docker run -d -it --name ome -e OME_HOST_IP=Your.HOST.IP.Address \
 -v $OME_DOCKER_HOME/logs:/var/log/ovenmediaengine \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 \
 -p 10000-10009:10000-10009/udp \
-airensoft/ovenmediaengine:latest
+ovenmedialabs/ovenmediaengine:latest
 ```
 {% endcode %}
 

--- a/docs/getting-started/getting-started-with-ome-docker-launcher.md
+++ b/docs/getting-started/getting-started-with-ome-docker-launcher.md
@@ -9,7 +9,7 @@ The OME Docker Launcher is a tool that simplifies the process of deploying and m
 The OME Docker Launcher provides a set of commands that allow users to easily manage the OME Docker container. These commands include:
 
 * [`setup`](getting-started-with-ome-docker-launcher.md#setup)
-  * This command pulls the OME Docker image(`airensoft/ovenmediaengine:latest`) from the Docker registry and copies the necessary configuration files to a specified location. This command needs to be run before starting the OME Docker container.
+  * This command pulls the OME Docker image(`ovenmedialabs/ovenmediaengine:latest`) from the Docker registry and copies the necessary configuration files to a specified location. This command needs to be run before starting the OME Docker container.
 * [`start`](getting-started-with-ome-docker-launcher.md#start)
   * This command creates and starts the Docker container. Once the container is started, the OME application can be accessed through a web browser using the container's IP address.
 * [`sh`](getting-started-with-ome-docker-launcher.md#sh)
@@ -32,19 +32,19 @@ OME Docker Launcher has not been tested in various environments yet. Therefore, 
 Run the following command in your Linux shell.
 
 ```
-curl -OL 'https://raw.githubusercontent.com/AirenSoft/OvenMediaEngine/master/misc/ome_docker_launcher.sh' && chmod +x ome_docker_launcher.sh
+curl -OL 'https://raw.githubusercontent.com/OvenMediaLabs/OvenMediaEngine/master/misc/ome_docker_launcher.sh' && chmod +x ome_docker_launcher.sh
 ```
 
 Below is an example of execution:
 
 ```bash
-$ curl -OL 'https://raw.githubusercontent.com/AirenSoft/OvenMediaEngine/master/misc/ome_docker_launcher.sh' && chmod +x ome_docker_launcher.sh
+$ curl -OL 'https://raw.githubusercontent.com/OvenMediaLabs/OvenMediaEngine/master/misc/ome_docker_launcher.sh' && chmod +x ome_docker_launcher.sh
 $ ./ome_docker_launcher.sh -h
 
  ▄██████▀███▄
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀
 
 • Usage: ./ome_docker_launcher.sh [OPTIONS] COMMAND ...
@@ -109,7 +109,7 @@ $ ./ome_docker_launcher.sh setup
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Creating configuration directory /usr/share/ovenmediaengine/conf
@@ -142,7 +142,7 @@ $ ./ome_docker_launcher.sh start
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Starting OvenMediaEngine...
@@ -210,7 +210,7 @@ $ ./ome_docker_launcher.sh sh
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Run a shell in the running container: ID: 7235ff9f8076
@@ -243,7 +243,7 @@ $ ./ome_docker_launcher.sh status
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Container is running: ID: 7235ff9f8076, name: ovenemediaengine
@@ -261,7 +261,7 @@ $ ./ome_docker_launcher.sh stop
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Stopping a container: ovenemediaengine
@@ -281,7 +281,7 @@ $ ./ome_docker_launcher.sh stop
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Restarting a container: ovenemediaengine
@@ -300,7 +300,7 @@ $ ./ome_docker_launcher.sh -d stop
  ▄██████▀███▄ 
 █████▀ ▄██████  OvenMediaEngine Launcher v0.1
 ███▄▄▄▄▀▀▀▀███
-██████▀ ▄█████  https://github.com/AirenSoft/OvenMediaEngine
+██████▀ ▄█████  https://github.com/OvenMediaLabs/OvenMediaEngine
  ▀███▄██████▀ 
 
 • Stopping a container: ovenemediaengine

--- a/docs/live-source/srt.md
+++ b/docs/live-source/srt.md
@@ -78,7 +78,7 @@ Server: srt://{OvenMediaEngine Host}:{SRT Port}
 Key: {streamid}
 ```
 
-The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](https://airensoft.gitbook.io/ovenmediaengine/v/0.16.4/live-source/srt-beta#blackmagic-web-presenter)
+The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](https://docs.ovenmediaengine.com/v/0.16.4/live-source/srt-beta#blackmagic-web-presenter)
 
 ## Multiple Audio Track
 

--- a/docs/origin-edge-clustering.md
+++ b/docs/origin-edge-clustering.md
@@ -153,7 +153,7 @@ This means that existing settings do not need to be updated when extending Origi
         </RedisServer>
         
         <!-- This is only needed for the origin server and used to register the ovt address of the stream.  -->
-        <OriginHostName>ome-dev.airensoft.com</OriginHostName>
+        <OriginHostName>ome-dev.ovenmedialabs.com</OriginHostName>
     </OriginMapStore>
     ...
 </VirtualHost>

--- a/docs/p2p-delivery.md
+++ b/docs/p2p-delivery.md
@@ -46,6 +46,6 @@ When any Host Peer is disconnected, OvenMediaEngine detects this situation and i
 Also, we are preparing a smarter algorithm based on user location, platform performance, and network statistical information for classifying Host Peers or Client Peers.
 {% endhint %}
 
-If you have a better idea, we hope that you improve our code and contribute to our project. Please visit [OvenMediaEngine GitHub](https://github.com/AirenSoft/OvenMediaEngine).
+If you have a better idea, we hope that you improve our code and contribute to our project. Please visit [OvenMediaEngine GitHub](https://github.com/OvenMediaLabs/OvenMediaEngine).
 
-{% embed url="https://github.com/AirenSoft/OvenMediaEngine/blob/master/src/projects/modules/rtc_signalling/p2p" %}
+{% embed url="https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/src/projects/modules/rtc_signalling/p2p" %}

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -9,7 +9,7 @@ Run docker with the command below. `OME_HOST_IP` must be an IP address accessibl
 ```sh
 $ docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
-airensoft/ovenmediaengine:latest
+ovenmedialabs/ovenmediaengine:latest
 ```
 
 <details>
@@ -21,7 +21,7 @@ You can check the docker container status with the following command:
 ```bash
 $ docker ps -f name=ome
 CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS              PORTS                                                                                                                                                                                                                                                                                                           NAMES
-c9dd9e56d7a0   airensoft/ovenmediaengine:latest   "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 80/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 3334/tcp, 8080/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 4000-4005/udp, 8090/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 10010/udp, 0.0.0.0:9999-10009->9999-10009/udp, :::9999-10009->9999-10009/udp   ome
+c9dd9e56d7a0   ovenmedialabs/ovenmediaengine:latest   "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 80/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 3334/tcp, 8080/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 4000-4005/udp, 8090/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 10010/udp, 0.0.0.0:9999-10009->9999-10009/udp, :::9999-10009->9999-10009/udp   ome
 ```
 
 You can view the log with the command below. This is important because you can check the version of OvenMediaEngine that is running.

--- a/docs/quick-start/test-player.md
+++ b/docs/quick-start/test-player.md
@@ -18,7 +18,7 @@ With OvenSpace, you can quickly and easily stream content with sub-second latenc
 
 OvenSpace is available online, so you can try it out for yourself at [https://space.ovenplayer.com/](https://space.ovenplayer.com/). You'll get a hands-on experience of how OvenMediaEngine, OvenPlayer, and OvenLiveKit work together seamlessly to deliver top-quality streaming, whether you're a developer looking to build a media service or someone who wants to experience sub-second or low-latency streaming firsthand.
 
-OvenSpace is also available on [Github](https://github.com/AirenSoft/OvenSpace) as open source. It will be a good reference when developing media services using OvenMediaEngine, OvenPlayer and OvenLiveKit.
+OvenSpace is also available on [Github](https://github.com/OvenMediaLabs/OvenSpace) as open source. It will be a good reference when developing media services using OvenMediaEngine, OvenPlayer and OvenLiveKit.
 
 <figure><img src="../.gitbook/assets/image (6) (1).png" alt=""><figcaption><p><a href="https://space.ovenplayer.com/">https://space.ovenplayer.com/</a></p></figcaption></figure>
 

--- a/docs/rest-api/README.md
+++ b/docs/rest-api/README.md
@@ -51,17 +51,17 @@ In order to use the API server, you must configure `<Managers>` as well as port 
 				<Name>*</Name>
 			</Names>
 			<TLS>
-				<CertPath>airensoft_com.crt</CertPath>
-				<KeyPath>airensoft_com.key</KeyPath>
-				<ChainCertPath>airensoft_com_chain.crt</ChainCertPath>
+				<CertPath>ovenmedialabs_com.crt</CertPath>
+				<KeyPath>ovenmedialabs_com.key</KeyPath>
+				<ChainCertPath>ovenmedialabs_com_chain.crt</ChainCertPath>
 			</TLS>
 		</Host>
 		<API>
 			<AccessToken>your_access_token</AccessToken>
 			<CrossDomains>
-				<Url>*.airensoft.com</Url>
-				<Url>http://*.sub-domain.airensoft.com</Url>
-				<Url>http?://airensoft.*</Url>
+				<Url>*.ovenmedialabs.com</Url>
+				<Url>http://*.sub-domain.ovenmedialabs.com</Url>
+				<Url>http?://ovenmedialabs.*</Url>
 			</CrossDomains>
 		</API>
 	</Managers>
@@ -86,9 +86,10 @@ For more information about HTTP Basic authentication, refer to the URL below.&#x
 
 #### CrossDomains
 
-To enable CORS on your API Server, you can add a setting. You can add `*` to allow all domains. If contains a scheme, such as https://, only that scheme can be allowed, or if the scheme is omitted, such as \*.airensoft.com, all schemes can be accepted.
+To enable CORS on your API Server, you can add a setting. You can add `*` to allow all domains. If contains a scheme, such as https://, only that scheme can be allowed, or if the scheme is omitted, such as \*.ovenmedialabs.com, all schemes can be accepted.
 
-
+
+
 
 ## API Request
 

--- a/docs/rest-api/v1/virtualhost/README.md
+++ b/docs/rest-api/v1/virtualhost/README.md
@@ -106,13 +106,13 @@ Configure virtual hosts to be created in <mark style="color:green;">Json array</
         "name": "vhost",
         "host": {
             "names": [
-                "ome-dev.airensoft.com",
-                "prod.airensoft.com"
+                "ome-dev.ovenmedialabs.com",
+                "prod.ovenmedialabs.com"
             ],
             "tls": {
-                "certPath": "/etc/pki/airensoft.com/_airensoft_com.crt",
-                "chainCertPath": "/etc/pki/airensoft.com/_airensoft_com.ca-bundle",
-                "keyPath": "/etc/pki/airensoft.com/_airensoft_com.key"
+                "certPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.crt",
+                "chainCertPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.ca-bundle",
+                "keyPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.key"
             }
         },
 
@@ -153,7 +153,7 @@ Configure virtual hosts to be created in <mark style="color:green;">Json array</
         },
 
         "originMapStore": {
-            "originHostName": "ome-dev.airensoft.com",
+            "originHostName": "ome-dev.ovenmedialabs.com",
             "redisServer": {
                 "auth": "!@#ovenmediaengine",
                 "host": "redis.server:6379"
@@ -227,13 +227,13 @@ It responds with <mark style="color:green;">**Json array**</mark> for each reque
 
             "host": {
                 "names": [
-                    "ome-dev.airensoft.com",
-                    "prod.airensoft.com"
+                    "ome-dev.ovenmedialabs.com",
+                    "prod.ovenmedialabs.com"
                 ],
                 "tls": {
-                    "certPath": "/etc/pki/airensoft.com/_airensoft_com.crt",
-                    "chainCertPath": "/etc/pki/airensoft.com/_airensoft_com.ca-bundle",
-                    "keyPath": "/etc/pki/airensoft.com/_airensoft_com.key"
+                    "certPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.crt",
+                    "chainCertPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.ca-bundle",
+                    "keyPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.key"
                 }
             },
             "signedPolicy": {
@@ -270,7 +270,7 @@ It responds with <mark style="color:green;">**Json array**</mark> for each reque
                 ]
             },
             "originMapStore": {
-                "originHostName": "ome-dev.airensoft.com",
+                "originHostName": "ome-dev.ovenmedialabs.com",
                 "redisServer": {
                     "auth": "!@#ovenmediaengine",
                     "host": "redis.server:6379"
@@ -441,13 +441,13 @@ Content-Type: application/json
 
         "host": {
             "names": [
-                "ome-dev.airensoft.com",
+                "ome-dev.ovenmedialabs.com",
                 "*"
             ],
             "tls": {
-                "certPath": "/etc/pki/airensoft.com/_airensoft_com.crt",
-                "chainCertPath": "/etc/pki/airensoft.com/_airensoft_com.ca-bundle",
-                "keyPath": "/etc/pki/airensoft.com/_airensoft_com.key"
+                "certPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.crt",
+                "chainCertPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.ca-bundle",
+                "keyPath": "/etc/pki/ovenmedialabs.com/_ovenmedialabs_com.key"
             }
         },
         
@@ -488,7 +488,7 @@ Content-Type: application/json
         },
 
         "originMapStore": {
-            "originHostName": "ome-dev.airensoft.com",
+            "originHostName": "ome-dev.ovenmedialabs.com",
             "redisServer": {
                 "auth": "!@#ovenmediaengine",
                 "host": "redis.server:6379"

--- a/docs/rest-api/v1/virtualhost/application/stream/send-event.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event.md
@@ -26,7 +26,7 @@ Authorization: Basic {credentials}
   "events":[
       {
         "frameType": "TXXX",
-        "info": "AirenSoft",
+        "info": "OvenMediaLabs",
         "data": "OvenMediaEngine"
       },
       {

--- a/docs/streaming/hls.md
+++ b/docs/streaming/hls.md
@@ -241,7 +241,7 @@ You can dump the HLS stream for VoD. You can enable it by setting the following 
                 <Playlist>playlist.m3u8</Playlist>
             </Playlists>
     
-            <OutputPath>/service/www/ome-dev.airensoft.com/html/${VHostName}_${AppName}_${StreamName}/${YYYY}_${MM}_${DD}_${hh}_${mm}_${ss}</OutputPath>
+            <OutputPath>/service/www/ome-dev.ovenmedialabs.com/html/${VHostName}_${AppName}_${StreamName}/${YYYY}_${MM}_${DD}_${hh}_${mm}_${ss}</OutputPath>
         </Dump>
     </Dumps>
     ...

--- a/docs/streaming/low-latency-hls.md
+++ b/docs/streaming/low-latency-hls.md
@@ -146,7 +146,7 @@ You can dump the LLHLS stream for VoD. You can enable it by setting the followin
                 <Playlist>abr.m3u8</Playlist>
             </Playlists>
     
-            <OutputPath>/service/www/ome-dev.airensoft.com/html/${VHostName}_${AppName}_${StreamName}/${YYYY}_${MM}_${DD}_${hh}_${mm}_${ss}</OutputPath>
+            <OutputPath>/service/www/ome-dev.ovenmedialabs.com/html/${VHostName}_${AppName}_${StreamName}/${YYYY}_${MM}_${DD}_${hh}_${mm}_${ss}</OutputPath>
         </Dump>
     </Dumps>
     ...
@@ -330,7 +330,7 @@ OvenPlayer now includes DRM-related options. Enable DRM and input the License UR
 ### Pallycon DRM
 
 {% hint style="danger" %}
-Pallycon is no longer supported by the Open Source project and is only supported in the [Enterprise](https://ovenmediaengine-enterprise.gitbook.io/docs/getting-started/getting-started-with-ubuntu) version. For more information, see this [article](https://github.com/AirenSoft/OvenMediaEngine/discussions/1634).
+Pallycon is no longer supported by the Open Source project and is only supported in the [Enterprise](https://ovenmediaengine-enterprise.gitbook.io/docs/getting-started/getting-started-with-ubuntu) version. For more information, see this [article](https://github.com/OvenMediaLabs/OvenMediaEngine/discussions/1634).
 {% endhint %}
 
 OvenMediaEngine integrates with [Pallycon](https://pallycon.com/), allowing you to more easily apply DRM to LLHLS streams.

--- a/docs/transcoding/gpu-usage.md
+++ b/docs/transcoding/gpu-usage.md
@@ -121,7 +121,7 @@ Please refer to the link for how to build and run.
 
 you must include the **--gpus all** option when running Docker
 
-<pre data-overflow="wrap"><code><strong>docker run -d ... --gpus all airensoft/ovenmediaengine:dev
+<pre data-overflow="wrap"><code><strong>docker run -d ... --gpus all ovenmedialabs/ovenmediaengine:dev
 </strong></code></pre>
 {% endhint %}
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,7 +264,7 @@ WebRTC does not support b-frame of H.264. But if your encoder sends b-frames the
 Or by **activating the encoding options** in OvenMediaEngine.
 
 {% hint style="info" %}
-Setting up Transcoding options in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/transcoding#encodes](https://airensoft.gitbook.io/ovenmediaengine/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#encodes](https://docs.ovenmediaengine.com/transcoding#encodes)
 {% endhint %}
 
 ### **2.** When streaming does not work in some players
@@ -274,7 +274,7 @@ In this case, you are probably trying to stream with UDP in an environment where
 If you want to monitor packet loss in your Chrome browser, you can access it by typing '**chrome://webrtc-internals**' in the address bar.
 
 {% hint style="info" %}
-Setting up WebRTC over TCP in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp](https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#webrtc-over-tcp)
+Setting up WebRTC over TCP in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp)
 {% endhint %}
 
 Also, if the device's network speed, which is running the player, isn't fast enough to accommodate the stream's BPS, the stuttering during streaming won't resolve and will eventually drop the connection. In this case, there is no other way than to speed up your network.
@@ -286,7 +286,7 @@ If the Origin server uses excessive CPU/Memory/Network, all players may experien
 When you see Origin is CPU intensive on your Origin-Edge structure, the transcoding options in the OvenMediaEngine may be the primary cause. That is, you may have set the quality of the input stream too high, or the output stream to exceed the capabilities of your hardware significantly. In this case, it can be solved by **enabling the hardware encoder** in OvenMediaEngine.
 
 {% hint style="info" %}
-Setting up GPU Acceleration in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/transcoding/gpu-usage](https://airensoft.gitbook.io/ovenmediaengine/transcoding/gpu-usage)
+Setting up GPU Acceleration in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding/gpu-usage](https://docs.ovenmediaengine.com/transcoding/gpu-usage)
 {% endhint %}
 
 ### **4.** When streaming fails due to excessive CPU/Memory/Network usage of Edge in OvenMediaEngine
@@ -300,7 +300,7 @@ If the edge server excessively uses CPU/Memory/Network, the player connected to 
 When you see a specific thread overuses the CPU, the video may not stream smoothly. Please refer to the manual below for more information on this.
 
 {% hint style="info" %}
-Tuning OvenMediaEngine Performance: [https://airensoft.gitbook.io/ovenmediaengine/performance-tuning#performance-tuning](https://airensoft.gitbook.io/ovenmediaengine/performance-tuning#performance-tuning)
+Tuning OvenMediaEngine Performance: [https://docs.ovenmediaengine.com/performance-tuning#performance-tuning](https://docs.ovenmediaengine.com/performance-tuning#performance-tuning)
 {% endhint %}
 
 #### 5-2. Tuning your Linux kernel
@@ -353,7 +353,7 @@ If you try to access OvenMediaEngine's WebRTC URL starting with **ws://** _(Non-
 In this case, you can solve this by installing a certificate in OvenMediaEngine and trying to connect with the **wss://** _(WebSocket/TLS)_ URL.
 
 {% hint style="info" %}
-Setting up TLS Encryption in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/streaming/tls-encryption](https://airensoft.gitbook.io/ovenmediaengine/streaming/tls-encryption)
+Setting up TLS Encryption in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/tls-encryption](https://docs.ovenmediaengine.com/streaming/tls-encryption)
 {% endhint %}
 
 ### **2.** Due to a Cross-Origin Resource Sharing (CORS) Error
@@ -383,7 +383,7 @@ In this case, you can solve this by setting the keyframe interval in the encoder
 Or by **enabling the encoding options** in OvenMediaEngine.
 
 {% hint style="info" %}
-Setting up Transcoding options in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/transcoding#encodes](https://airensoft.gitbook.io/ovenmediaengine/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#encodes](https://docs.ovenmediaengine.com/transcoding#encodes)
 {% endhint %}
 
 ## A/V is out of sync
@@ -399,7 +399,7 @@ However, this can be resolved naturally as the player will sync A/V while stream
 Also, suppose you are using a transcoder in OvenMediaEngine and trying to input with b-frames of H264. Audio is encoded fast, but a video is buffered at the decoder because of b-frames. Therefore, there is a time difference at the start of each encoding, which may cause the A/V to be out of sync. Even in this case, **enabling JitterBuffer** will solve this problem.
 
 {% hint style="info" %}
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#publisher](https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher)
 {% endhint %}
 
 ### 2. Time has passed, but A/V is out of sync
@@ -407,12 +407,12 @@ Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://airensoft.gitbook.io
 There may be cases where the A/V sync is not corrected even after a certain amount of time has elapsed after playback. This problem is caused by **small internal buffers** in some browsers such as Firefox, which causes the player to give up calibration if the A/V sync differs too much. But this can also be solved by **enabling JitterBuffer**.
 
 {% hint style="info" %}
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#publisher](https://airensoft.gitbook.io/ovenmediaengine/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher)
 {% endhint %}
 
 Nevertheless, if the A/V sync is not corrected, you should suspect an error in the original video file, which can be checked by playing as HLS.
 
-However, if A/V sync is well during streaming with HLS, this is OvenMediaEnigne's bug. If you find any bugs, please feel free to report them to [**OvenMediaEngine GitHub Issues**](https://github.com/AirenSoft/OvenMediaEngine/issues).
+However, if A/V sync is well during streaming with HLS, this is OvenMediaEnigne's bug. If you find any bugs, please feel free to report them to [**OvenMediaEngine GitHub Issues**](https://github.com/OvenMediaLabs/OvenMediaEngine/issues).
 
 ## No audio is output
 
@@ -421,7 +421,7 @@ However, if A/V sync is well during streaming with HLS, this is OvenMediaEnigne'
 WebRTC supports Opus, not AAC, as an audio codec. Because RTMP and other protocols mainly use and transmit AAC as the audio codec, you may not have set up Opus, but WebRTC cannot output audio without Opus. This can be solved by **setting Opus** in OvenMediaEnigne.
 
 {% hint style="info" %}
-Setting up Opus Codec in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/transcoding#audio](https://airensoft.gitbook.io/ovenmediaengine/transcoding#audio)
+Setting up Opus Codec in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#audio](https://docs.ovenmediaengine.com/transcoding#audio)
 {% endhint %}
 
 ## Not the video quality you want
@@ -433,7 +433,7 @@ If you are using video encoding in OME, the video bitrate may be set low. In thi
 However, since OvenMediaEngine has the default to the fastest encoding option for sub-second latency streaming, the video quality may not be as good as the set video bitrate. In this case, OvenMediaEngine provides an **output profile preset** that can control the quality, so you can choose to solve it.
 
 {% hint style="info" %}
-Choosing an Encoding Preset in OvenMediaEngine: [https://airensoft.gitbook.io/ovenmediaengine/transcoding#video](https://airensoft.gitbook.io/ovenmediaengine/transcoding#video)
+Choosing an Encoding Preset in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#video](https://docs.ovenmediaengine.com/transcoding#video)
 {% endhint %}
 
 ### 2. If you are using Transcoding as Bypass in OvenMediaEngine

--- a/misc/ome_docker_launcher.sh
+++ b/misc/ome_docker_launcher.sh
@@ -119,7 +119,7 @@ need_to_report()
 	local ARGS=("$@")
 	loge "• ERROR: ${ARGS[@]}"
 	loge "• This may be a bug of this launcher, and should not be occurred."
-	loge "• Please report this issue to https://github.com/AirenSoft/OvenMediaEngine/issues"
+	loge "• Please report this issue to https://github.com/OvenMediaLabs/OvenMediaEngine/issues"
 	exit 1
 }
 
@@ -131,7 +131,7 @@ banner()
 	logi "${COLOR_YELLOW} ▄██████▀███▄ "
 	logi "${COLOR_YELLOW}█████▀ ▄██████${COLOR_RESET}  ${COLOR_YELLOW}OvenMediaEngine${COLOR_RESET} Launcher ${VERSION}"
 	logi "${COLOR_YELLOW}███▄▄▄▄▀▀▀▀███"
-	logi "${COLOR_YELLOW}██████▀ ▄█████${COLOR_RESET}  ${COLOR_BLUE}https://github.com/AirenSoft/OvenMediaEngine"
+	logi "${COLOR_YELLOW}██████▀ ▄█████${COLOR_RESET}  ${COLOR_BLUE}https://github.com/OvenMediaLabs/OvenMediaEngine"
 	logi "${COLOR_YELLOW} ▀███▄██████▀ "
 	logi
 }

--- a/misc/oven_rtc_tester/go.mod
+++ b/misc/oven_rtc_tester/go.mod
@@ -1,4 +1,4 @@
-module github.com/airensoft/OvenMediaEngine/OvenRtcTester
+module github.com/OvenMediaLabs/OvenMediaEngine/OvenRtcTester
 
 go 1.17
 

--- a/misc/prerequisites.sh
+++ b/misc/prerequisites.sh
@@ -544,7 +544,7 @@ install_ovenmediaengine()
     (DIR=${TEMP_PATH}/ome && \
     mkdir -p ${DIR} && \
     cd ${DIR} && \
-    curl -sSLf https://github.com/AirenSoft/OvenMediaEngine/archive/${OME_VERSION}.tar.gz | tar -xz --strip-components=1 && \
+    curl -sSLf https://github.com/OvenMediaLabs/OvenMediaEngine/archive/${OME_VERSION}.tar.gz | tar -xz --strip-components=1 && \
     cd src && \
     make release && \
     sudo make install && \


### PR DESCRIPTION
update all URLs, domain references, and identifiers from AirenSoft to OvenMediaLabs across documentation and scripts.

- `https://github.com/AirenSoft/*` → `https://github.com/OvenMediaLabs/*`
- `https://airensoft.gitbook.io/ovenmediaengine` → `https://docs.ovenmediaengine.com`
- `https://airensoft.gitbook.io/ovenplayer` → `https://docs.ovenplayer.com`
- `https://hub.docker.com/r/airensoft/ovenmediaengine` → `https://hub.docker.com/r/ovenmedialabs/ovenmediaengine`
- `airensoft/ovenmediaengine:latest` → `ovenmedialabs/ovenmediaengine:latest`
- `airensoft.com` → `ovenmedialabs.com`
- `airensoft_com` / `_airensoft_com` → `ovenmedialabs_com` / `_ovenmedialabs_com`