### PR TITLE
docs: document how to target a specific release version

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -39,6 +39,22 @@ curl -LOJ https://github.com/OvenMediaLabs/OvenMediaEngine/archive/master.tar.gz
 tar xvfz OvenMediaEngine-master.tar.gz
 ```
 
+
+:::tip Building a specific release
+
+The command above builds the latest development code from the `master` branch. To build a **specific stable release** instead (recommended for production), choose a version from the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and download its source archive:
+
+```bash
+# Replace 0.20.5 with the release you want
+curl -LOJ https://github.com/OvenMediaLabs/OvenMediaEngine/archive/v0.20.5.tar.gz && \
+tar xvfz OvenMediaEngine-0.20.5.tar.gz
+```
+
+The build steps below are identical — just use the extracted `OvenMediaEngine-0.20.5` directory instead of `OvenMediaEngine-master`.
+
+:::
+
+
 Then build and install using the commands for your platform:
 
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -45,12 +45,13 @@ tar xvfz OvenMediaEngine-master.tar.gz
 The command above builds the latest development code from the `master` branch. To build a **specific stable release** instead (recommended for production), choose a version from the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and download its source archive:
 
 ```bash
-# Replace 0.20.5 with the release you want
-curl -LOJ https://github.com/OvenMediaLabs/OvenMediaEngine/archive/v0.20.5.tar.gz && \
-tar xvfz OvenMediaEngine-0.20.5.tar.gz
+# Set OME_VERSION to the release you want (see the releases page above)
+OME_VERSION=0.20.5
+curl -LOJ https://github.com/OvenMediaLabs/OvenMediaEngine/archive/v${OME_VERSION}.tar.gz && \
+tar xvfz OvenMediaEngine-${OME_VERSION}.tar.gz
 ```
 
-The build steps below are identical — just use the extracted `OvenMediaEngine-0.20.5` directory instead of `OvenMediaEngine-master`.
+The build steps below are identical — just replace `OvenMediaEngine-master` with the extracted release directory (e.g. `OvenMediaEngine-0.20.5`).
 
 :::
 

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -14,6 +14,27 @@ ovenmedialabs/ovenmediaengine:latest
 ```
 
 
+:::tip Choosing an image tag
+
+The `ovenmedialabs/ovenmediaengine` repository provides the following tags:
+
+| Tag | Description |
+| --- | --- |
+| `latest` | The most recent stable release (recommended for production). |
+| `dev` | The latest development build from the `master` branch. |
+| `v0.20.5` | A specific stable release. Browse the [available tags](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine/tags) or the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and pin the version you want. |
+
+For example, to run a specific release:
+
+```sh
+docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+ovenmedialabs/ovenmediaengine:v0.20.5
+```
+
+:::
+
+
 :::warning
 
 If a certificate is not installed in OvenMediaEngine, some functions (WebRTC Ingest, LLHLS playback) may not work due to the browser's security policy. Please refer to [Complex Configuration](getting-started-with-docker.md#getting-started-with-complex-configuration) section to install the certificate.

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -20,9 +20,9 @@ The `ovenmedialabs/ovenmediaengine` repository provides the following tags:
 
 | Tag | Description |
 | --- | --- |
-| `latest` | The most recent stable release (recommended for production). |
+| `latest` | The most recent stable release. Convenient, but the version it points to changes as new releases ship. |
 | `dev` | The latest development build from the `master` branch. |
-| `v0.20.5` | A specific stable release. Browse the [available tags](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine/tags) or the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and pin the version you want. |
+| `v0.20.5` | A specific stable release — recommended for production, so deployments stay on a fixed version. Browse the [available tags](https://hub.docker.com/r/ovenmedialabs/ovenmediaengine/tags) or the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and pin the version you want. |
 
 For example, to run a specific release:
 


### PR DESCRIPTION
## Summary

- Getting Started: add a tip showing how to download a specific release source archive instead of the `master` tarball.
- Getting Started with Docker: add an image-tag table (`latest` / `dev` / `vX.Y.Z`) with a pinned-release `docker run` example.

## Why

Docs now track only the `master` branch, but production users typically deploy a specific stable release and had no guidance for pinning a version.
