### PR TITLE
build: fix permission for auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -5,7 +5,7 @@ on:
     types: [review_requested]
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Problem

The workflow added in #2115 fails with HTTP 403 ("Resource not accessible by integration") when the team auto-assignment fires on a new PR. `issues: write` alone does not grant `GITHUB_TOKEN` permission to add assignees on a PR, even though the underlying REST endpoint sits under `/issues/{n}/assignees`.

## Solution

Use `pull-requests: write` for the assignees API call.

Note: this PR will itself fail the auto-assign workflow check, because `pull_request_target` runs the workflow file from the base branch (master), where the broken version is still in effect. The check will pass on subsequent PRs after this is merged.