### PR TITLE
docs: fix broken links in docs-site

### DIFF
--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -255,7 +255,7 @@ Origins (also we called `OriginMap`) are a feature to pull streams from external
 
 The Origin has `<Location>` and `<Pass>` elements. Location is a URI pattern for incoming requests. If the incoming URL request matches Location, OvenMediaEngine pulls the stream according to a Pass element. In the Pass element, you can set the origin stream's protocol and URLs.
 
-To run the Edge server, Origin creates application and stream if there isn't those when user request. For more learn about Origin-Edge, see the [Live Source](../live-source/) chapter.
+To run the Edge server, Origin creates application and stream if there isn't those when user request. For more learn about Origin-Edge, see the [Live Source](/docs/ome/live-source) chapter.
 
 ```xml
 <!-- /Server/VirtualHosts -->
@@ -390,7 +390,7 @@ For more information about the `<OutputProfiles>`, please see the [Transcoding](
 </Application>
 ```
 
-If you want to get more information about the `<Providers>`, please refer to the [Live Source](../live-source/) chapter.
+If you want to get more information about the `<Providers>`, please refer to the [Live Source](/docs/ome/live-source) chapter.
 
 #### Publishers
 

--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -255,7 +255,7 @@ Origins (also we called `OriginMap`) are a feature to pull streams from external
 
 The Origin has `<Location>` and `<Pass>` elements. Location is a URI pattern for incoming requests. If the incoming URL request matches Location, OvenMediaEngine pulls the stream according to a Pass element. In the Pass element, you can set the origin stream's protocol and URLs.
 
-To run the Edge server, Origin creates application and stream if there isn't those when user request. For more learn about Origin-Edge, see the [Live Source](/docs/ome/live-source) chapter.
+To run the Edge server, Origin creates application and stream if there isn't those when user request. For more learn about Origin-Edge, see the [Live Source](../live-source/README.md) chapter.
 
 ```xml
 <!-- /Server/VirtualHosts -->
@@ -390,7 +390,7 @@ For more information about the `<OutputProfiles>`, please see the [Transcoding](
 </Application>
 ```
 
-If you want to get more information about the `<Providers>`, please refer to the [Live Source](/docs/ome/live-source) chapter.
+If you want to get more information about the `<Providers>`, please refer to the [Live Source](../live-source/README.md) chapter.
 
 #### Publishers
 

--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -255,7 +255,7 @@ Origins (also we called `OriginMap`) are a feature to pull streams from external
 
 The Origin has `<Location>` and `<Pass>` elements. Location is a URI pattern for incoming requests. If the incoming URL request matches Location, OvenMediaEngine pulls the stream according to a Pass element. In the Pass element, you can set the origin stream's protocol and URLs.
 
-To run the Edge server, Origin creates application and stream if there isn't those when user request. For more learn about Origin-Edge, see the [Live Source](../live-source/README.md) chapter.
+When an Edge server receives a request for an application or stream that does not exist, the Origin creates them on demand. To learn more about Origin-Edge, see the [Live Source](../live-source/README.md) chapter.
 
 ```xml
 <!-- /Server/VirtualHosts -->

--- a/docs-site/intro.md
+++ b/docs-site/intro.md
@@ -71,7 +71,7 @@ We have tested OvenMediaEngine on platforms, listed below. However, we think it 
 
 ## Getting Started
 
-Please read [Getting Started](getting-started/) chapter in the tutorials.
+Please read [Getting Started](/docs/ome/getting-started) chapter in the tutorials.
 
 ## How to Contribute
 

--- a/docs-site/intro.md
+++ b/docs-site/intro.md
@@ -71,7 +71,7 @@ We have tested OvenMediaEngine on platforms, listed below. However, we think it 
 
 ## Getting Started
 
-Please read [Getting Started](/docs/ome/getting-started) chapter in the tutorials.
+Please read [Getting Started](getting-started/README.md) chapter in the tutorials.
 
 ## How to Contribute
 

--- a/docs-site/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs-site/rest-api/v1/virtualhost/application/stream/README.md
@@ -730,7 +730,7 @@ Delete Stream. This terminates the ingress connection.
 
 :::warning
 
-The sender can reconnect after the connection is terminated. To prevent reconnection, you must use [AccessControl](../../../../../access-control/).
+The sender can reconnect after the connection is terminated. To prevent reconnection, you must use [AccessControl](/docs/ome/access-control).
 
 :::
 

--- a/docs-site/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs-site/rest-api/v1/virtualhost/application/stream/README.md
@@ -730,7 +730,7 @@ Delete Stream. This terminates the ingress connection.
 
 :::warning
 
-The sender can reconnect after the connection is terminated. To prevent reconnection, you must use [AccessControl](/docs/ome/access-control).
+The sender can reconnect after the connection is terminated. To prevent reconnection, you must use [AccessControl](../../../../../access-control/README.md).
 
 :::
 

--- a/docs-site/streaming/low-latency-hls.md
+++ b/docs-site/streaming/low-latency-hls.md
@@ -59,7 +59,7 @@ To use LLHLS, you need to add the `<LLHLS>` elements to the `<Publishers>` in th
 | `ChunkDuration`   | Set the partial segment length to fractional seconds. This value affects low-latency HLS player. We recommend **`0.2`** seconds for this value.                                                                                                |
 | `SegmentDuration` | Set the length of the segment in seconds. Therefore, a shorter value allows the stream to start faster. However, a value that is too short will make legacy HLS players unstable. Apple recommends **`6`** seconds for this value.             |
 | `SegmentCount`    | The number of segments listed in the playlist. This value has little effect on LLHLS players, so use **`10`** as recommended by Apple. 5 is recommended for legacy HLS players. Do not set below `3`. It can only be used for experimentation. |
-| `CrossDomains`    | Control the domain in which the player works through `<CrossDomain>`. For more information, please refer to the [CrossDomain](../crossdomains.md) section.                                                         |
+| `CrossDomains`    | Control the domain in which the player works through `<CrossDomains>`. For more information, please refer to the [CrossDomains](../crossdomains.md) section.                                                         |
 
 
 

--- a/docs-site/streaming/low-latency-hls.md
+++ b/docs-site/streaming/low-latency-hls.md
@@ -59,7 +59,7 @@ To use LLHLS, you need to add the `<LLHLS>` elements to the `<Publishers>` in th
 | `ChunkDuration`   | Set the partial segment length to fractional seconds. This value affects low-latency HLS player. We recommend **`0.2`** seconds for this value.                                                                                                |
 | `SegmentDuration` | Set the length of the segment in seconds. Therefore, a shorter value allows the stream to start faster. However, a value that is too short will make legacy HLS players unstable. Apple recommends **`6`** seconds for this value.             |
 | `SegmentCount`    | The number of segments listed in the playlist. This value has little effect on LLHLS players, so use **`10`** as recommended by Apple. 5 is recommended for legacy HLS players. Do not set below `3`. It can only be used for experimentation. |
-| `CrossDomains`    | Control the domain in which the player works through `<CrossDomain>`. For more information, please refer to the [CrossDomain](/docs/ome/crossdomains) section.                                                         |
+| `CrossDomains`    | Control the domain in which the player works through `<CrossDomain>`. For more information, please refer to the [CrossDomain](../crossdomains.md) section.                                                         |
 
 
 

--- a/docs-site/streaming/low-latency-hls.md
+++ b/docs-site/streaming/low-latency-hls.md
@@ -59,7 +59,7 @@ To use LLHLS, you need to add the `<LLHLS>` elements to the `<Publishers>` in th
 | `ChunkDuration`   | Set the partial segment length to fractional seconds. This value affects low-latency HLS player. We recommend **`0.2`** seconds for this value.                                                                                                |
 | `SegmentDuration` | Set the length of the segment in seconds. Therefore, a shorter value allows the stream to start faster. However, a value that is too short will make legacy HLS players unstable. Apple recommends **`6`** seconds for this value.             |
 | `SegmentCount`    | The number of segments listed in the playlist. This value has little effect on LLHLS players, so use **`10`** as recommended by Apple. 5 is recommended for legacy HLS players. Do not set below `3`. It can only be used for experimentation. |
-| `CrossDomains`    | Control the domain in which the player works through `<CrossDomain>`. For more information, please refer to the [CrossDomain](/broken/pages/-LceAWo6lMtkZlNTfsM4#crossdomain) section.                                                         |
+| `CrossDomains`    | Control the domain in which the player works through `<CrossDomain>`. For more information, please refer to the [CrossDomain](/docs/ome/crossdomains) section.                                                         |
 
 
 


### PR DESCRIPTION
## Summary

Four broken links flagged by the consuming Docusaurus site (ovenmedialabs.com) are now resolved. Three were URL-relative paths that resolved one directory too high; one was a `/broken/pages/<gitbook-id>` placeholder left over from the GitBook migration.

## Why

Docusaurus resolves bare relative links (no `.md`) against the source page URL, not the source file path. A link like `[AccessControl](../../../../../access-control/)` from `rest-api/v1/virtualhost/application/stream/` resolved to `/docs/access-control` instead of `/docs/ome/access-control`. Switching to absolute `/docs/ome/...` paths is unambiguous and survives whatever trailing-slash convention the consuming site adopts.