### PR TITLE
build: auto-assign requested reviewer as assignee

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -5,12 +5,13 @@ on:
     types: [review_requested]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:
   assign:
-    if: github.event.requested_reviewer.type == 'User'
+    if: |
+      github.event.requested_reviewer != null &&
+      github.event.requested_reviewer.type == 'User'
     runs-on: ubuntu-latest
     steps:
       - name: Add requested reviewer as assignee

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,24 @@
+name: Auto-assign reviewer
+
+on:
+  pull_request_target:
+    types: [review_requested]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign:
+    if: github.event.requested_reviewer.type == 'User'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add requested reviewer as assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: ${{ github.event.requested_reviewer.login }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/assignees" \
+            -f "assignees[]=${REVIEWER}"


### PR DESCRIPTION
## Problem

The PR list view does not show requested reviewers, so it is not obvious at a glance who is reviewing each PR. The reviewer is auto-picked from the team, but the name only surfaces in the list if it is also set as an assignee, which had to be done manually.

## Solution

Add a workflow that mirrors the requested reviewer to the assignee on every `review_requested` event. Bots are skipped via a `type == 'User'` filter.