### PR TITLE
docs: fix HLS dump example placed inside LLHLS block

### DIFF
--- a/docs/streaming/hls.md
+++ b/docs/streaming/hls.md
@@ -227,11 +227,11 @@ You can create as long a playlist as you want by setting `<DVR>` to the HLS publ
 
 ## Dump
 
-You can dump the HLS stream for VoD. You can enable it by setting the following in `<Application><Publishers><LLHLS>`. Unlike LLHLS, dump function cannot be controlled by REST API at this time.
+You can dump the HLS stream for VoD. You can enable it by setting the following in `<Application><Publishers><HLS>`. Unlike LLHLS, dump function cannot be controlled by REST API at this time.
 
 {% code overflow="wrap" %}
 ```xml
-<LLHLS>
+<HLS>
     <Dumps>
         <Dump>
             <Enable>true</Enable>
@@ -245,7 +245,7 @@ You can dump the HLS stream for VoD. You can enable it by setting the following 
         </Dump>
     </Dumps>
     ...
-</LLHLS>
+</HLS>
 ```
 {% endcode %}
 


### PR DESCRIPTION
## Summary

The `## Dump` section of [docs/streaming/hls.md](docs/streaming/hls.md) wrapped the HLS dump example in `<LLHLS>` tags. The HLS publisher only reads `<HLS><Dumps>`, so a user copying this example would configure an LL-HLS dump and see no HLS dump output.

Replaced the wrapping element (and the surrounding sentence) with `<HLS>`.

Addresses: #2092