### PR TITLE
refactor: use steady_clock for elapsed time and timeout tracking

### DIFF
--- a/src/projects/base/info/push.cpp
+++ b/src/projects/base/info/push.cpp
@@ -208,7 +208,7 @@ namespace info
 	}
 	void Push::UpdatePushTime()
 	{
-		_Push_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _Push_start_time).count();
+		_Push_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _Push_start_time_steady).count();
 	}
 	void Push::IncreaseSequence()
 	{
@@ -221,6 +221,7 @@ namespace info
 	void Push::UpdatePushStartTime()
 	{
 		_Push_start_time = std::chrono::system_clock::now();
+		_Push_start_time_steady = std::chrono::steady_clock::now();
 	}
 	void Push::UpdatePushStopTime()
 	{

--- a/src/projects/base/info/push.h
+++ b/src/projects/base/info/push.h
@@ -159,8 +159,10 @@ namespace info
 
 		std::chrono::system_clock::time_point _created_time;
 
-		std::chrono::system_clock::time_point _Push_start_time;		
-		std::chrono::system_clock::time_point _Push_stop_time;	
+		std::chrono::system_clock::time_point _Push_start_time;
+		std::chrono::system_clock::time_point _Push_stop_time;
+		// Steady-clock baseline for duration measurement (immune to wall-clock jumps)
+		std::chrono::steady_clock::time_point _Push_start_time_steady;
 
 		PushState _state;
 

--- a/src/projects/base/info/record.cpp
+++ b/src/projects/base/info/record.cpp
@@ -43,6 +43,7 @@ namespace info
 		_schedule_next = std::chrono::system_clock::time_point{};
 		_record_start_time = std::chrono::system_clock::time_point{};
 		_record_stop_time = std::chrono::system_clock::time_point{};
+		_record_start_time_steady = std::chrono::steady_clock::time_point{};
 
 		_session_id = 0;
 		_enable = false;
@@ -321,7 +322,7 @@ namespace info
 	}
 	void Record::UpdateRecordTime()
 	{
-		_record_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _record_start_time).count();
+		_record_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _record_start_time_steady).count();
 	}
 	void Record::IncreaseSequence()
 	{
@@ -334,6 +335,7 @@ namespace info
 	void Record::UpdateRecordStartTime()
 	{
 		_record_start_time = std::chrono::system_clock::now();
+		_record_start_time_steady = std::chrono::steady_clock::now();
 	}
 	void Record::UpdateRecordStopTime()
 	{
@@ -445,6 +447,7 @@ namespace info
 		record->_created_time			= _created_time;
 		record->_record_start_time		= _record_start_time;
 		record->_record_stop_time		= _record_stop_time;
+		record->_record_start_time_steady = _record_start_time_steady;
 		record->_state					= _state;
 		record->_session_id				= _session_id;
 	}

--- a/src/projects/base/info/record.h
+++ b/src/projects/base/info/record.h
@@ -237,6 +237,8 @@ namespace info
 		std::chrono::system_clock::time_point _created_time;
 		std::chrono::system_clock::time_point _record_start_time;
 		std::chrono::system_clock::time_point _record_stop_time;
+		// Steady-clock baseline for duration measurement (immune to wall-clock jumps)
+		std::chrono::steady_clock::time_point _record_start_time_steady;
 
 		RecordState _state;
 

--- a/src/projects/base/info/stream.cpp
+++ b/src/projects/base/info/stream.cpp
@@ -251,12 +251,6 @@ namespace info
 		return GetPublishedTime();
 	}
 
-	uint32_t Stream::GetUptimeSec()
-	{
-		auto current = std::chrono::high_resolution_clock::now();
-		return std::chrono::duration_cast<std::chrono::seconds>(current - GetCreatedTime()).count();
-	}
-
 	StreamSourceType Stream::GetSourceType() const
 	{
 		return _source_type;

--- a/src/projects/base/info/stream.h
+++ b/src/projects/base/info/stream.h
@@ -66,7 +66,6 @@ namespace info
 		const std::chrono::system_clock::time_point &GetInputStreamPublishedTime() const;
 		const std::chrono::system_clock::time_point &GetPublishedTime() const;
 
-		uint32_t GetUptimeSec();
 		StreamSourceType GetSourceType() const;
 		ProviderType GetProviderType() const;
 		

--- a/src/projects/base/ovcrypto/openssl/ocsp_context.cpp
+++ b/src/projects/base/ovcrypto/openssl/ocsp_context.cpp
@@ -272,7 +272,7 @@ namespace ov
 		}
 
 		_response_code = SSL_TLSEXT_ERR_OK;
-		_received_time = std::chrono::system_clock::now();
+		_received_time = std::chrono::steady_clock::now();
 		return true;
 	}
 

--- a/src/projects/base/ovcrypto/openssl/ocsp_context.h
+++ b/src/projects/base/ovcrypto/openssl/ocsp_context.h
@@ -50,7 +50,7 @@ namespace ov
 				return false;
 			}
 
-			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _received_time);
+			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _received_time);
 
 			return (delta.count() >= millisecond_time);
 		}
@@ -90,7 +90,7 @@ namespace ov
 		// Used to request to OCSP responder if the responder URL is HTTPS
 		ov::RaiiPtr<SSL_CTX> _ssl_request_ctx = {nullptr, ::SSL_CTX_free};
 
-		std::chrono::time_point<std::chrono::system_clock> _received_time;
+		std::chrono::time_point<std::chrono::steady_clock> _received_time;
 
 		ov::RaiiPtr<OCSP_RESPONSE> _response = {nullptr, ::OCSP_RESPONSE_free};
 		// Last error code generated when querying OCSP responder

--- a/src/projects/base/ovlibrary/clock.h
+++ b/src/projects/base/ovlibrary/clock.h
@@ -61,9 +61,9 @@ namespace ov
 			lsw = (uint32_t)((double)(now.tv_nsec/1000)*(double)(((uint64_t)1)<<32)*1.0e-6);
 		}
 
-		static uint64_t GetElapsedMiliSecondsFromNow(std::chrono::system_clock::time_point time)
+		static uint64_t GetElapsedMiliSecondsFromNow(std::chrono::steady_clock::time_point time)
 		{
-			auto current = std::chrono::high_resolution_clock::now();
+			auto current = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - time).count();
 		}
 	};

--- a/src/projects/base/ovlibrary/delay_queue.h
+++ b/src/projects/base/ovlibrary/delay_queue.h
@@ -57,7 +57,7 @@ namespace ov
 
 			int after_msec;
 
-			std::chrono::time_point<std::chrono::system_clock> time_point;
+			std::chrono::time_point<std::chrono::steady_clock> time_point;
 
 			DelayQueueItem(int64_t index, DelayQueueFunction function, void *parameter, int after_msec)
 				: index(index),
@@ -72,7 +72,7 @@ namespace ov
 
 			void RecalculateTimePoint()
 			{
-				time_point = std::chrono::system_clock::now() + std::chrono::milliseconds(after_msec);
+				time_point = std::chrono::steady_clock::now() + std::chrono::milliseconds(after_msec);
 			}
 
 			bool operator<(const DelayQueueItem &item) const

--- a/src/projects/base/ovlibrary/event.cpp
+++ b/src/projects/base/ovlibrary/event.cpp
@@ -40,13 +40,13 @@ namespace ov
 	{
 		if(timeout != Infinite)
 		{
-			return Wait(std::chrono::system_clock::now() + std::chrono::milliseconds(timeout));
+			return Wait(std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout));
 		}
 
-		return Wait(std::chrono::time_point<std::chrono::system_clock>::max());
+		return Wait(std::chrono::time_point<std::chrono::steady_clock>::max());
 	}
 
-	bool Event::Wait(std::chrono::time_point<std::chrono::system_clock> time_point)
+	bool Event::Wait(std::chrono::time_point<std::chrono::steady_clock> time_point)
 	{
 		std::unique_lock<std::mutex> lock(_mutex);
 

--- a/src/projects/base/ovlibrary/event.h
+++ b/src/projects/base/ovlibrary/event.h
@@ -27,7 +27,7 @@ namespace ov
 
 		// timeout in milliseconds
 		bool Wait(int timeout = Infinite);
-		bool Wait(std::chrono::time_point<std::chrono::system_clock> time_point);
+		bool Wait(std::chrono::time_point<std::chrono::steady_clock> time_point);
 
 	protected:
 		bool _manual_reset;

--- a/src/projects/base/ovlibrary/precise_timer.cpp
+++ b/src/projects/base/ovlibrary/precise_timer.cpp
@@ -20,7 +20,7 @@ namespace ov
 
 		_is_valid = true;
 		_interval = interval;
-		_start = std::chrono::high_resolution_clock::now();
+		_start = std::chrono::steady_clock::now();
 	}
 
 	void PreciseTimer::Stop()
@@ -30,7 +30,7 @@ namespace ov
 
 	bool PreciseTimer::Update()
 	{
-		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _start).count();
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _start).count();
 
 		while (_end_time <= elapsed)
 		{
@@ -42,7 +42,7 @@ namespace ov
 
 	bool PreciseTimer::IsTimeout() const
 	{
-		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - _start).count();
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _start).count();
 
 		if (_end_time <= elapsed)
 		{
@@ -54,7 +54,7 @@ namespace ov
 
 	int64_t PreciseTimer::GetElapsed() const
 	{
-		auto current = std::chrono::high_resolution_clock::now();
+		auto current = std::chrono::steady_clock::now();
 		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(current - _start).count();
 
 		return elapsed;

--- a/src/projects/base/ovlibrary/precise_timer.h
+++ b/src/projects/base/ovlibrary/precise_timer.h
@@ -29,6 +29,6 @@ namespace ov
 
 		bool _is_valid { false };
 
-		std::chrono::high_resolution_clock::time_point _start;
+		std::chrono::steady_clock::time_point _start;
 	};
 }

--- a/src/projects/base/ovlibrary/queue.h
+++ b/src/projects/base/ovlibrary/queue.h
@@ -111,8 +111,8 @@ namespace ov
 				auto result = (_queue.empty() == false) ? true : false;
 				if (!result)
 				{
-					std::chrono::system_clock::time_point expire =
-						(timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+					std::chrono::steady_clock::time_point expire =
+						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
 					result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 						return ((_queue.empty() == false) || _stop);
@@ -154,8 +154,8 @@ namespace ov
 
 				if (result == false)
 				{
-					std::chrono::system_clock::time_point expire =
-						(timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+					std::chrono::steady_clock::time_point expire =
+						(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
 					result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 						return ((_queue.empty() == false) || _stop);
@@ -200,8 +200,8 @@ namespace ov
 				{
 					if (timeout > 0)
 					{
-						std::chrono::system_clock::time_point expire =
-							(timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+						std::chrono::steady_clock::time_point expire =
+							(timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
 						result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 							return ((_queue.empty() == false) || _stop);

--- a/src/projects/base/ovlibrary/stop_watch.cpp
+++ b/src/projects/base/ovlibrary/stop_watch.cpp
@@ -30,7 +30,7 @@ namespace ov
 		}
 
 		_is_valid = true;
-		_start = std::chrono::high_resolution_clock::now();
+		_start = std::chrono::steady_clock::now();
 		_last = _start;
 	}
 
@@ -57,7 +57,7 @@ namespace ov
 			return;
 		}
 
-		_pause_time = std::chrono::high_resolution_clock::now();
+		_pause_time = std::chrono::steady_clock::now();
 		_is_paused = true;
 	}
 
@@ -68,13 +68,13 @@ namespace ov
 			return;
 		}
 
-		_paused_duration += std::chrono::high_resolution_clock::now() - _pause_time;
+		_paused_duration += std::chrono::steady_clock::now() - _pause_time;
 		_is_paused = false;
 	}
 
 	bool StopWatch::Update()
 	{
-		_last = std::chrono::high_resolution_clock::now();
+		_last = std::chrono::steady_clock::now();
 		return _is_valid;
 	}
 
@@ -89,7 +89,7 @@ namespace ov
 	{
 		if (_is_valid)
 		{
-			auto current = std::chrono::high_resolution_clock::now();
+			auto current = std::chrono::steady_clock::now();
 			auto elapsed = current - _last - _paused_duration;
 
 			if(nano == false)
@@ -109,7 +109,7 @@ namespace ov
 	{
 		if (_is_valid)
 		{
-			auto current = std::chrono::high_resolution_clock::now();
+			auto current = std::chrono::steady_clock::now();
 			auto elapsed = current - _last - _paused_duration;
 
 			return std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
@@ -127,7 +127,7 @@ namespace ov
 	{
 		if (_is_valid)
 		{
-			auto current = std::chrono::high_resolution_clock::now();
+			auto current = std::chrono::steady_clock::now();
 
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - _start).count();
 		}

--- a/src/projects/base/ovlibrary/stop_watch.h
+++ b/src/projects/base/ovlibrary/stop_watch.h
@@ -37,11 +37,11 @@ namespace ov
 		String _tag;
 
 		bool _is_valid { false };
-		std::chrono::high_resolution_clock::time_point _start;
-		std::chrono::high_resolution_clock::time_point _last;
+		std::chrono::steady_clock::time_point _start;
+		std::chrono::steady_clock::time_point _last;
 
 		bool _is_paused { false };
-		std::chrono::high_resolution_clock::time_point _pause_time;
-		std::chrono::high_resolution_clock::duration _paused_duration = std::chrono::high_resolution_clock::duration::zero();
+		std::chrono::steady_clock::time_point _pause_time;
+		std::chrono::steady_clock::duration _paused_duration = std::chrono::steady_clock::duration::zero();
 	};
 }

--- a/src/projects/base/ovsocket/socket.cpp
+++ b/src/projects/base/ovsocket/socket.cpp
@@ -1921,24 +1921,24 @@ namespace ov
 		return socket_error;
 	}
 
-	std::chrono::system_clock::time_point Socket::GetLastRecvTime() const
+	std::chrono::steady_clock::time_point Socket::GetLastRecvTime() const
 	{
 		return _last_recv_time;
 	}
 
-	std::chrono::system_clock::time_point Socket::GetLastSentTime() const
+	std::chrono::steady_clock::time_point Socket::GetLastSentTime() const
 	{
 		return _last_sent_time;
 	}
 
 	void Socket::UpdateLastRecvTime()
 	{
-		_last_recv_time = std::chrono::high_resolution_clock::now();
+		_last_recv_time = std::chrono::steady_clock::now();
 	}
 
 	void Socket::UpdateLastSentTime()
 	{
-		_last_sent_time = std::chrono::high_resolution_clock::now();
+		_last_sent_time = std::chrono::steady_clock::now();
 	}
 
 	bool Socket::Flush()

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -386,7 +386,7 @@ namespace ov
 
 			String ToString() const
 			{
-				auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - enqueued_time).count();
+				int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - enqueued_time).count();
 				auto description = String::FormatString(
 					"<DispatchCommand: %p, elapsed: %" PRId64 "ms, type: %s",
 					this,

--- a/src/projects/base/ovsocket/socket.h
+++ b/src/projects/base/ovsocket/socket.h
@@ -205,8 +205,8 @@ namespace ov
 		// If MakeNonBlocking() is called, non_block is ignored
 		std::shared_ptr<const SocketError> RecvFrom(std::shared_ptr<Data> &data, SocketAddressPair *address_pair, const bool non_block = false);
 
-		std::chrono::system_clock::time_point GetLastRecvTime() const;
-		std::chrono::system_clock::time_point GetLastSentTime() const;
+		std::chrono::steady_clock::time_point GetLastRecvTime() const;
+		std::chrono::steady_clock::time_point GetLastSentTime() const;
 
 		// Dispatches as many command as possible
 		DispatchResult DispatchEvents();
@@ -312,7 +312,7 @@ namespace ov
 			DispatchCommand(const std::shared_ptr<const Data> &data)
 				: type(Type::Send),
 				  data(data),
-				  enqueued_time(std::chrono::system_clock::now())
+				  enqueued_time(std::chrono::steady_clock::now())
 			{
 			}
 
@@ -320,7 +320,7 @@ namespace ov
 				: type(Type::SendTo),
 				  address(address),
 				  data(data),
-				  enqueued_time(std::chrono::system_clock::now())
+				  enqueued_time(std::chrono::steady_clock::now())
 			{
 			}
 
@@ -328,20 +328,20 @@ namespace ov
 				: type(Type::SendFromTo),
 				  address_pair(address_pair),
 				  data(data),
-				  enqueued_time(std::chrono::system_clock::now())
+				  enqueued_time(std::chrono::steady_clock::now())
 			{
 			}
 
 			DispatchCommand(Type type)
 				: type(type),
-				  enqueued_time(std::chrono::system_clock::now())
+				  enqueued_time(std::chrono::steady_clock::now())
 			{
 			}
 
 			DispatchCommand(Type type, SocketState new_state)
 				: type(type),
 				  new_state(new_state),
-				  enqueued_time(std::chrono::system_clock::now())
+				  enqueued_time(std::chrono::steady_clock::now())
 			{
 			}
 
@@ -374,22 +374,23 @@ namespace ov
 
 			void UpdateTime()
 			{
-				enqueued_time = std::chrono::system_clock::now();
+				enqueued_time = std::chrono::steady_clock::now();
 			}
 
 			bool IsExpired(int millisecond_time) const
 			{
-				auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - enqueued_time);
+				auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - enqueued_time);
 
 				return (delta.count() >= millisecond_time);
 			}
 
 			String ToString() const
 			{
+				auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - enqueued_time).count();
 				auto description = String::FormatString(
-					"<DispatchCommand: %p, %s, type: %s",
+					"<DispatchCommand: %p, elapsed: %" PRId64 "ms, type: %s",
 					this,
-					Converter::ToISO8601String(enqueued_time).CStr(),
+					elapsed_ms,
 					StringFromType(type));
 
 				if (type == DispatchCommand::Type::SendTo)
@@ -417,7 +418,7 @@ namespace ov
 			SocketAddress address;
 			SocketAddressPair address_pair;
 			std::shared_ptr<const Data> data;
-			std::chrono::time_point<std::chrono::system_clock> enqueued_time;
+			std::chrono::time_point<std::chrono::steady_clock> enqueued_time;
 		};
 
 	protected:
@@ -556,7 +557,7 @@ namespace ov
 		void UpdateLastRecvTime();
 		void UpdateLastSentTime();
 
-		std::chrono::system_clock::time_point _last_recv_time = std::chrono::system_clock::now();
-		std::chrono::system_clock::time_point _last_sent_time = std::chrono::system_clock::now();
+		std::chrono::steady_clock::time_point _last_recv_time = std::chrono::steady_clock::now();
+		std::chrono::steady_clock::time_point _last_sent_time = std::chrono::steady_clock::now();
 	};
 }  // namespace ov

--- a/src/projects/base/provider/pull_provider/application.cpp
+++ b/src/projects/base/provider/pull_provider/application.cpp
@@ -81,7 +81,7 @@ namespace pvd
 				}
 				else
 				{
-					auto current = std::chrono::high_resolution_clock::now();
+					auto current = std::chrono::steady_clock::now();
 
 					// Default Properties of PullStream
 					auto is_persistent = false;
@@ -153,8 +153,8 @@ namespace pvd
 					auto stream_metrics = StreamMetrics(*std::static_pointer_cast<info::Stream>(stream));
 					if(stream_metrics != nullptr)
 					{
-						int64_t elapsed_time_from_last_sent = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastSentTime()).count();
-						int64_t elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastRecvTime()).count();
+						int64_t elapsed_time_from_last_sent = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastSentTimeSteady()).count();
+						int64_t elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastRecvTimeSteady()).count();
 
 						if((elapsed_time_from_last_sent > unused_stream_timeout_ms) && (!is_persistent))
 						{

--- a/src/projects/base/provider/pull_provider/stream_props.h
+++ b/src/projects/base/provider/pull_provider/stream_props.h
@@ -140,16 +140,16 @@ namespace pvd
 		// TODO: However, it doesn't seem suitable for use in this class. This should be moved to another class.
 		void UpdateFailbackCheckTime()
 		{
-			_last_failback_check_time = std::chrono::system_clock::now();
+			_last_failback_check_time = std::chrono::steady_clock::now();
 		}
 
-		std::chrono::system_clock::time_point GetLastFailbackCheckTime()
+		std::chrono::steady_clock::time_point GetLastFailbackCheckTime()
 		{
 			return _last_failback_check_time;
 		}
 
 	private:
-		std::chrono::system_clock::time_point _last_failback_check_time;
+		std::chrono::steady_clock::time_point _last_failback_check_time;
 	};
 
 }  // namespace pvd

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -84,11 +84,11 @@ namespace pvd
 		auto last_pkt_received_time_us = _last_pkt_received_time_us.load();
 		if (last_pkt_received_time_us >= 0)
 		{
-			auto current_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
+			int64_t current_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
 				std::chrono::steady_clock::now().time_since_epoch()).count();
-			auto reconnection_time_us = current_time_us - last_pkt_received_time_us;
+			int64_t reconnection_time_us = current_time_us - last_pkt_received_time_us;
 
-			logti("Time taken to reconnect is %" PRId64 " milliseconds. add to the basetime", reconnection_time_us/1000);
+			logti("Time taken to reconnect is %" PRId64 " milliseconds. add to the basetime", reconnection_time_us / 1000);
 
 			_base_timestamp_us += reconnection_time_us;
 		}

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -85,7 +85,7 @@ namespace pvd
 		if (last_pkt_received_time_us >= 0)
 		{
 			auto current_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
-				std::chrono::system_clock::now().time_since_epoch()).count();
+				std::chrono::steady_clock::now().time_since_epoch()).count();
 			auto reconnection_time_us = current_time_us - last_pkt_received_time_us;
 
 			logti("Time taken to reconnect is %" PRId64 " milliseconds. add to the basetime", reconnection_time_us/1000);
@@ -345,7 +345,7 @@ namespace pvd
 		MonitorInstance->IncreaseBytesIn(*GetSharedPtrAs<info::Stream>(), packet->GetDataLength());
 
 		_last_pkt_received_time_us = std::chrono::duration_cast<std::chrono::microseconds>(
-			std::chrono::system_clock::now().time_since_epoch()).count();
+			std::chrono::steady_clock::now().time_since_epoch()).count();
 
 		auto master_clock_track = GetMediaTrackByOrder(cmn::MediaType::Video, 0);
 		if (master_clock_track == nullptr)

--- a/src/projects/mediarouter/mediarouter_stats.cpp
+++ b/src/projects/mediarouter/mediarouter_stats.cpp
@@ -17,7 +17,7 @@ using namespace cmn;
 
 MediaRouterStats::MediaRouterStats()
 {
-	_stat_start_time = std::chrono::system_clock::now();
+	_stat_start_time = std::chrono::steady_clock::now();
 	_stop_watch.Start();
 }
 
@@ -55,7 +55,7 @@ void MediaRouterStats::Update(
 	if (_stop_watch.IsElapsed(5000) && _stop_watch.Update())
 	{
 		// Uptime
-		int64_t uptime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _stat_start_time).count();
+		int64_t uptime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _stat_start_time).count();
 
 		int64_t min_pts = -1LL;
 		int64_t max_pts = -1LL;

--- a/src/projects/mediarouter/mediarouter_stats.h
+++ b/src/projects/mediarouter/mediarouter_stats.h
@@ -43,6 +43,6 @@ public:
 
 	// Time for statistics
 	ov::StopWatch _stop_watch;
-	std::chrono::time_point<std::chrono::system_clock> _last_recv_time;
-	std::chrono::time_point<std::chrono::system_clock> _stat_start_time;
+	std::chrono::time_point<std::chrono::steady_clock> _last_recv_time;
+	std::chrono::time_point<std::chrono::steady_clock> _stat_start_time;
 };

--- a/src/projects/mediarouter/mediarouter_stats.h
+++ b/src/projects/mediarouter/mediarouter_stats.h
@@ -43,6 +43,5 @@ public:
 
 	// Time for statistics
 	ov::StopWatch _stop_watch;
-	std::chrono::time_point<std::chrono::steady_clock> _last_recv_time;
 	std::chrono::time_point<std::chrono::steady_clock> _stat_start_time;
 };

--- a/src/projects/mediarouter/mediarouter_stream.h
+++ b/src/projects/mediarouter/mediarouter_stream.h
@@ -47,19 +47,19 @@ public:
 		MirrorBufferItem(std::shared_ptr<MediaPacket> &packet)
 			: packet(packet)
 		{
-			created_time = std::chrono::system_clock::now();
+			created_time = std::chrono::steady_clock::now();
 		}
 
 		// Elapsed milliseconds
 		int64_t GetElapsedMilliseconds()
 		{
-			auto now = std::chrono::system_clock::now();
+			auto now = std::chrono::steady_clock::now();
 			auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - created_time);
 			return elapsed.count();
 		}
 
 		// timepoint created
-		std::chrono::time_point<std::chrono::system_clock> created_time;
+		std::chrono::time_point<std::chrono::steady_clock> created_time;
 		std::shared_ptr<MediaPacket> packet;
 	};
 	std::vector<std::shared_ptr<MirrorBufferItem>> GetMirrorBuffer();

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -59,7 +59,7 @@ namespace ffmpeg
 			return 1;
 		}
 
-		auto ellapse = std::chrono::high_resolution_clock::now() - writer->GetLastPacketSentTime();
+		auto ellapse = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
 		if(writer->GetState() == WriterStateClosed)
 		{
 			logte("Writer is closed. stop the writer.");
@@ -332,7 +332,7 @@ namespace ffmpeg
 
 		if (!(av_format->oformat->flags & AVFMT_NOFILE))
 		{
-			_last_packet_sent_time = std::chrono::high_resolution_clock::now();
+			_last_packet_sent_time = std::chrono::steady_clock::now();
 			int error = avio_open2(&av_format->pb, av_format->url, AVIO_FLAG_WRITE, &_interrupt_cb, nullptr);
 			if (error < 0)
 			{
@@ -347,7 +347,7 @@ namespace ffmpeg
 		_need_to_close = true;
 
 		// Write header
-		_last_packet_sent_time = std::chrono::high_resolution_clock::now();
+		_last_packet_sent_time = std::chrono::steady_clock::now();
 
 		// Disable edts box
 		AVDictionary *format_options = nullptr;
@@ -589,7 +589,7 @@ namespace ffmpeg
 			return false;
 		}
 
-		_last_packet_sent_time = std::chrono::high_resolution_clock::now();
+		_last_packet_sent_time = std::chrono::steady_clock::now();
 
 		std::unique_lock<std::shared_mutex> mlock(_av_format_lock);
 
@@ -633,7 +633,7 @@ namespace ffmpeg
 		return true;
 	}
 
-	std::chrono::high_resolution_clock::time_point Writer::GetLastPacketSentTime()
+	std::chrono::steady_clock::time_point Writer::GetLastPacketSentTime()
 	{
 		return _last_packet_sent_time;
 	}

--- a/src/projects/modules/ffmpeg/writer.cpp
+++ b/src/projects/modules/ffmpeg/writer.cpp
@@ -59,7 +59,7 @@ namespace ffmpeg
 			return 1;
 		}
 
-		auto ellapse = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
+		auto elapsed = std::chrono::steady_clock::now() - writer->GetLastPacketSentTime();
 		if(writer->GetState() == WriterStateClosed)
 		{
 			logte("Writer is closed. stop the writer.");
@@ -67,19 +67,19 @@ namespace ffmpeg
 		}
 		else if(writer->GetState() == WriterStateConnecting)
 		{
-			auto ellapse_ms = std::chrono::duration_cast<std::chrono::milliseconds>(ellapse).count();
-			if(ellapse_ms > writer->GetConnectionTimeout())
+			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+			if(elapsed_ms > writer->GetConnectionTimeout())
 			{
-				logte("connection timeout occurred. stop the writer. %" PRId64 " milliseconds. ", ellapse_ms);
+				logte("connection timeout occurred. stop the writer. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}
 		else if(writer->GetState() == WriterStateConnected)
 		{
-			auto ellapse_ms = std::chrono::duration_cast<std::chrono::milliseconds>(ellapse).count();
-			if(ellapse_ms > writer->GetSendTimeout())
+			int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+			if(elapsed_ms > writer->GetSendTimeout())
 			{
-				logte("Send timeout occurred. stop the writer. %" PRId64 " milliseconds. ", ellapse_ms);
+				logte("Send timeout occurred. stop the writer. %" PRId64 " milliseconds. ", elapsed_ms);
 				return 1;
 			}
 		}

--- a/src/projects/modules/ffmpeg/writer.h
+++ b/src/projects/modules/ffmpeg/writer.h
@@ -74,7 +74,7 @@ namespace ffmpeg
 		int32_t GetTrackCountByType(cmn::MediaType media_type);
 		std::shared_ptr<MediaTrack> GetTrackByTrackId(int32_t track_id) const;
 				
-		std::chrono::high_resolution_clock::time_point GetLastPacketSentTime();
+		std::chrono::steady_clock::time_point GetLastPacketSentTime();
 
 		void SetTimestampMode(TimestampMode mode);
 		TimestampMode GetTimestampMode();
@@ -116,7 +116,7 @@ namespace ffmpeg
 
 		ov::String _output_format_name;
 		AVIOInterruptCB _interrupt_cb;
-		std::chrono::high_resolution_clock::time_point _last_packet_sent_time;
+		std::chrono::steady_clock::time_point _last_packet_sent_time;
 		int32_t _connection_timeout = 5000;	// Default 5s
 		int32_t _send_timeout 		= 2000;	// Default 2s
 

--- a/src/projects/modules/http/server/http_connection.cpp
+++ b/src/projects/modules/http/server/http_connection.cpp
@@ -84,8 +84,8 @@ namespace http
 
 		void HttpConnection::CheckTimeout()
 		{
-			// Check timeout 
-			auto current = std::chrono::high_resolution_clock::now();
+			// Check timeout
+			auto current = std::chrono::steady_clock::now();
 			auto elapsed_time_from_last_sent = std::chrono::duration_cast<std::chrono::milliseconds>(current - _client_socket->GetLastSentTime()).count();
 			auto elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - _client_socket->GetLastRecvTime()).count();
 

--- a/src/projects/modules/ice/ice_port.h
+++ b/src/projects/modules/ice/ice_port.h
@@ -136,7 +136,7 @@ private:
 		{
 			_transaction_id = transaction_id;
 			_ice_session = ice_session;
-			_requested_time = std::chrono::system_clock::now();
+			_requested_time = std::chrono::steady_clock::now();
 		}
 
 		bool IsExpired() const
@@ -151,7 +151,7 @@ private:
 
 		ov::String _transaction_id;
 		std::shared_ptr<IceSession> _ice_session;
-		std::chrono::time_point<std::chrono::system_clock>	_requested_time;
+		std::chrono::time_point<std::chrono::steady_clock>	_requested_time;
 	};
 
 	std::atomic<session_id_t> _session_id_counter;

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -38,7 +38,7 @@ ov::String IceSession::ToString() const
 void IceSession::Refresh()
 {
 	std::scoped_lock lock(_expire_time_mutex);
-	_expire_time = std::chrono::system_clock::now() + std::chrono::milliseconds(_expire_after_ms);
+	_expire_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(_expire_after_ms);
 }
 
 bool IceSession::IsExpired() const
@@ -49,7 +49,7 @@ bool IceSession::IsExpired() const
 	}
 
 	std::shared_lock lock(_expire_time_mutex);
-	return (std::chrono::system_clock::now() > _expire_time);
+	return (std::chrono::steady_clock::now() > _expire_time);
 }
 
 void IceSession::SetState(IceConnectionState state)

--- a/src/projects/modules/ice/ice_session.h
+++ b/src/projects/modules/ice/ice_session.h
@@ -112,7 +112,7 @@ private:
     std::map<ov::SocketAddressPair, std::shared_ptr<IceCandidatePair>> _candidate_pairs;
 
 	mutable std::shared_mutex _expire_time_mutex;
-	std::chrono::time_point<std::chrono::system_clock> _expire_time;
+	std::chrono::time_point<std::chrono::steady_clock> _expire_time;
 	const int _expire_after_ms;
 	const uint64_t _lifetime_epoch_ms;
 

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -37,13 +37,13 @@ namespace ov
 
 			ManagedQueueNode* next;
 
-			std::chrono::high_resolution_clock::time_point _start;
+			std::chrono::steady_clock::time_point _start;
 			bool _urgent = false;
 
 			ManagedQueueNode(const T& value, bool urgent, ManagedQueueNode* next_node = nullptr)
-				: data(value), next(next_node), _start(std::chrono::high_resolution_clock::time_point::min()), _urgent(urgent)
+				: data(value), next(next_node), _start(std::chrono::steady_clock::time_point::min()), _urgent(urgent)
 			{
-				_start = std::chrono::high_resolution_clock::now();
+				_start = std::chrono::steady_clock::now();
 			}
 		};
 
@@ -135,7 +135,7 @@ namespace ov
 
 			if (_size == 0)
 			{
-				std::chrono::system_clock::time_point expire = (timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 					return (((_size == 0) == false) || _stop);
@@ -169,7 +169,7 @@ namespace ov
 
 			if (_size == 0)
 			{
-				std::chrono::system_clock::time_point expire = (timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 					return (((_size == 0) == false) || _stop);
@@ -195,8 +195,8 @@ namespace ov
 
 			// Compute the hard deadline from the caller-supplied timeout.
 			auto deadline = (timeout != Infinite)
-				? std::chrono::system_clock::now() + std::chrono::milliseconds(timeout)
-				: std::chrono::system_clock::time_point::max();
+				? std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout)
+				: std::chrono::steady_clock::time_point::max();
 
 			// Wait loop: expire is recalculated on every wakeup so that the
 			// buffering_delay timer fires correctly even when no new packets
@@ -235,7 +235,7 @@ namespace ov
 						// Time elapsed between the check above and here — ready now.
 						continue;
 					}
-					auto buffering_expire = std::chrono::system_clock::now() + std::chrono::milliseconds(remaining_ms);
+					auto buffering_expire = std::chrono::steady_clock::now() + std::chrono::milliseconds(remaining_ms);
 					if (buffering_expire < expire)
 					{
 						expire = buffering_expire;
@@ -245,7 +245,7 @@ namespace ov
 				_condition.wait_until(unique_lock, expire);
 
 				// Check the hard deadline after waking.
-				if (timeout != Infinite && std::chrono::system_clock::now() >= deadline)
+				if (timeout != Infinite && std::chrono::steady_clock::now() >= deadline)
 				{
 					return {};	// timed out
 				}
@@ -271,9 +271,9 @@ namespace ov
 			_output_message_count++;
 
 			// Update statistics of waiting time (microseconds)
-			if (node->_start != std::chrono::system_clock::time_point::max())
+			if (node->_start != std::chrono::steady_clock::time_point::max())
 			{
-				auto current = std::chrono::high_resolution_clock::now();
+				auto current = std::chrono::steady_clock::now();
 				_waiting_time_in_us = _waiting_time_in_us * 0.9 + std::chrono::duration_cast<std::chrono::microseconds>(current - node->_start).count() * 0.1;
 			}
 
@@ -383,7 +383,7 @@ namespace ov
 				return ov::Infinite;
 			}
 
-			auto current = std::chrono::high_resolution_clock::now();
+			auto current = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(current - _front_node->_start).count();
 		}
 
@@ -413,7 +413,7 @@ namespace ov
 			// Wait until the queue size is less than threshold
 			if(_exceed_threshold_and_wait_enabled == true)
 			{
-				std::chrono::system_clock::time_point expire = (timeout == Infinite) ? std::chrono::system_clock::time_point::max() : std::chrono::system_clock::now() + std::chrono::milliseconds(timeout);
+				std::chrono::steady_clock::time_point expire = (timeout == Infinite) ? std::chrono::steady_clock::time_point::max() : std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
 				auto result = _condition.wait_until(unique_lock, expire, [this]() -> bool {
 					return (!IsThresholdExceeded());
 				});

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.cpp
@@ -26,7 +26,7 @@ void RtcpReportBlockGenerator::AddRTPPacketInfo(const std::shared_ptr<RtpPacket>
 		// Calculate interarrival jitter
 		uint32_t rtp_timestamp_diff = rtp_packet->Timestamp() - _last_rtp_timestamp;
 
-		// Get wall clock time in milliseconds
+		// Elapsed milliseconds since the last RTP packet was received (monotonic)
 		auto clock_timestamp_diff = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _last_rtp_received_time).count();
 
 		// Calculate clock_timestamp_diff in RTP timestamp units
@@ -106,7 +106,7 @@ std::shared_ptr<RtcpPacket> RtcpReportBlockGenerator::PopRtcpRRPacket()
 	uint32_t delay_since_last_sender_report = 0;
 	if (last_sender_report_timestamp != 0)
 	{
-		// Get wall clock time in milliseconds
+		// Elapsed milliseconds since the last SR was received (monotonic)
 		auto delay = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _last_sender_report_received_time).count();
 
 		// Convert to delay since last SR in 65536 units

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.cpp
@@ -27,7 +27,7 @@ void RtcpReportBlockGenerator::AddRTPPacketInfo(const std::shared_ptr<RtpPacket>
 		uint32_t rtp_timestamp_diff = rtp_packet->Timestamp() - _last_rtp_timestamp;
 
 		// Get wall clock time in milliseconds
-		auto clock_timestamp_diff = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _last_rtp_received_time).count();
+		auto clock_timestamp_diff = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _last_rtp_received_time).count();
 
 		// Calculate clock_timestamp_diff in RTP timestamp units
 		clock_timestamp_diff = (clock_timestamp_diff * _codec_rate) / 1000;
@@ -44,7 +44,7 @@ void RtcpReportBlockGenerator::AddRTPPacketInfo(const std::shared_ptr<RtpPacket>
 
 	_last_sequence_number = rtp_packet->SequenceNumber();
 	_last_rtp_timestamp = rtp_packet->Timestamp();
-	_last_rtp_received_time = std::chrono::system_clock::now();
+	_last_rtp_received_time = std::chrono::steady_clock::now();
 
 	_packet_count += 1;
 	_session_packet_count += 1;
@@ -60,7 +60,7 @@ void RtcpReportBlockGenerator::AddSenderReportInfo(const std::shared_ptr<SenderR
 	
 	_last_sender_report_timestamp = lsr;
 
-	_last_sender_report_received_time = std::chrono::system_clock::now();
+	_last_sender_report_received_time = std::chrono::steady_clock::now();
 }
 
 bool RtcpReportBlockGenerator::IsAvailableRtcpRRPacket() const
@@ -107,7 +107,7 @@ std::shared_ptr<RtcpPacket> RtcpReportBlockGenerator::PopRtcpRRPacket()
 	if (last_sender_report_timestamp != 0)
 	{
 		// Get wall clock time in milliseconds
-		auto delay = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _last_sender_report_received_time).count();
+		auto delay = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _last_sender_report_received_time).count();
 
 		// Convert to delay since last SR in 65536 units
 		delay_since_last_sender_report = (delay * 65536) / 1000;

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_report_block_generator.h
@@ -36,8 +36,8 @@ private:
 
 	uint32_t _interarrival_jitter = 0;
 	uint32_t _last_rtp_timestamp = 0;
-	std::chrono::system_clock::time_point _last_rtp_received_time;
+	std::chrono::steady_clock::time_point _last_rtp_received_time;
 
 	uint32_t _last_sender_report_timestamp = 0;
-	std::chrono::system_clock::time_point _last_sender_report_received_time;
+	std::chrono::steady_clock::time_point _last_sender_report_received_time;
 };

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_sr_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_sr_generator.cpp
@@ -5,8 +5,8 @@ RtcpSRGenerator::RtcpSRGenerator(uint32_t ssrc, uint32_t codec_rate)
 {
     _ssrc = ssrc;
 	_codec_rate = codec_rate;
-    _created_time = std::chrono::system_clock::now();
-    _last_generated_time = std::chrono::system_clock::now();
+    _created_time = std::chrono::steady_clock::now();
+    _last_generated_time = std::chrono::steady_clock::now();
 }
 
 void RtcpSRGenerator::AddRTPPacketInfo(const std::shared_ptr<RtpPacket> &rtp_packet)
@@ -53,7 +53,7 @@ std::shared_ptr<RtcpPacket> RtcpSRGenerator::PopRtcpSRPacket()
 	// Reset RTCP information
 	_packet_count = 0;
 	_octec_count = 0;
-	_last_generated_time = std::chrono::system_clock::now();
+	_last_generated_time = std::chrono::steady_clock::now();
 	_rtcp_generated_count++;
 
     return rtcp_packet;
@@ -61,10 +61,10 @@ std::shared_ptr<RtcpPacket> RtcpSRGenerator::PopRtcpSRPacket()
 
 uint32_t RtcpSRGenerator::GetElapsedTimeMSFromCreated()
 {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _created_time).count();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _created_time).count();
 }
 
 uint32_t RtcpSRGenerator::GetElapsedTimeMSFromRtcpSRGenerated()
 {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - _last_generated_time).count();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _last_generated_time).count();
 }

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_sr_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_sr_generator.h
@@ -24,8 +24,8 @@ private:
     uint32_t    _packet_count = 0;
     uint32_t    _octec_count = 0;
 
-	std::chrono::system_clock::time_point _created_time;
-    std::chrono::system_clock::time_point _last_generated_time;
+	std::chrono::steady_clock::time_point _created_time;
+    std::chrono::steady_clock::time_point _last_generated_time;
 	uint32_t	_codec_rate = 1;
 
 	std::shared_ptr<RtcpPacket>	_rtcp_packet = nullptr;

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.cpp
@@ -18,7 +18,7 @@ RtcpTransportCcFeedbackGenerator::RtcpTransportCcFeedbackGenerator(uint8_t exten
 	_extension_id = extension_id;
 	_sender_ssrc = sender_ssrc;
 
-	_created_time = std::chrono::system_clock::now();
+	_created_time = std::chrono::steady_clock::now();
 	_last_report_time = _created_time;
 }
 
@@ -58,7 +58,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 		_transport_cc->SetBaseSequenceNumber(wide_sequence_number);
 
 		// Reference time
-		_last_reference_time = std::chrono::system_clock::now();
+		_last_reference_time = std::chrono::steady_clock::now();
 
 		// multiples of 64ms
 		uint32_t reference_time = std::chrono::duration_cast<std::chrono::milliseconds>(_last_reference_time - _created_time).count() / 64;
@@ -99,7 +99,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 	else
 	{
 		// delta : multiple of 250us from the last rtp received time
-		auto now = std::chrono::system_clock::now();
+		auto now = std::chrono::steady_clock::now();
 		int64_t diff = std::chrono::duration_cast<std::chrono::microseconds>(now - _last_rtp_received_time).count();
 		delta = diff / 250;
 
@@ -156,7 +156,7 @@ bool RtcpTransportCcFeedbackGenerator::AddReceivedRtpPacket(const std::shared_pt
 
 bool RtcpTransportCcFeedbackGenerator::HasElapsedSinceLastTransportCc(uint32_t milliseconds)
 {
-	auto now = std::chrono::system_clock::now();
+	auto now = std::chrono::steady_clock::now();
 	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_report_time).count();
 
 	if (elapsed >= milliseconds)
@@ -182,7 +182,7 @@ std::shared_ptr<RtcpPacket> RtcpTransportCcFeedbackGenerator::GenerateTransportC
 	auto rtcp_packet = std::make_shared<RtcpPacket>();
 	rtcp_packet->Build(_transport_cc);
 
-	_last_report_time = std::chrono::system_clock::now();
+	_last_report_time = std::chrono::steady_clock::now();
 
 	_transport_cc.reset();
 

--- a/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
+++ b/src/projects/modules/rtp_rtcp/rtcp_info/rtcp_transport_cc_feedback_generator.h
@@ -70,7 +70,7 @@ public:
 	}
 
 private:
-	std::chrono::high_resolution_clock::time_point _created_time;
+	std::chrono::steady_clock::time_point _created_time;
 	uint8_t _extension_id = 0;
 	uint32_t _sender_ssrc = 0;
 	uint32_t _last_media_ssrc = 0;
@@ -80,9 +80,9 @@ private:
 
 	uint8_t _fb_pkt_count = 0;
 
-	std::chrono::high_resolution_clock::time_point _last_reference_time; // multiples of 64ms, now() - created_time base
-	std::chrono::high_resolution_clock::time_point _last_rtp_received_time;
+	std::chrono::steady_clock::time_point _last_reference_time; // multiples of 64ms, now() - created_time base
+	std::chrono::steady_clock::time_point _last_rtp_received_time;
 	std::shared_ptr<TransportCc> _transport_cc = nullptr;
 
-	std::chrono::high_resolution_clock::time_point _last_report_time;
+	std::chrono::steady_clock::time_point _last_report_time;
 };

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
@@ -98,7 +98,7 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 		auto now = std::chrono::steady_clock::now();
 		int64_t rtp_received_time_diff = std::chrono::duration_cast<std::chrono::microseconds>(now - _last_rtp_received_time).count();
 
-		// Calculate wall clock diff in RTP timestamp units
+		// Convert the elapsed (monotonic) time diff to RTP timestamp units
 		rtp_received_time_diff = (uint32_t)((double)rtp_received_time_diff / 1000000.0 * (double)_clock_rate);
 
 		// J(i) = J(i-1) + (|D(i-1,i)| - J(i-1))/16

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.cpp
@@ -33,7 +33,7 @@ bool RtpReceiveStatistics::AddReceivedRtpPacket(const std::shared_ptr<RtpPacket>
 
 bool RtpReceiveStatistics::AddReceivedRtcpSenderReport(const std::shared_ptr<SenderReport> &report)
 {
-	_last_sr_received_time = std::chrono::system_clock::now();
+	_last_sr_received_time = std::chrono::steady_clock::now();
 
 	// the middle 32 bits out of 64 in the NTP timestamp
 	uint64_t ntp_timestamp = (uint64_t)report->GetMsw() << 32 | (uint64_t)report->GetLsw();
@@ -95,7 +95,7 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 	{
 		int64_t rtp_timestamp_diff = packet->Timestamp() - _last_rtp_timestamp;
 
-		auto now = std::chrono::system_clock::now();
+		auto now = std::chrono::steady_clock::now();
 		int64_t rtp_received_time_diff = std::chrono::duration_cast<std::chrono::microseconds>(now - _last_rtp_received_time).count();
 
 		// Calculate wall clock diff in RTP timestamp units
@@ -114,7 +114,7 @@ bool RtpReceiveStatistics::UpdateStat(const std::shared_ptr<RtpPacket> &packet)
 	}
 	else if (_received_packets == 0)
 	{
-		_last_rtp_received_time = std::chrono::system_clock::now();
+		_last_rtp_received_time = std::chrono::steady_clock::now();
 		_last_rtp_timestamp = packet->Timestamp();
 	}
 
@@ -166,7 +166,7 @@ std::shared_ptr<ReportBlock> RtpReceiveStatistics::GenerateReportBlock()
 	if (_last_sr_timestamp != 0)
 	{
 		// get delay since _last_sr_received_time in us
-		auto delay_in_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - _last_sr_received_time).count();
+		auto delay_in_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - _last_sr_received_time).count();
 		
 		// convert to 1/65536 second
 		dlsr = (uint32_t)((double)delay_in_us / 1000000.0 * 65536.0);

--- a/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
+++ b/src/projects/modules/rtp_rtcp/rtp_receive_statistics.h
@@ -39,7 +39,7 @@ private:
 	uint32_t	_clock_rate = 0;
 
 	// From SR
-	std::chrono::system_clock::time_point _last_sr_received_time;
+	std::chrono::steady_clock::time_point _last_sr_received_time;
 	uint32_t	_last_sr_timestamp = 0;
 
 	// For Receiver Report
@@ -55,7 +55,7 @@ private:
 	uint32_t	_interarrival_jitter = 0;
 
 	uint32_t 	_last_rtp_timestamp = 0;
-	std::chrono::system_clock::time_point _last_rtp_received_time;
+	std::chrono::steady_clock::time_point _last_rtp_received_time;
 
 	uint32_t	_received_bytes = 0;
 

--- a/src/projects/monitoring/common_metrics.cpp
+++ b/src/projects/monitoring/common_metrics.cpp
@@ -26,10 +26,12 @@ namespace mon
 		_last_throughtput_out		  = 0;
 		_last_total_bytes_out		  = 0;
 
-		_last_throughput_measure_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+		_last_throughput_measure_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 		_max_total_connection_time	  = std::chrono::system_clock::now();
 		_last_recv_time				  = std::chrono::system_clock::now();
 		_last_sent_time				  = std::chrono::system_clock::now();
+		_last_recv_time_steady		  = std::chrono::steady_clock::now();
+		_last_sent_time_steady		  = std::chrono::steady_clock::now();
 
 		for (int i = 0; i < static_cast<int8_t>(PublisherType::NumberOfPublishers); i++)
 		{
@@ -77,12 +79,6 @@ namespace mon
 	void CommonMetrics::ShowInfo([[maybe_unused]] bool show_children)
 	{
 		logti("%s", GetInfoString().CStr());
-	}
-
-	uint32_t CommonMetrics::GetUnusedTimeSec() const
-	{
-		auto current = std::chrono::high_resolution_clock::now();
-		return std::chrono::duration_cast<std::chrono::seconds>(current - GetLastUpdatedTime()).count();
 	}
 
 	const std::chrono::system_clock::time_point &CommonMetrics::GetCreatedTime() const
@@ -158,6 +154,16 @@ namespace mon
 		return _last_sent_time;
 	}
 
+	std::chrono::steady_clock::time_point CommonMetrics::GetLastRecvTimeSteady() const
+	{
+		return _last_recv_time_steady;
+	}
+
+	std::chrono::steady_clock::time_point CommonMetrics::GetLastSentTimeSteady() const
+	{
+		return _last_sent_time_steady;
+	}
+
 	uint64_t CommonMetrics::GetBytesOut(PublisherType type) const
 	{
 		return _publisher_metrics[static_cast<int8_t>(type)]._bytes_out;
@@ -180,6 +186,7 @@ namespace mon
 	{
 		_total_bytes_in += value;
 		_last_recv_time = std::chrono::system_clock::now();
+		_last_recv_time_steady = std::chrono::steady_clock::now();
 
 		// If there are no clients of the publisher, output throughput is not calculated.
 		// So, In/Oout throughput calculations are handled here.
@@ -198,6 +205,7 @@ namespace mon
 		_publisher_metrics[static_cast<int8_t>(type)]._bytes_out += value;
 		_total_bytes_out += value;
 		_last_sent_time = std::chrono::system_clock::now();
+		_last_sent_time_steady = std::chrono::steady_clock::now();
 
 		UpdateDate();
 	}
@@ -249,7 +257,7 @@ namespace mon
 
 	void CommonMetrics::UpdateThroughput()
 	{
-		auto now_ms	    = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+		auto now_ms	    = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 		auto last_ms    = _last_throughput_measure_time.load();
 		auto elapsed_ms = now_ms - last_ms;
 

--- a/src/projects/monitoring/common_metrics.h
+++ b/src/projects/monitoring/common_metrics.h
@@ -16,7 +16,6 @@ namespace mon
 		virtual ov::String GetInfoString(bool show_children = true);
 		virtual void ShowInfo(bool show_children = true);
 
-		uint32_t GetUnusedTimeSec() const;
 		const std::chrono::system_clock::time_point &GetCreatedTime() const;
 		const std::chrono::system_clock::time_point &GetLastUpdatedTime() const;
 
@@ -33,6 +32,9 @@ namespace mon
 		virtual std::chrono::system_clock::time_point GetMaxTotalConnectionsTime() const;
 		virtual std::chrono::system_clock::time_point GetLastRecvTime() const;
 		virtual std::chrono::system_clock::time_point GetLastSentTime() const;
+		// Steady-clock baseline for elapsed-time checks (not affected by wall-clock jumps)
+		virtual std::chrono::steady_clock::time_point GetLastRecvTimeSteady() const;
+		virtual std::chrono::steady_clock::time_point GetLastSentTimeSteady() const;
 		virtual uint64_t GetBytesOut(PublisherType type) const;
 		virtual uint64_t GetConnections(PublisherType type) const;
 		uint32_t GetModuleUsageCount(cmn::MediaCodecModuleId module_id) const;
@@ -69,6 +71,8 @@ namespace mon
 		std::chrono::system_clock::time_point _max_total_connection_time;
 		std::chrono::system_clock::time_point _last_recv_time;
 		std::chrono::system_clock::time_point _last_sent_time;
+		std::chrono::steady_clock::time_point _last_recv_time_steady;
+		std::chrono::steady_clock::time_point _last_sent_time_steady;
 
 		// Throughput from Provider
 		std::atomic<uint64_t> _avg_throughtput_in;

--- a/src/projects/providers/multiplex/multiplex_application.cpp
+++ b/src/projects/providers/multiplex/multiplex_application.cpp
@@ -130,8 +130,8 @@ namespace pvd
 					auto stream_metrics = StreamMetrics(*std::static_pointer_cast<info::Stream>(stream));
 					if (stream_metrics != nullptr)
 					{
-						auto current = std::chrono::high_resolution_clock::now();
-						auto elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastRecvTime()).count();
+						auto current = std::chrono::steady_clock::now();
+						auto elapsed_time_from_last_recv = std::chrono::duration_cast<std::chrono::milliseconds>(current - stream_metrics->GetLastRecvTimeSteady()).count();
 
 						if (elapsed_time_from_last_recv > _packet_silence_timeout_ms)
 						{

--- a/src/projects/transcoder/filter/filter_rescaler.cpp
+++ b/src/projects/transcoder/filter/filter_rescaler.cpp
@@ -759,9 +759,9 @@ void FilterRescaler::WorkerThread()
 			}
 			else
 			{
-				auto start_time = std::chrono::high_resolution_clock::now();
+				auto start_time = std::chrono::steady_clock::now();
 				DO_FILTER_ONCE(frame);
-				auto elapsed_time_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count();
+				auto elapsed_time_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
 
 				// Update the weighted average frame processing time
 				// It includes the time taken for filtering + overlay + delivery to the encoder (including waiting time if there is a load on the encoder).

--- a/src/projects/transcoder/transcoder_alert.h
+++ b/src/projects/transcoder/transcoder_alert.h
@@ -61,20 +61,20 @@ private:
 			auto record				 = std::make_shared<ErrorRecord>();
 			record->error_type		 = type;
 			record->track_id		 = track_id;
-			record->first_error_time = std::chrono::system_clock::now();
+			record->first_error_time = std::chrono::steady_clock::now();
 			record->error_count		 = 1;
 			return record;
 		}
 
 		uint32_t GetElapsedMs()
 		{
-			auto now = std::chrono::system_clock::now();
+			auto now = std::chrono::steady_clock::now();
 			return std::chrono::duration_cast<std::chrono::milliseconds>(now - first_error_time).count();
 		}
 
 		void Reset()
 		{
-			first_error_time = std::chrono::system_clock::now();
+			first_error_time = std::chrono::steady_clock::now();
 			error_count	  = 0;
 		}
 
@@ -89,7 +89,7 @@ private:
 		}
 		
 	public:
-		std::chrono::system_clock::time_point first_error_time;
+		std::chrono::steady_clock::time_point first_error_time;
 		int32_t error_count = 0;
 		ErrorType error_type;
 		uint32_t track_id;


### PR DESCRIPTION
## Problem

Internal elapsed time, timeout, and scheduling logic was based on `std::chrono::system_clock`, which tracks wall clock. NTP corrections, manual time changes, or DST transitions can shift wall clock backward or forward, which causes timers to misfire, watchdogs to trip incorrectly, and elapsed time statistics to drift.

Some places also used `std::chrono::high_resolution_clock`, which aliases to `system_clock` on libstdc++ (Linux) but to `steady_clock` on libc++ (macOS), so behavior diverged across platforms.

## Solution

Internal elapsed time and timeout calculations now use `std::chrono::steady_clock`, which is monotonic and unaffected by wall clock changes. Wall clock semantics (JSON timestamps in the monitoring API, ISO8601 export, file naming, HLS PROGRAM-DATE-TIME, RTP NTP timestamps) keep using `system_clock`.

For fields used for both display and elapsed measurement (`CommonMetrics::_last_recv_time` and `_last_sent_time`, `info::Push::_Push_start_time`, `info::Record::_record_start_time`), a parallel `_steady` field and matching getter were added so JSON serialization keeps wall clock values while internal logic compares against the monotonic baseline.

All `high_resolution_clock` usages were replaced with the appropriate explicit clock.

Two unused functions (`info::Stream::GetUptimeSec`, `mon::CommonMetrics::GetUnusedTimeSec`) were removed.