### PR TITLE
docs: document <PlayoutDelay> option for WebRTC publisher

### DIFF
--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -122,18 +122,28 @@ Configure `<WebRTC>` under `<Publishers>` in the Application settings:
         <Rtx>false</Rtx>
         <Ulpfec>false</Ulpfec>
         <JitterBuffer>true</JitterBuffer>
+        <PlayoutDelay>
+            <Min>0</Min>
+            <Max>0</Max>
+        </PlayoutDelay>
     </WebRTC>
     ...
 </Publishers>
 ```
 
-<table><thead><tr><th width="189">Option</th><th width="433.33333333333326">Description</th><th>Default</th></tr></thead><tbody><tr><td><code>Timeout</code></td><td>ICE (STUN request/response) timeout as milliseconds, if there is no request or response during this time, the session is terminated.</td><td><code>30000</code></td></tr><tr><td><code>Rtx</code></td><td>WebRTC retransmission, a useful option in WebRTC/udp, but ineffective in WebRTC/tcp.</td><td><code>false</code></td></tr><tr><td><code>Ulpfec</code></td><td>WebRTC forward error correction, a useful option in WebRTC/udp, but ineffective in WebRTC/tcp.</td><td><code>false</code></td></tr><tr><td><code>JitterBuffer</code></td><td>Smooths bursty frame delivery by spacing media frames according to their PTS. See below for details.</td><td><code>false</code></td></tr><tr><td><code>BandwidthEstimation</code></td><td><p>Determines which method OvenMediaEngine uses to estimate the bandwidth of the connected player. This bandwidth estimation is required for WebRTC ABR when OME selects and sends an appropriate rendition to the player.</p><p>If <strong>TransportCC</strong> or <strong>REMB</strong> is set, only one method is used. If the default value <strong>All</strong> is set, both methods are included in the SDP offer, and the player operates according to its preference. Most modern browsers use Transport-cc by default in this case. Transport-cc provides more accurate bandwidth estimation.</p></td><td><code>All</code></td></tr></tbody></table>
+<table><thead><tr><th width="189">Option</th><th width="433.33333333333326">Description</th><th>Default</th></tr></thead><tbody><tr><td><code>Timeout</code></td><td>ICE (STUN request/response) timeout as milliseconds, if there is no request or response during this time, the session is terminated.</td><td><code>30000</code></td></tr><tr><td><code>Rtx</code></td><td>WebRTC retransmission, a useful option in WebRTC/udp, but ineffective in WebRTC/tcp.</td><td><code>false</code></td></tr><tr><td><code>Ulpfec</code></td><td>WebRTC forward error correction, a useful option in WebRTC/udp, but ineffective in WebRTC/tcp.</td><td><code>false</code></td></tr><tr><td><code>JitterBuffer</code></td><td>Smooths bursty frame delivery by spacing media frames according to their PTS. See below for details.</td><td><code>false</code></td></tr><tr><td><code>PlayoutDelay</code></td><td>Hints the minimum and maximum playout delay (in milliseconds, from 0 to 40950) to the player so it keeps a deeper jitter buffer for video. Useful when the network introduces bursty latency and the default low-latency buffer causes hitches. See below for details.</td><td><code>Disabled</code></td></tr><tr><td><code>BandwidthEstimation</code></td><td><p>Determines which method OvenMediaEngine uses to estimate the bandwidth of the connected player. This bandwidth estimation is required for WebRTC ABR when OME selects and sends an appropriate rendition to the player.</p><p>If <strong>TransportCC</strong> or <strong>REMB</strong> is set, only one method is used. If the default value <strong>All</strong> is set, both methods are included in the SDP offer, and the player operates according to its preference. Most modern browsers use Transport-cc by default in this case. Transport-cc provides more accurate bandwidth estimation.</p></td><td><code>All</code></td></tr></tbody></table>
 
 #### JitterBuffer
 
 Without the jitter buffer, frames are forwarded to the player as soon as they arrive from the Provider. Any timing jitter introduced upstream (network jitter, encoder bursts, ingest pacing, and so on) is passed straight through to the player, which can result in uneven playback.
 
 When the jitter buffer is enabled, OvenMediaEngine evens out the spacing between frames before sending. The player receives a steady stream and playback runs at a consistent speed. In a healthy environment where upstream jitter is already low, the added latency is negligible.
+
+#### PlayoutDelay
+
+`<PlayoutDelay>` asks the player to hold incoming video for at least `<Min>` and at most `<Max>` milliseconds before rendering. A larger minimum gives the player a deeper buffer to absorb network jitter, at the cost of higher end-to-end latency. Both values must be between `0` and `40950`. Omit the `<PlayoutDelay>` element to leave playout timing entirely up to the player.
+
+The hint applies to video only. With a non-trivial `<Min>`, audio may briefly play ahead of video for a few seconds at session start, until the player aligns the two streams. If this initial offset is undesirable, lower `<Min>` or omit `<PlayoutDelay>`.
 
 ### Encoding
 


### PR DESCRIPTION
## Problem
The `<PlayoutDelay>` option under `<Publishers><WebRTC>` is supported by the engine but missing from the WebRTC Publisher manual, so users have no reference for the XML schema, value range, or the initial audio/video offset that appears when `<Min>` is non-trivial.

## Solution
Document `<PlayoutDelay>` in `docs/streaming/webrtc-publishing.md`: add it to the example XML block, add a row to the options table, and add a `#### PlayoutDelay` subsection that explains the `<Min>`/`<Max>` range, the latency tradeoff, and the brief initial A/V offset users may observe at session start.