### PR TITLE
refactor(config): fix JSON naming convention for all-caps acronyms

### DIFF
--- a/src/projects/config/items/alert/rules/egress/egress.h
+++ b/src/projects/config/items/alert/rules/egress/egress.h
@@ -35,11 +35,11 @@ namespace cfg
 						_stream_status = true;
 						return nullptr;
 					});
-					Register<Optional>("LLHLSReady", &_llhls_ready, nullptr, [=]() -> std::shared_ptr<ConfigError> {
+					Register<Optional>({"LLHLSReady", "llhlsReady"}, &_llhls_ready, nullptr, [=]() -> std::shared_ptr<ConfigError> {
 						_llhls_ready = true;
 						return nullptr;
 					});
-					Register<Optional>("HLSReady", &_hls_ready, nullptr, [=]() -> std::shared_ptr<ConfigError> {
+					Register<Optional>({"HLSReady", "hlsReady"}, &_hls_ready, nullptr, [=]() -> std::shared_ptr<ConfigError> {
 						_hls_ready = true;
 						return nullptr;
 					});

--- a/src/projects/config/items/modules/modules.h
+++ b/src/projects/config/items/modules/modules.h
@@ -45,13 +45,13 @@ namespace cfg
 		protected:
 			void MakeList() override
 			{
-				Register<Optional>("HTTP2", &_http2);
-				Register<Optional>("LLHLS", &_ll_hls);
+				Register<Optional>({"HTTP2", "http2"}, &_http2);
+				Register<Optional>({"LLHLS", "llhls"}, &_ll_hls);
 				Register<Optional>({"P2P", "p2p"}, &_p2p);
 				Register<Optional>("Recovery", &_recovery);
 				Register<Optional>("DynamicAppRemoval", &_dynamic_app_removal);
 				Register<Optional>("ETag", &_etag);
-				Register<Optional>("ERTMP", &_ertmp);
+				Register<Optional>({"ERTMP", "ertmp"}, &_ertmp);
 				Register<Optional>("Whisper", &_whisper);
 			}
 		};

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/bypass_if_match.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/bypass_if_match.h
@@ -64,7 +64,7 @@ namespace cfg
 							auto val = _height.UpperCaseString();
 							return (val == "EQ" || val == "GTE" || val == "LTE") ? nullptr : CreateConfigErrorPtr("BypassIfMatch.Height must specified only one of eq, lte, gte");
 						});
-						Register<Optional>("SAR", &_sar, nullptr, [=]() -> std::shared_ptr<ConfigError> {
+						Register<Optional>({"SAR", "sar"}, &_sar, nullptr, [=]() -> std::shared_ptr<ConfigError> {
 							auto val = _sar.UpperCaseString();
 							return (val == "EQ") ? nullptr : CreateConfigErrorPtr("BypassIfMatch.SAR must specified only one of eq");
 						});

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/media_options.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/media_options/media_options.h
@@ -73,8 +73,8 @@ namespace cfg
 									return nullptr;
 								}
 						);
-						Register<Optional>({"Overlays", "overlays"}, &_overlays);
-						Register<Optional>("STT", &_stt);
+						Register<Optional>("Overlays", &_overlays);
+						Register<Optional>({"STT", "stt"}, &_stt);
 					}
 				};
 			}  // namespace oprf

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/playlist/options.h
@@ -41,7 +41,7 @@ namespace cfg
 					void MakeList() override
 					{
 						Register<Optional>("WebRtcAutoAbr", &_webrtc_auto_abr);
-						Register<Optional>("HLSChunklistPathDepth", &_hls_chunklist_path_depth);
+						Register<Optional>({"HLSChunklistPathDepth", "hlsChunklistPathDepth"}, &_hls_chunklist_path_depth);
 						Register<Optional>("EnableTsPackaging", &_enable_ts_packaging);
 						Register<Optional>("EnableSubtitles", &_enable_subtitles);
 					}

--- a/src/projects/config/items/virtual_hosts/applications/providers/event_generator/event.h
+++ b/src/projects/config/items/virtual_hosts/applications/providers/event_generator/event.h
@@ -32,7 +32,7 @@ namespace cfg
 					void MakeList() override
 					{
 						Register("Trigger", &_trigger);
-						Register<Optional>("HLSID3v2", &_hls_id3v2);
+						Register<Optional>({"HLSID3v2", "hlsId3v2"}, &_hls_id3v2);
 					}
 				};
 			}  // namespace pvd

--- a/src/projects/config/items/virtual_hosts/applications/providers/webrtc_provider.h
+++ b/src/projects/config/items/virtual_hosts/applications/providers/webrtc_provider.h
@@ -37,7 +37,7 @@ namespace cfg
 
 						Register<Optional>("Timeout", &_timeout);
 						Register<Optional>("CrossDomains", &_cross_domains);
-						Register<Optional>("FIRInterval", &_fir_interval);
+						Register<Optional>({"FIRInterval", "firInterval"}, &_fir_interval);
 						Register<Optional>("RtcpBasedTimestamp", &_rtcp_based_timestamp);
 					}
 

--- a/src/projects/config/items/virtual_hosts/applications/publishers/hls_publisher.h
+++ b/src/projects/config/items/virtual_hosts/applications/publishers/hls_publisher.h
@@ -65,7 +65,7 @@ namespace cfg
 						Register<Optional>("SegmentCount", &_segment_count);
 						Register<Optional>("SegmentDuration", &_segment_duration);
 						Register<Optional>("CrossDomains", &_cross_domains);
-						Register<Optional>("DVR", &_dvr);
+						Register<Optional>({"DVR", "dvr"}, &_dvr);
 						Register<Optional>("Dumps", &_dumps);
 						Register<Optional>("CacheControl", &_cache_control);
 						Register<Optional>("DefaultQueryString", &_default_query_string);

--- a/src/projects/config/items/virtual_hosts/applications/publishers/ll_hls_publisher.h
+++ b/src/projects/config/items/virtual_hosts/applications/publishers/ll_hls_publisher.h
@@ -46,7 +46,7 @@ namespace cfg
 						Register<Optional>("ChunkDuration", &_chunk_duration);
 						Register<Optional>("PartHoldBack", &_part_hold_back);
 						Register<Optional>("EnablePreloadHint", &_enable_preload_hint);
-						Register<Optional>("DRM", &_drm);
+						Register<Optional>({"DRM", "drm"}, &_drm);
 					}
 				};
 			}  // namespace pub

--- a/src/projects/config/items/virtual_hosts/applications/publishers/publishers.h
+++ b/src/projects/config/items/virtual_hosts/applications/publishers/publishers.h
@@ -80,7 +80,7 @@ namespace cfg
 						Register<Optional>({"SRT", "srt"}, &_srt_publisher);
 
 						// Deprecated
-						Register<Optional>("MPEGTSPush", &_mpegtspush_publisher, nullptr,
+						Register<Optional>({"MPEGTSPush", "mpegtsPush"}, &_mpegtspush_publisher, nullptr,
 										   [=]() -> std::shared_ptr<ConfigError> {
 											   _push_publisher.SetParsed(true);
 											   logw("Config", "MPEGTSPush will be deprecated. Please use Push instead");

--- a/src/projects/config/items/virtual_hosts/applications/web_console/web_console.h
+++ b/src/projects/config/items/virtual_hosts/applications/web_console/web_console.h
@@ -27,8 +27,8 @@ namespace cfg
 					void MakeList() override
 					{
 						Register<Optional>("ListenPort", &_listen_port);
-						Register<Optional>("LoginID", &_login_id);
-						Register("LoginPW", &_login_pw);
+						Register<Optional>({"LoginID", "loginId"}, &_login_id);
+						Register({"LoginPW", "loginPw"}, &_login_pw);
 						Register("DocumentPath", &_document_path);
 					}
 

--- a/src/projects/config/items/virtual_hosts/origins/origin.h
+++ b/src/projects/config/items/virtual_hosts/origins/origin.h
@@ -35,7 +35,7 @@ namespace cfg
 					Register<Optional>("Failback", &_failback);
 					Register<Optional>("StrictLocation", &_strict_location);
 					Register<Optional>("Relay", &_relay);
-					Register<Optional>("IgnoreRtcpSRTimestamp", &_ignore_rtcp_sr_timestamp);
+					Register<Optional>({"IgnoreRtcpSRTimestamp", "ignoreRtcpSrTimestamp"}, &_ignore_rtcp_sr_timestamp);
 				}
 				ov::String _location;
 				Pass _pass;


### PR DESCRIPTION
## Summary

- Fix incorrect JSON camelCase names caused by the auto-derivation rule (`Register("XXX")` lowercases only the first character), which produces malformed results for multi-character all-caps acronyms (e.g. `"DVR"` -> `"dVR"`, `"LLHLS"` -> `"lLHLS"`)
- Convert all violating entries to the explicit `{"XMLName", "jsonName"}` form so the JSON name is correct camelCase while the XML name remains unchanged for backward compatibility

## Changed items

| XML name | Before (auto JSON) | After (explicit JSON) |
|---|---|---|
| `HTTP2` | `hTTP2` ❌ | `http2` ✅ |
| `LLHLS` | `lLHLS` ❌ | `llhls` ✅ |
| `ERTMP` | `eRTMP` ❌ | `ertmp` ✅ |
| `LLHLSReady` | `lLHLSReady` ❌ | `llhlsReady` ✅ |
| `HLSReady` | `hLSReady` ❌ | `hlsReady` ✅ |
| `HLSID3v2` | `hLSID3v2` ❌ | `hlsId3v2` ✅ |
| `SAR` | `sAR` ❌ | `sar` ✅ |
| `STT` | `sTT` ❌ | `stt` ✅ |
| `FIRInterval` | `fIRInterval` ❌ | `firInterval` ✅ |
| `HLSChunklistPathDepth` | `hLSChunklistPathDepth` ❌ | `hlsChunklistPathDepth` ✅ |
| `DVR` | `dVR` ❌ | `dvr` ✅ |
| `DRM` | `dRM` ❌ | `drm` ✅ |
| `MPEGTSPush` | `mPEGTSPush` ❌ | `mpegtsPush` ✅ |
| `LoginID` | `loginID` ❌ | `loginId` ✅ |
| `LoginPW` | `loginPW` ❌ | `loginPw` ✅ |
| `IgnoreRtcpSRTimestamp` | `ignoreRtcpSRTimestamp` ❌ | `ignoreRtcpSrTimestamp` ✅ |
