### PR TITLE
ci: allow 'ci' prefix in PR title check

### DIFF
--- a/.github/workflows/ome-pr-check.yml
+++ b/.github/workflows/ome-pr-check.yml
@@ -30,6 +30,7 @@ jobs:
             docs
             test
             build
+            ci
             chore
 
 
@@ -69,6 +70,7 @@ jobs:
             | \`docs\` | Documentation update |
             | \`test\` | Unit or integration tests |
             | \`build\` | Build system or dependency changes |
+            | \`ci\` | CI configuration changes (workflows, actions) |
             | \`chore\` | General maintenance |
 
             **Examples:**


### PR DESCRIPTION
## Summary

Add `ci` to the conventional-commit type list enforced by the PR title check.

## Why

The title check rejects PRs starting with `ci:` because the type isn't on the allowed list, even though `ci:` is a standard Conventional Commits prefix and the more accurate label for CI-only changes than `build:` or `chore:`.