### PR TITLE
docs: rewrite legacy GitBook URLs to ovenmedialabs.com /docs/ome paths

### DIFF
--- a/docs-site/access-control/admission-webhooks.md
+++ b/docs-site/access-control/admission-webhooks.md
@@ -117,7 +117,7 @@ As shown below, the trigger condition of request is different for each protocol.
 | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | WebRTC   | When a client requests Offer SDP                                                                                         |
 | RTMP     | When a client sends a publish message                                                                                    |
-| SRT      | When a client send a [streamid](https://docs.ovenmediaengine.com/live-source/srt-beta#encoders-and-streamid) |
+| SRT      | When a client send a [streamid](/docs/ome/live-source/srt#encoders-and-streamid) |
 | LLHLS    | When a client requests a playlist (llhls.m3u8)                                                                           |
 
 ## Response for closing status

--- a/docs-site/access-control/admission-webhooks.md
+++ b/docs-site/access-control/admission-webhooks.md
@@ -117,7 +117,7 @@ As shown below, the trigger condition of request is different for each protocol.
 | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | WebRTC   | When a client requests Offer SDP                                                                                         |
 | RTMP     | When a client sends a publish message                                                                                    |
-| SRT      | When a client send a [streamid](/docs/ome/live-source/srt#encoders-and-streamid) |
+| SRT      | When a client send a [streamid](../live-source/srt.md#encoders-and-streamid) |
 | LLHLS    | When a client requests a playlist (llhls.m3u8)                                                                           |
 
 ## Response for closing status

--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -123,7 +123,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -160,7 +160,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -510,7 +510,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -550,7 +550,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -626,7 +626,7 @@ Finally, `Server.xml` is configured as follows:
             </Host>
 
             <!--
-                Refer to https://docs.ovenmediaengine.com/signedpolicy
+                Refer to /docs/ome/access-control/signedpolicy
             -->
             <!--
             <SignedPolicy>

--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -123,7 +123,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -160,7 +160,7 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <!-- 
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
@@ -510,7 +510,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -550,7 +550,7 @@ Finally, `Server.xml` is configured as follows:
                     <!--
                         If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
                         This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer /docs/ome/streaming/webrtc-publishing#webrtc-over-tcp
+                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
                     -->
                     <TcpRelay>*:3478</TcpRelay>
                     <!--
@@ -626,7 +626,7 @@ Finally, `Server.xml` is configured as follows:
             </Host>
 
             <!--
-                Refer to /docs/ome/access-control/signedpolicy
+                Refer to ../access-control/signedpolicy.md
             -->
             <!--
             <SignedPolicy>

--- a/docs-site/live-source/srt.md
+++ b/docs-site/live-source/srt.md
@@ -85,7 +85,7 @@ Server: srt://{OvenMediaEngine Host}:{SRT Port}
 Key: {streamid}
 ```
 
-The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](https://docs.ovenmediaengine.com/v/0.16.4/live-source/srt-beta#blackmagic-web-presenter)
+The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](/docs/ome/live-source/srt#blackmagic-web-presenter)
 
 ## Multiple Audio Track
 

--- a/docs-site/live-source/srt.md
+++ b/docs-site/live-source/srt.md
@@ -85,7 +85,7 @@ Server: srt://{OvenMediaEngine Host}:{SRT Port}
 Key: {streamid}
 ```
 
-The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](/docs/ome/live-source/srt#blackmagic-web-presenter)
+The default streaming profiles work well, and there are more advanced configuration options available if you [edit the streaming.xml settings file](srt.md#blackmagic-web-presenter)
 
 ## Multiple Audio Track
 

--- a/docs-site/streaming/low-latency-hls.md
+++ b/docs-site/streaming/low-latency-hls.md
@@ -343,7 +343,7 @@ OvenPlayer now includes DRM-related options. Enable DRM and input the License UR
 
 :::danger
 
-Pallycon is no longer supported by the Open Source project and is only supported in the [Enterprise](https://ovenmediaengine-enterprise.gitbook.io/docs/getting-started/getting-started-with-ubuntu) version. For more information, see this [article](https://github.com/OvenMediaLabs/OvenMediaEngine/discussions/1634).
+Pallycon is no longer supported by the Open Source project and is only supported in the [Enterprise](/docs/ome-enterprise/pre-built-package-installation/getting-started/getting-started-with-linux) version. For more information, see this [article](https://github.com/OvenMediaLabs/OvenMediaEngine/discussions/1634).
 
 :::
 

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -254,7 +254,7 @@ Or by **activating the encoding options** in OvenMediaEngine.
 
 :::info
 
-Setting up Transcoding options in OvenMediaEngine: [/docs/ome/transcoding#encodes](/docs/ome/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [transcoding/README.md#encodes](transcoding/README.md#encodes)
 
 :::
 
@@ -268,7 +268,7 @@ If you want to monitor packet loss in your Chrome browser, you can access it by 
 
 :::info
 
-Setting up WebRTC over TCP in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#webrtc-over-tcp](/docs/ome/streaming/webrtc-publishing#webrtc-over-tcp)
+Setting up WebRTC over TCP in OvenMediaEngine: [streaming/webrtc-publishing.md#webrtc-over-tcp](streaming/webrtc-publishing.md#webrtc-over-tcp)
 
 :::
 
@@ -284,7 +284,7 @@ When you see Origin is CPU intensive on your Origin-Edge structure, the transcod
 
 :::info
 
-Setting up GPU Acceleration in OvenMediaEngine: [/docs/ome/transcoding/gpu-usage](/docs/ome/transcoding/gpu-usage)
+Setting up GPU Acceleration in OvenMediaEngine: [transcoding/gpu-usage.md](transcoding/gpu-usage.md)
 
 :::
 
@@ -302,7 +302,7 @@ When you see a specific thread overuses the CPU, the video may not stream smooth
 
 :::info
 
-Tuning OvenMediaEngine Performance: [/docs/ome/performance-tuning#performance-tuning](/docs/ome/performance-tuning#performance-tuning)
+Tuning OvenMediaEngine Performance: [performance-tuning.md#performance-tuning](performance-tuning.md#performance-tuning)
 
 :::
 
@@ -359,7 +359,7 @@ In this case, you can solve this by installing a certificate in OvenMediaEngine 
 
 :::info
 
-Setting up TLS Encryption in OvenMediaEngine: [/docs/ome/configuration/tls-encryption](/docs/ome/configuration/tls-encryption)
+Setting up TLS Encryption in OvenMediaEngine: [configuration/tls-encryption.md](configuration/tls-encryption.md)
 
 :::
 
@@ -393,7 +393,7 @@ Or by **enabling the encoding options** in OvenMediaEngine.
 
 :::info
 
-Setting up Transcoding options in OvenMediaEngine: [/docs/ome/transcoding#encodes](/docs/ome/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [transcoding/README.md#encodes](transcoding/README.md#encodes)
 
 :::
 
@@ -413,7 +413,7 @@ Also, suppose you are using a transcoder in OvenMediaEngine and trying to input 
 
 :::info
 
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#publisher](/docs/ome/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [streaming/webrtc-publishing.md#publisher](streaming/webrtc-publishing.md#publisher)
 
 :::
 
@@ -425,7 +425,7 @@ There may be cases where the A/V sync is not corrected even after a certain amou
 
 :::info
 
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#publisher](/docs/ome/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [streaming/webrtc-publishing.md#publisher](streaming/webrtc-publishing.md#publisher)
 
 :::
 
@@ -443,7 +443,7 @@ WebRTC supports Opus, not AAC, as an audio codec. Because RTMP and other protoco
 
 :::info
 
-Setting up Opus Codec in OvenMediaEngine: [/docs/ome/transcoding#audio](/docs/ome/transcoding#audio)
+Setting up Opus Codec in OvenMediaEngine: [transcoding/README.md#audio](transcoding/README.md#audio)
 
 :::
 
@@ -459,7 +459,7 @@ However, since OvenMediaEngine has the default to the fastest encoding option fo
 
 :::info
 
-Choosing an Encoding Preset in OvenMediaEngine: [/docs/ome/transcoding#video](/docs/ome/transcoding#video)
+Choosing an Encoding Preset in OvenMediaEngine: [transcoding/README.md#video](transcoding/README.md#video)
 
 :::
 

--- a/docs-site/troubleshooting.md
+++ b/docs-site/troubleshooting.md
@@ -254,7 +254,7 @@ Or by **activating the encoding options** in OvenMediaEngine.
 
 :::info
 
-Setting up Transcoding options in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#encodes](https://docs.ovenmediaengine.com/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [/docs/ome/transcoding#encodes](/docs/ome/transcoding#encodes)
 
 :::
 
@@ -268,7 +268,7 @@ If you want to monitor packet loss in your Chrome browser, you can access it by 
 
 :::info
 
-Setting up WebRTC over TCP in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#webrtc-over-tcp)
+Setting up WebRTC over TCP in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#webrtc-over-tcp](/docs/ome/streaming/webrtc-publishing#webrtc-over-tcp)
 
 :::
 
@@ -284,7 +284,7 @@ When you see Origin is CPU intensive on your Origin-Edge structure, the transcod
 
 :::info
 
-Setting up GPU Acceleration in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding/gpu-usage](https://docs.ovenmediaengine.com/transcoding/gpu-usage)
+Setting up GPU Acceleration in OvenMediaEngine: [/docs/ome/transcoding/gpu-usage](/docs/ome/transcoding/gpu-usage)
 
 :::
 
@@ -302,7 +302,7 @@ When you see a specific thread overuses the CPU, the video may not stream smooth
 
 :::info
 
-Tuning OvenMediaEngine Performance: [https://docs.ovenmediaengine.com/performance-tuning#performance-tuning](https://docs.ovenmediaengine.com/performance-tuning#performance-tuning)
+Tuning OvenMediaEngine Performance: [/docs/ome/performance-tuning#performance-tuning](/docs/ome/performance-tuning#performance-tuning)
 
 :::
 
@@ -359,7 +359,7 @@ In this case, you can solve this by installing a certificate in OvenMediaEngine 
 
 :::info
 
-Setting up TLS Encryption in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/tls-encryption](https://docs.ovenmediaengine.com/streaming/tls-encryption)
+Setting up TLS Encryption in OvenMediaEngine: [/docs/ome/configuration/tls-encryption](/docs/ome/configuration/tls-encryption)
 
 :::
 
@@ -393,7 +393,7 @@ Or by **enabling the encoding options** in OvenMediaEngine.
 
 :::info
 
-Setting up Transcoding options in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#encodes](https://docs.ovenmediaengine.com/transcoding#encodes)
+Setting up Transcoding options in OvenMediaEngine: [/docs/ome/transcoding#encodes](/docs/ome/transcoding#encodes)
 
 :::
 
@@ -413,7 +413,7 @@ Also, suppose you are using a transcoder in OvenMediaEngine and trying to input 
 
 :::info
 
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#publisher](/docs/ome/streaming/webrtc-publishing#publisher)
 
 :::
 
@@ -425,7 +425,7 @@ There may be cases where the A/V sync is not corrected even after a certain amou
 
 :::info
 
-Setting up WebRTC JitterBuffer in OvenMediaEngine: [https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher](https://docs.ovenmediaengine.com/streaming/webrtc-publishing#publisher)
+Setting up WebRTC JitterBuffer in OvenMediaEngine: [/docs/ome/streaming/webrtc-publishing#publisher](/docs/ome/streaming/webrtc-publishing#publisher)
 
 :::
 
@@ -443,7 +443,7 @@ WebRTC supports Opus, not AAC, as an audio codec. Because RTMP and other protoco
 
 :::info
 
-Setting up Opus Codec in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#audio](https://docs.ovenmediaengine.com/transcoding#audio)
+Setting up Opus Codec in OvenMediaEngine: [/docs/ome/transcoding#audio](/docs/ome/transcoding#audio)
 
 :::
 
@@ -459,7 +459,7 @@ However, since OvenMediaEngine has the default to the fastest encoding option fo
 
 :::info
 
-Choosing an Encoding Preset in OvenMediaEngine: [https://docs.ovenmediaengine.com/transcoding#video](https://docs.ovenmediaengine.com/transcoding#video)
+Choosing an Encoding Preset in OvenMediaEngine: [/docs/ome/transcoding#video](/docs/ome/transcoding#video)
 
 :::
 


### PR DESCRIPTION
## Summary

Rewrite 28 in-tree links across 5 files in `docs-site/` that pointed at `docs.ovenmediaengine.com` or `airensoft.gitbook.io/ovenmediaengine` so they point at the consolidated Docusaurus pages on ovenmedialabs.com under `/docs/ome/...`.

## Why

ovenmedialabs.com is becoming the single home for the OvenMediaEngine manual. `docs.ovenmediaengine.com` and the airensoft GitBook will be redirected to it at the DNS layer during cutover, but in-tree links should already be relative to the new home so the manual reads cleanly when viewed locally, on GitHub, or as a static build — without depending on the external redirect layer.