### PR TITLE
fix: create dynamic application for HTTP publishers with wildcard template

### DIFF
--- a/src/projects/publishers/hls/hls_publisher.cpp
+++ b/src/projects/publishers/hls/hls_publisher.cpp
@@ -352,31 +352,30 @@ std::shared_ptr<TsHttpInterceptor> HlsPublisher::CreateInterceptor()
 		}
 
 		auto application = std::static_pointer_cast<HlsApplication>(GetApplicationByName(vhost_app_name));
-		if (application == nullptr)
+		auto stream = std::static_pointer_cast<HlsStream>(GetStream(vhost_app_name, stream_name));
+		if (stream == nullptr)
 		{
-			logte("Cannot find application (%s)", vhost_app_name.CStr());
+			// PullStream may create the app from the wildcard template
+			stream = std::dynamic_pointer_cast<HlsStream>(PullStream(final_url, vhost_app_name, host_name, stream_name));
+			if (stream != nullptr)
+			{
+				if (application == nullptr)
+				{
+					application = std::static_pointer_cast<HlsApplication>(GetApplicationByName(vhost_app_name));
+				}
+				logti("URL %s is requested", stream->GetMediaSource().CStr());
+			}
+		}
+
+		if (application == nullptr || stream == nullptr)
+		{
+			logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
 			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
 
 		// Cors Setting
 		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
-
-		auto stream = std::static_pointer_cast<HlsStream>(GetStream(vhost_app_name, stream_name));
-		if (stream == nullptr)
-		{
-			stream = std::dynamic_pointer_cast<HlsStream>(PullStream(final_url, vhost_app_name, host_name, stream_name));
-			if (stream != nullptr)
-			{
-				logti("URL %s is requested", stream->GetMediaSource().CStr());
-			}
-			else
-			{
-				logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
-				response->SetStatusCode(http::StatusCode::NotFound);
-				return http::svr::NextHandler::DoNotCall;
-			}
-		}
 
 		// TODO(Getroot): Improve this so that the player's first request is played immediately. This policy was temporarily changed due to a performance issue at the edge.
 		if (stream->WaitUntilStart(0) == false)

--- a/src/projects/publishers/hls/hls_publisher.cpp
+++ b/src/projects/publishers/hls/hls_publisher.cpp
@@ -367,15 +367,18 @@ std::shared_ptr<TsHttpInterceptor> HlsPublisher::CreateInterceptor()
 			}
 		}
 
+		// Apply CORS once the application is known so error responses still carry the headers
+		if (application != nullptr)
+		{
+			application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
+		}
+
 		if (application == nullptr || stream == nullptr)
 		{
 			logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
 			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
-
-		// Cors Setting
-		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
 
 		// TODO(Getroot): Improve this so that the player's first request is played immediately. This policy was temporarily changed due to a performance issue at the edge.
 		if (stream->WaitUntilStart(0) == false)

--- a/src/projects/publishers/llhls/llhls_publisher.cpp
+++ b/src/projects/publishers/llhls/llhls_publisher.cpp
@@ -358,30 +358,30 @@ std::shared_ptr<LLHlsHttpInterceptor> LLHlsPublisher::CreateInterceptor()
 		}
 
 		auto application = std::static_pointer_cast<LLHlsApplication>(GetApplicationByName(vhost_app_name));
-		if (application == nullptr)
-		{
-			logte("Cannot find application (%s)", vhost_app_name.CStr());
-			response->SetStatusCode(http::StatusCode::NotFound);
-			return http::svr::NextHandler::DoNotCall;
-		}
-		// Cors Setting
-		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
-		
 		auto stream = std::static_pointer_cast<LLHlsStream>(GetStream(vhost_app_name, stream_name));
 		if (stream == nullptr)
 		{
+			// PullStream may create the app from the wildcard template
 			stream = std::dynamic_pointer_cast<LLHlsStream>(PullStream(final_url, vhost_app_name, host_name, stream_name));
 			if (stream != nullptr)
 			{
+				if (application == nullptr)
+				{
+					application = std::static_pointer_cast<LLHlsApplication>(GetApplicationByName(vhost_app_name));
+				}
 				logti("URL %s is requested", stream->GetMediaSource().CStr());
 			}
-			else
-			{
-				logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
-				response->SetStatusCode(http::StatusCode::NotFound);
-				return http::svr::NextHandler::DoNotCall;
-			}
 		}
+
+		if (application == nullptr || stream == nullptr)
+		{
+			logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
+			response->SetStatusCode(http::StatusCode::NotFound);
+			return http::svr::NextHandler::DoNotCall;
+		}
+
+		// Cors Setting
+		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
 
 		// TODO(Getroot): Improve this so that the player's first request is played immediately. This policy was temporarily changed due to a performance issue at the edge.
 		if (stream->WaitUntilStart(0) == false)

--- a/src/projects/publishers/llhls/llhls_publisher.cpp
+++ b/src/projects/publishers/llhls/llhls_publisher.cpp
@@ -373,15 +373,18 @@ std::shared_ptr<LLHlsHttpInterceptor> LLHlsPublisher::CreateInterceptor()
 			}
 		}
 
+		// Apply CORS once the application is known so error responses still carry the headers
+		if (application != nullptr)
+		{
+			application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
+		}
+
 		if (application == nullptr || stream == nullptr)
 		{
 			logte("Cannot find stream (%s/%s)", vhost_app_name.CStr(), stream_name.CStr());
 			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
-
-		// Cors Setting
-		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response, {http::Method::Options, http::Method::Get, http::Method::Head});
 
 		// TODO(Getroot): Improve this so that the player's first request is played immediately. This policy was temporarily changed due to a performance issue at the edge.
 		if (stream->WaitUntilStart(0) == false)

--- a/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
@@ -288,32 +288,28 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			}
 		}
 
-		// Check CORS
+		// PullStream may create the app from the wildcard template
 		auto application = std::static_pointer_cast<ThumbnailApplication>(GetApplicationByName(vhost_app_name));
-		if (application == nullptr)
+		auto stream = GetStream(vhost_app_name, request_url->Stream());
+		if (stream == nullptr)
 		{
-			logte("Cannot find application (%s)", vhost_app_name.CStr());
-			response->AppendString("Could not found application of thumbnail publisher");
+			stream = PullStream(request_url, vhost_app_name, host_name, stream_name);
+			if (stream != nullptr && application == nullptr)
+			{
+				application = std::static_pointer_cast<ThumbnailApplication>(GetApplicationByName(vhost_app_name));
+			}
+		}
+
+		if (application == nullptr || stream == nullptr)
+		{
+			logte("There is no stream or cannot pull a stream. stream(%s)", request_url->Stream().CStr());
+			response->AppendString("There is no stream or cannot pull a stream");
 			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
 
+		// CORS
 		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response);
-
-		// Check Stream
-		auto stream = GetStream(vhost_app_name, request_url->Stream());		
-		if (stream == nullptr)
-		{
-			// If the stream does not exists, request to the provider
-			stream = PullStream(request_url, vhost_app_name, host_name, stream_name);
-			if (stream == nullptr)
-			{
-				logte("There is no stream or cannot pull a stream. stream(%s)", request_url->Stream().CStr());
-				response->AppendString("There is no stream or cannot pull a stream");
-				response->SetStatusCode(http::StatusCode::NotFound);			
-				return http::svr::NextHandler::DoNotCall;
-			}			
-		}
 
 		if(stream->GetState() != pub::Stream::State::STARTED)
 		{

--- a/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
+++ b/src/projects/publishers/thumbnail/thumbnail_publisher.cpp
@@ -288,6 +288,14 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			}
 		}
 
+		if (vhost_app_name.IsValid() == false)
+		{
+			logte("Could not resolve application name from domain: %s", request_url->Host().CStr());
+			response->AppendString("Could not resolve application name from domain");
+			response->SetStatusCode(http::StatusCode::NotFound);
+			return http::svr::NextHandler::DoNotCall;
+		}
+
 		// PullStream may create the app from the wildcard template
 		auto application = std::static_pointer_cast<ThumbnailApplication>(GetApplicationByName(vhost_app_name));
 		auto stream = GetStream(vhost_app_name, request_url->Stream());
@@ -300,6 +308,12 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			}
 		}
 
+		// Apply CORS once the application is known so error responses still carry the headers
+		if (application != nullptr)
+		{
+			application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response);
+		}
+
 		if (application == nullptr || stream == nullptr)
 		{
 			logte("There is no stream or cannot pull a stream. stream(%s)", request_url->Stream().CStr());
@@ -307,9 +321,6 @@ std::shared_ptr<ThumbnailInterceptor> ThumbnailPublisher::CreateInterceptor()
 			response->SetStatusCode(http::StatusCode::NotFound);
 			return http::svr::NextHandler::DoNotCall;
 		}
-
-		// CORS
-		application->GetCorsManager().SetupHttpCorsHeader(vhost_app_name, request, response);
 
 		if(stream->GetState() != pub::Stream::State::STARTED)
 		{


### PR DESCRIPTION
## Problem

With a wildcard application template (`<Name>*</Name>`) combined with `<Origins>` (local OriginMap) or `OriginMapStore`, HTTP-based publishers (LLHLS, HLS, Thumbnail) returned 404 for requests to applications that have not yet been instantiated. Only WebRTC correctly created the dynamic application on demand.

## Solution

Aligned the request flow of LLHLS, HLS, and Thumbnail with WebRTC so that the application is dynamically created from the wildcard template on the first request, regardless of whether local OriginMap or OriginMapStore is configured.

Addresses: #2070