### PR TITLE
docs: fix remaining broken links in docs-site

### DIFF
--- a/docs-site/configuration/README.md
+++ b/docs-site/configuration/README.md
@@ -366,7 +366,7 @@ When an Edge server receives a request for an application or stream that does no
 </Application>
 ```
 
-For more information about the `<OutputProfiles>`, please see the [Transcoding](../transcoding/) chapter.
+For more information about the `<OutputProfiles>`, please see the [Transcoding](../transcoding/README.md) chapter.
 
 #### Providers
 

--- a/docs-site/intro.md
+++ b/docs-site/intro.md
@@ -77,15 +77,15 @@ Please read [Getting Started](getting-started/README.md) chapter in the tutorial
 
 Thank you so much for being so interested in OvenMediaEngine.
 
-We need your help to keep and develop our open-source project, and we want to tell you that you can contribute in many ways. Please see our [Guidelines](../CONTRIBUTING.md), [Rules](../CODE_OF_CONDUCT.md), and [Contribute](https://www.ovenmediaengine.com/contribute).
+We need your help to keep and develop our open-source project, and we want to tell you that you can contribute in many ways. Please see our [Guidelines](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md), [Rules](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CODE_OF_CONDUCT.md), and [Contribute](https://www.ovenmediaengine.com/contribute).
 
-* [Finding Bugs](../CONTRIBUTING.md#finding-bugs)
-* [Reviewing Code](../CONTRIBUTING.md#reviewing-code)
-* [Sharing Ideas](../CONTRIBUTING.md#sharing-ideas)
-* [Testing](../CONTRIBUTING.md#testing)
-* [Improving Documentation](../CONTRIBUTING.md#improving-documentation)
-* [Spreading & Use Cases](../CONTRIBUTING.md#spreading--use-cases)
-* [Recurring Donations](../CONTRIBUTING.md#recurring-donations)
+* [Finding Bugs](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#finding-bugs)
+* [Reviewing Code](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#reviewing-code)
+* [Sharing Ideas](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#sharing-ideas)
+* [Testing](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#testing)
+* [Improving Documentation](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#improving-documentation)
+* [Spreading & Use Cases](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#spreading--use-cases)
+* [Recurring Donations](https://github.com/OvenMediaLabs/OvenMediaEngine/blob/master/CONTRIBUTING.md#recurring-donations)
 
 We always hope that OvenMediaEngine will give you good inspiration.
 


### PR DESCRIPTION
## Summary

Three additional broken links surfaced on the consuming Docusaurus site (ovenmedialabs.com) once the previous batch was merged. Docusaurus reports one broken link per source page, so these were hidden until earlier fixes uncovered them.

## Why

`(../transcoding/)` needed the `README.md` suffix so Docusaurus uses file-relative resolution. `(../CONTRIBUTING.md)` and `(../CODE_OF_CONDUCT.md)` point to files outside `docs-site/` — Docusaurus can't map them to doc pages, so swap them for GitHub blob URLs that work in both GitHub's markdown preview and on Docusaurus.