### PR TITLE
docs: add SEO/AIO meta descriptions to docs frontmatter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,13 @@ description: Configure on-the-fly recording of WebRTC streams.
 
 - `title` — page title shown in browser tab and as H1
 - `sidebar_position` — order within the section (smaller = higher)
-- `description` — SEO meta description; appears in search snippets
+- `description` — **required.** A one-sentence meta description
+  (~120–155 chars) stating what the page covers; include
+  "OvenMediaEngine". This is what search engines show in snippets and
+  what AI answer engines quote, so **always write one.** If omitted,
+  the site falls back to a low-quality auto-excerpt of the first line
+  (often a bare heading like "Configuration"), which hurts search and
+  AI discoverability.
 - `slug` (optional) — override URL path; useful for `intro.md` (`slug: /`)
 
 ### Admonitions

--- a/docs/access-control/README.md
+++ b/docs/access-control/README.md
@@ -1,5 +1,6 @@
 ---
 title: Access Control
+description: "Restrict who can publish and play OvenMediaEngine streams using SignedPolicy signed URLs and AdmissionWebhooks authorization."
 sidebar_position: 29
 ---
 

--- a/docs/access-control/admission-webhooks.md
+++ b/docs/access-control/admission-webhooks.md
@@ -1,5 +1,6 @@
 ---
 title: AdmissionWebhooks
+description: "Authorize OvenMediaEngine publishing and playback in real time with AdmissionWebhooks HTTP callbacks to your control server."
 sidebar_position: 31
 ---
 

--- a/docs/access-control/signedpolicy.md
+++ b/docs/access-control/signedpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: SignedPolicy
+description: "Limit OvenMediaEngine stream access with SignedPolicy — time-limited, privilege-scoped signed URLs for publishing and playback."
 sidebar_position: 30
 ---
 

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -1,5 +1,6 @@
 ---
 title: Alert
+description: "Detect stream and system anomalies in OvenMediaEngine and send notifications with the Alert module."
 sidebar_position: 59
 ---
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: "Configure OvenMediaEngine through Server.xml — origin and edge modes, binds, virtual hosts, and applications."
 sidebar_position: 7
 ---
 

--- a/docs/configuration/ipv6.md
+++ b/docs/configuration/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6
+description: "Configure OvenMediaEngine to listen on IPv6, including the multiple IP bindings supported from v0.15.1."
 sidebar_position: 9
 ---
 

--- a/docs/configuration/tls-encryption.md
+++ b/docs/configuration/tls-encryption.md
@@ -1,5 +1,6 @@
 ---
 title: TLS Encryption
+description: "Enable TLS encryption in OvenMediaEngine by linking certificates, including certificate setup for Docker deployments."
 sidebar_position: 8
 ---
 

--- a/docs/crossdomains.md
+++ b/docs/crossdomains.md
@@ -1,5 +1,6 @@
 ---
 title: CrossDomains
+description: "Configure CORS for OvenMediaEngine — a global default cross-domain policy and per-application overrides."
 sidebar_position: 28
 ---
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: "Get started with OvenMediaEngine using the official Docker image or the OME Docker Launcher."
 sidebar_position: 4
 ---
 

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with Docker
+description: "Run OvenMediaEngine from the official OvenMedia Labs Docker image with default settings in a single command."
 sidebar_position: 5
 ---
 

--- a/docs/getting-started/getting-started-with-ome-docker-launcher.md
+++ b/docs/getting-started/getting-started-with-ome-docker-launcher.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with OME Docker Launcher
+description: "Deploy and manage OvenMediaEngine in Docker containers easily with the OME Docker Launcher tool."
 sidebar_position: 6
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 slug: /
 title: Introduction
+description: "OvenMediaEngine is an open-source sub-second latency live streaming server for large-scale, high-definition real-time delivery."
 sidebar_position: 1
 ---
 

--- a/docs/live-source/README.md
+++ b/docs/live-source/README.md
@@ -1,5 +1,6 @@
 ---
 title: Live Source
+description: "Ingest live sources into OvenMediaEngine over RTMP, SRT, WebRTC/WHIP, MPEG-2 TS, RTSP, and scheduled or multiplex channels."
 sidebar_position: 10
 ---
 

--- a/docs/live-source/mpeg-2-ts-beta.md
+++ b/docs/live-source/mpeg-2-ts-beta.md
@@ -1,5 +1,6 @@
 ---
 title: MPEG-2 TS
+description: "Ingest live input into OvenMediaEngine over MPEG-2 TS by binding ports and mapping them to streams."
 sidebar_position: 14
 ---
 

--- a/docs/live-source/multiplex-channel.md
+++ b/docs/live-source/multiplex-channel.md
@@ -1,5 +1,6 @@
 ---
 title: Multiplex Channel
+description: "Create multiplexed channels in OvenMediaEngine by combining existing streams with the Multiplex Provider."
 sidebar_position: 17
 ---
 

--- a/docs/live-source/rtmp.md
+++ b/docs/live-source/rtmp.md
@@ -1,5 +1,6 @@
 ---
 title: RTMP
+description: "Ingest live streams into OvenMediaEngine over RTMP by configuring the RTMP provider and bind ports."
 sidebar_position: 11
 ---
 

--- a/docs/live-source/rtsp-pull.md
+++ b/docs/live-source/rtsp-pull.md
@@ -1,5 +1,6 @@
 ---
 title: RTSP Pull
+description: "Pull live sources into OvenMediaEngine from an RTSP server — OME acts as the RTSP client, no bind required."
 sidebar_position: 15
 ---
 

--- a/docs/live-source/scheduled-channel.md
+++ b/docs/live-source/scheduled-channel.md
@@ -1,5 +1,6 @@
 ---
 title: Scheduled Channel
+description: "Build pre-scheduled, playlist-style live channels in OvenMediaEngine with the Schedule Provider."
 sidebar_position: 16
 ---
 

--- a/docs/live-source/srt.md
+++ b/docs/live-source/srt.md
@@ -1,5 +1,6 @@
 ---
 title: SRT
+description: "Ingest low-latency live input into OvenMediaEngine over SRT by configuring the SRT listen port."
 sidebar_position: 13
 ---
 

--- a/docs/live-source/webrtc.md
+++ b/docs/live-source/webrtc.md
@@ -1,5 +1,6 @@
 ---
 title: WebRTC / WHIP
+description: "Ingest sub-second live input into OvenMediaEngine over WebRTC and WHIP by configuring the WebRTC provider."
 sidebar_position: 12
 ---
 

--- a/docs/logs-and-statistics.md
+++ b/docs/logs-and-statistics.md
@@ -1,5 +1,6 @@
 ---
 title: Logs and Statistics
+description: "Monitor OvenMediaEngine in real time through configurable log files and runtime statistics via Logger.xml."
 sidebar_position: 61
 ---
 

--- a/docs/origin-edge-clustering.md
+++ b/docs/origin-edge-clustering.md
@@ -1,5 +1,6 @@
 ---
 title: Clustering
+description: "Scale OvenMediaEngine with origin-edge clustering — edges pull streams from origins over OVT using OriginMap."
 sidebar_position: 32
 ---
 

--- a/docs/p2p-delivery.md
+++ b/docs/p2p-delivery.md
@@ -1,5 +1,6 @@
 ---
 title: P2P Delivery (Experiment)
+description: "Reduce OvenMediaEngine delivery bandwidth with experimental P2P Delivery that offloads distribution between players."
 sidebar_position: 63
 ---
 

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,5 +1,6 @@
 ---
 title: Performance Tuning
+description: "Tune OvenMediaEngine for scale and measure WebRTC capacity with the OvenRtcTester load-testing tool."
 sidebar_position: 60
 ---
 

--- a/docs/push-publishing.md
+++ b/docs/push-publishing.md
@@ -1,5 +1,6 @@
 ---
 title: Push Publishing
+description: "Push OvenMediaEngine streams to external destinations over RTMP, SRT, or MPEG-2 TS with the Push publisher."
 sidebar_position: 37
 ---
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -1,5 +1,6 @@
 ---
 title: Quick Start
+description: "Run OvenMediaEngine quickly with Docker and play a test stream in minutes."
 sidebar_position: 2
 ---
 

--- a/docs/quick-start/test-player.md
+++ b/docs/quick-start/test-player.md
@@ -1,5 +1,6 @@
 ---
 title: Online Demo
+description: "Test OvenMediaEngine instantly with the online OvenPlayer (WebRTC/LLHLS) and OvenLiveKit WebRTC encoder demos."
 sidebar_position: 3
 ---
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -1,5 +1,6 @@
 ---
 title: Recording
+description: "Record OvenMediaEngine streams to file by adding the FILE publisher to the configuration."
 sidebar_position: 36
 ---
 

--- a/docs/rest-api/README.md
+++ b/docs/rest-api/README.md
@@ -1,5 +1,6 @@
 ---
 title: REST API
+description: "Query and change OvenMediaEngine settings — virtual hosts, applications, and streams — through the REST API."
 sidebar_position: 38
 ---
 

--- a/docs/rest-api/v1/README.md
+++ b/docs/rest-api/v1/README.md
@@ -1,5 +1,6 @@
 ---
 title: v1
+description: "OvenMediaEngine REST API v1 — manage virtual hosts, applications, and streams and query statistics."
 sidebar_position: 39
 ---
 

--- a/docs/rest-api/v1/managers/README.md
+++ b/docs/rest-api/v1/managers/README.md
@@ -1,5 +1,6 @@
 ---
 title: Managers
+description: "OvenMediaEngine v1 REST API manager endpoints for administering the API server at runtime."
 sidebar_position: 56
 ---
 

--- a/docs/rest-api/v1/managers/api-server/README.md
+++ b/docs/rest-api/v1/managers/api-server/README.md
@@ -1,5 +1,6 @@
 ---
 title: API Server
+description: "Administer the OvenMediaEngine API server over the v1 REST API, including TLS certificate reloads."
 sidebar_position: 57
 ---
 

--- a/docs/rest-api/v1/managers/api-server/reload-certificate.md
+++ b/docs/rest-api/v1/managers/api-server/reload-certificate.md
@@ -1,5 +1,6 @@
 ---
 title: Reload Certificate
+description: "Reload the OvenMediaEngine API server TLS certificate via REST without a restart; the old cert stays on failure."
 sidebar_position: 58
 ---
 

--- a/docs/rest-api/v1/statistics/README.md
+++ b/docs/rest-api/v1/statistics/README.md
@@ -1,5 +1,6 @@
 ---
 title: Statistics
+description: "Query real-time OvenMediaEngine statistics — connections, throughput, and per-stream metrics — via the v1 REST API."
 sidebar_position: 54
 ---
 

--- a/docs/rest-api/v1/statistics/current.md
+++ b/docs/rest-api/v1/statistics/current.md
@@ -1,5 +1,6 @@
 ---
 title: Current
+description: "Get current OvenMediaEngine statistics for a virtual host, application, or stream through the v1 REST API."
 sidebar_position: 55
 ---
 

--- a/docs/rest-api/v1/virtualhost/README.md
+++ b/docs/rest-api/v1/virtualhost/README.md
@@ -1,5 +1,6 @@
 ---
 title: VirtualHost
+description: "List and manage OvenMediaEngine virtual hosts through the v1 REST API."
 sidebar_position: 40
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/README.md
+++ b/docs/rest-api/v1/virtualhost/application/README.md
@@ -1,5 +1,6 @@
 ---
 title: Application
+description: "List and manage OvenMediaEngine applications within a virtual host through the v1 REST API."
 sidebar_position: 42
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/output-profile.md
+++ b/docs/rest-api/v1/virtualhost/application/output-profile.md
@@ -1,5 +1,6 @@
 ---
 title: Output Profile
+description: "Manage OvenMediaEngine output profiles (transcoding renditions) for an application through the v1 REST API."
 sidebar_position: 43
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/push.md
+++ b/docs/rest-api/v1/virtualhost/application/push.md
@@ -1,5 +1,6 @@
 ---
 title: Push
+description: "Start and stop OvenMediaEngine push publishing over SRT, RTMP, or MPEG-2 TS through the v1 REST API."
 sidebar_position: 45
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/recording.md
+++ b/docs/rest-api/v1/virtualhost/application/recording.md
@@ -1,5 +1,6 @@
 ---
 title: Record
+description: "Start and stop OvenMediaEngine stream recording through the v1 REST API, with reservation for not-yet-created streams."
 sidebar_position: 44
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/scheduledchannel-api-1.md
+++ b/docs/rest-api/v1/virtualhost/application/scheduledchannel-api-1.md
@@ -1,5 +1,6 @@
 ---
 title: MultiplexChannel
+description: "Create, list, and manage OvenMediaEngine multiplex channels for an application through the v1 REST API."
 sidebar_position: 53
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/scheduledchannel-api.md
+++ b/docs/rest-api/v1/virtualhost/application/scheduledchannel-api.md
@@ -1,5 +1,6 @@
 ---
 title: ScheduledChannel
+description: "Create, list, and manage OvenMediaEngine scheduled channels for an application through the v1 REST API."
 sidebar_position: 52
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/README.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/README.md
@@ -1,5 +1,6 @@
 ---
 title: Stream
+description: "List and manage OvenMediaEngine streams within an application through the v1 REST API."
 sidebar_position: 46
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/conclude-hls-live.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/conclude-hls-live.md
@@ -1,5 +1,6 @@
 ---
 title: Conclude HLS Live
+description: "Conclude an OvenMediaEngine HLS/LLHLS live stream and finalize its playlist through the v1 REST API."
 sidebar_position: 50
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/hls-dump.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/hls-dump.md
@@ -1,5 +1,6 @@
 ---
 title: HLS Dump
+description: "Start and stop dumping OvenMediaEngine HLS segments to storage through the v1 REST API."
 sidebar_position: 49
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/send-event-1.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event-1.md
@@ -1,5 +1,6 @@
 ---
 title: Send Subtitles
+description: "Inject subtitle cues into a live OvenMediaEngine stream through the v1 REST API."
 sidebar_position: 48
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/send-event.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/send-event.md
@@ -1,5 +1,6 @@
 ---
 title: Send Event
+description: "Send timed events and metadata into a live OvenMediaEngine stream through the v1 REST API."
 sidebar_position: 47
 ---
 

--- a/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
+++ b/docs/rest-api/v1/virtualhost/application/stream/stt-control.md
@@ -1,5 +1,6 @@
 ---
 title: STT Control
+description: "Control real-time speech-to-text subtitle generation for an OvenMediaEngine stream through the v1 REST API."
 sidebar_position: 51
 ---
 

--- a/docs/rest-api/v1/virtualhost/reload-certificate.md
+++ b/docs/rest-api/v1/virtualhost/reload-certificate.md
@@ -1,5 +1,6 @@
 ---
 title: Reload Certificate
+description: "Batch-reload TLS certificates for all OvenMediaEngine virtual hosts via REST; old certs stay on failure."
 sidebar_position: 41
 ---
 

--- a/docs/streaming/README.md
+++ b/docs/streaming/README.md
@@ -1,5 +1,6 @@
 ---
 title: Streaming
+description: "Deliver OvenMediaEngine streams with sub-second latency over WebRTC and Low-Latency HLS, plus HLS and SRT."
 sidebar_position: 23
 ---
 

--- a/docs/streaming/hls.md
+++ b/docs/streaming/hls.md
@@ -1,5 +1,6 @@
 ---
 title: HLS
+description: "Deliver OvenMediaEngine streams over HLS by adding the HLS publisher to the configuration."
 sidebar_position: 26
 ---
 

--- a/docs/streaming/low-latency-hls.md
+++ b/docs/streaming/low-latency-hls.md
@@ -1,5 +1,6 @@
 ---
 title: Low-Latency HLS
+description: "Deliver sub-second OvenMediaEngine streams over Low-Latency HLS (LLHLS) by configuring the LLHLS publisher."
 sidebar_position: 25
 ---
 

--- a/docs/streaming/srt.md
+++ b/docs/streaming/srt.md
@@ -1,5 +1,6 @@
 ---
 title: SRT
+description: "Deliver OvenMediaEngine streams over SRT by configuring the SRT listen port."
 sidebar_position: 27
 ---
 

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -1,5 +1,6 @@
 ---
 title: WebRTC Streaming
+description: "Deliver sub-second OvenMediaEngine streams over WebRTC by configuring the WebRTC publisher in Server.xml."
 sidebar_position: 24
 ---
 

--- a/docs/subtitles/README.md
+++ b/docs/subtitles/README.md
@@ -1,5 +1,6 @@
 ---
 title: Subtitles
+description: "Add real-time subtitles to OvenMediaEngine streams by enabling subtitle tracks and inserting cues via the API."
 sidebar_position: 33
 ---
 

--- a/docs/subtitles/realtime-speech-to-text.md
+++ b/docs/subtitles/realtime-speech-to-text.md
@@ -1,5 +1,6 @@
 ---
 title: Realtime Speech-to-Text
+description: "Generate live subtitles for OvenMediaEngine streams with GPU-accelerated real-time speech-to-text."
 sidebar_position: 34
 ---
 

--- a/docs/thumbnail.md
+++ b/docs/thumbnail.md
@@ -1,5 +1,6 @@
 ---
 title: Thumbnail
+description: "Publish OvenMediaEngine stream thumbnails over HTTP(S), optionally sharing the HLS/DASH port."
 sidebar_position: 35
 ---
 

--- a/docs/transcoding/README.md
+++ b/docs/transcoding/README.md
@@ -1,5 +1,6 @@
 ---
 title: ABR and Transcoding
+description: "Transcode OvenMediaEngine streams — codec, bitrate, resolution, frame rate — and build adaptive bitrate renditions."
 sidebar_position: 18
 ---
 

--- a/docs/transcoding/abr.md
+++ b/docs/transcoding/abr.md
@@ -1,5 +1,6 @@
 ---
 title: ABR
+description: "Encode OvenMediaEngine streams into multiple bitrate renditions and deliver adaptive bitrate streaming to players."
 sidebar_position: 20
 ---
 

--- a/docs/transcoding/gpu-usage.md
+++ b/docs/transcoding/gpu-usage.md
@@ -1,5 +1,6 @@
 ---
 title: GPU Acceleration
+description: "Accelerate OvenMediaEngine transcoding with GPU hardware, including NVIDIA driver installation guidance."
 sidebar_position: 22
 ---
 

--- a/docs/transcoding/output-profile.md
+++ b/docs/transcoding/output-profile.md
@@ -1,5 +1,6 @@
 ---
 title: Transcoding
+description: "Define OvenMediaEngine output streams with OutputProfile and Encodes to re-encode codec, bitrate, and resolution."
 sidebar_position: 19
 ---
 

--- a/docs/transcoding/transcodewebhook.md
+++ b/docs/transcoding/transcodewebhook.md
@@ -1,5 +1,6 @@
 ---
 title: TranscodeWebhook
+description: "Control OvenMediaEngine transcoding per stream dynamically with the TranscodeWebhook HTTP callback."
 sidebar_position: 21
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: "Resolve common OvenMediaEngine build and runtime issues, including InstallPrerequisites.cmake failures."
 sidebar_position: 62
 ---
 


### PR DESCRIPTION
## Summary

- Add an authored `description:` to the frontmatter of docs pages that previously had none (or only a weak Docusaurus first-line auto-excerpt).
- Document `description` as required in the docs contributor guide.

## Why

Most docs shipped with no authored meta description; the consuming ovenmedialabs.com site then fell back to low-quality first-line excerpts, weakening search snippets and AI answer extraction.
