### PR TITLE
docs: fix admonition title syntax for Docusaurus 3

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -40,7 +40,7 @@ tar xvfz OvenMediaEngine-master.tar.gz
 ```
 
 
-:::tip Building a specific release
+:::tip[Building a specific release]
 
 The command above builds the latest development code from the `master` branch. To build a **specific stable release** instead (recommended for production), choose a version from the [releases page](https://github.com/OvenMediaLabs/OvenMediaEngine/releases) and download its source archive:
 

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -14,7 +14,7 @@ ovenmedialabs/ovenmediaengine:latest
 ```
 
 
-:::tip Choosing an image tag
+:::tip[Choosing an image tag]
 
 The `ovenmedialabs/ovenmediaengine` repository provides the following tags:
 


### PR DESCRIPTION
## Summary

- `getting-started/README.md`, `getting-started-with-docker.md`: change the admonition titles from `:::tip Title` to `:::tip[Title]`.

## Why

The space-separated title form is not parsed as a container directive in Docusaurus 3 / MDX 3, so the `:::tip` block introduced in #2138 renders literally on the docs site. The bracketed form is the v3 syntax.
