### PR TITLE
docs: update webrtc ice candidate port from range to single port (10000/udp + 10000/tcp)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ ENV     DEBIAN_FRONTEND=noninteractive
 RUN     apt-get update && apt-get install -y tzdata sudo libgomp1
 
 WORKDIR         /opt/ovenmediaengine/bin
-EXPOSE          80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000-10010/udp 9000/tcp
+EXPOSE          80/tcp 8080/tcp 8090/tcp 1935/tcp 3333/tcp 3334/tcp 4000-4005/udp 10000/udp 10000/tcp 9000/tcp
 COPY            --from=build /opt/ovenmediaengine /opt/ovenmediaengine
 
 ENV     NVIDIA_VISIBLE_DEVICES=all

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Although we have tested OvenMediaEngine on the platforms listed below, it may wo
 ### Docker
 ```bash
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 
@@ -83,7 +83,7 @@ You can also store the configuration files on your host:
 
 ```bash
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
 -v ome-origin-conf:/opt/ovenmediaengine/bin/origin_conf \
 -v ome-edge-conf:/opt/ovenmediaengine/bin/edge_conf \
 ovenmedialabs/ovenmediaengine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     - "3333:3333/tcp" # WebRTC Signaling / LLHLS
     - "3334:3334/tcp" # TLS WebRTC Signaling / LLHLS - Optional unless TLS is enabled
     - "3478:3478/tcp" # WebRTC TURN
-    - "10000-10004:10000-10004/udp" # WebRTC Candidate
+    - "10000:10000/udp" # WebRTC Candidate
+    - "10000:10000/tcp" # WebRTC Candidate
     environment:
     - OME_HOST_IP=192.168.0.160
     - OME_ORIGIN_PORT=9000
@@ -22,7 +23,8 @@ services:
     - OME_WEBRTC_SIGNALLING_PORT=3333 #LLHLS or WebRTC should be different if both are enabled.
     - OME_WEBRTC_SIGNALLING_TLS_PORT=3334 # Optional, unless using TLS
     - OME_WEBRTC_TCP_RELAY_PORT=3478
-    - OME_WEBRTC_CANDIDATE_PORT=10000-10004/udp
+    - OME_WEBRTC_CANDIDATE_PORT=10000/udp
+    - OME_WEBRTC_TCP_ICE_PORT=10000/tcp
     restart: always
     # Uncomment the following line to use your own configuration file (./origin_conf/Server.xml)
     #volumes:
@@ -38,7 +40,8 @@ services:
     ports:
     - "4333:3333/tcp" # WebRTC Signaling / LLHLS
     - "3479:3479/tcp" # WebRTC TURN
-    - "10005-10009:10005-10009/udp" # WebRTC Candidate
+    - "10001:10001/udp" # WebRTC Candidate
+    - "10001:10001/tcp" # WebRTC Candidate
     environment:
     - OME_HOST_IP=192.168.0.160
     - DEFAULT_ORIGIN_SERVER=192.168.0.160
@@ -47,7 +50,8 @@ services:
     - OME_WEBRTC_SIGNALLING_PORT=3333 #LLHLS or WebRTC should be different if both are enabled.
     - OME_WEBRTC_SIGNALLING_TLS_PORT=3334 # Optional, unless using TLS
     - OME_WEBRTC_TCP_RELAY_PORT=3479
-    - OME_WEBRTC_CANDIDATE_PORT=10005-10009/udp
+    - OME_WEBRTC_CANDIDATE_PORT=10001/udp
+    - OME_WEBRTC_TCP_ICE_PORT=10001/tcp
     restart: always
     # Uncomment the following line to use your own configuration file (./edge_conf/Server.xml)
     #volumes:

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -119,15 +119,15 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                 </Signalling>
 
                 <IceCandidates>
-                    <IceCandidate>*:10000/udp</IceCandidate>
-                    <!-- 
-                        If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                        This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
-                    -->
-                    <TcpRelay>*:3478</TcpRelay>
-                    <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
-                    <TcpForce>true</TcpForce>
+                    <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <!-- Direct TCP ICE (RFC 6544) -->
+                    <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                    <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                    <TcpRelay>${PublicIP}:3478</TcpRelay>
+                    <TcpRelayForce>false</TcpRelayForce>
+                    <IceWorkerCount>1</IceWorkerCount>
+                    <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
             </WebRTC>
@@ -156,15 +156,15 @@ The `<Bind>` is the configuration for the server port that will be used. Bind co
                     <WorkerCount>1</WorkerCount>
                 </Signalling>
                 <IceCandidates>
-                    <IceCandidate>*:10000-10005/udp</IceCandidate>
-                    <!-- 
-                        If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                        This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP. 
-                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
-                    -->
-                    <TcpRelay>*:3478</TcpRelay>
-                    <!-- TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming. (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail. -->
-                    <TcpForce>true</TcpForce>
+                    <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <!-- Direct TCP ICE (RFC 6544) -->
+                    <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                    <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                    <TcpRelay>${PublicIP}:3478</TcpRelay>
+                    <TcpRelayForce>false</TcpRelayForce>
+                    <IceWorkerCount>1</IceWorkerCount>
+                    <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
             </WebRTC>
@@ -506,18 +506,15 @@ Finally, `Server.xml` is configured as follows:
                 </Signalling>
 
                 <IceCandidates>
-                    <IceCandidate>*:10000/udp</IceCandidate>
-                    <!--
-                        If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                        This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
-                    -->
-                    <TcpRelay>*:3478</TcpRelay>
-                    <!--
-                        TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming.
-                        (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail.
-                    -->
-                    <TcpForce>true</TcpForce>
+                    <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <!-- Direct TCP ICE (RFC 6544) -->
+                    <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                    <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                    <TcpRelay>${PublicIP}:3478</TcpRelay>
+                    <TcpRelayForce>false</TcpRelayForce>
+                    <IceWorkerCount>1</IceWorkerCount>
+                    <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
             </WebRTC>
@@ -546,18 +543,15 @@ Finally, `Server.xml` is configured as follows:
                     <WorkerCount>1</WorkerCount>
                 </Signalling>
                 <IceCandidates>
-                    <IceCandidate>*:10000-10005/udp</IceCandidate>
-                    <!--
-                        If you want to stream WebRTC over TCP, specify IP:Port for TURN server.
-                        This uses the TURN protocol, which delivers the stream from the built-in TURN server to the player's TURN client over TCP.
-                        For detailed information, refer ../streaming/webrtc-publishing.md#webrtc-over-tcp
-                    -->
-                    <TcpRelay>*:3478</TcpRelay>
-                    <!--
-                        TcpForce is an option to force the use of TCP rather than UDP in WebRTC streaming.
-                        (You can omit ?transport=tcp accordingly.) If <TcpRelay> is not set, playback may fail.
-                    -->
-                    <TcpForce>true</TcpForce>
+                    <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                    <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                    <!-- Direct TCP ICE (RFC 6544) -->
+                    <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                    <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                    <TcpRelay>${PublicIP}:3478</TcpRelay>
+                    <TcpRelayForce>false</TcpRelayForce>
+                    <IceWorkerCount>1</IceWorkerCount>
+                    <TcpIceWorkerCount>1</TcpIceWorkerCount>
                     <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
                 </IceCandidates>
             </WebRTC>

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -152,7 +152,7 @@ The default configuration uses the following ports, so you need to open it in yo
 | <p>3333/TCP<br />3334/TLS</p> | <p>LLHLS Streaming<br /><strong>* Streaming over Non-TLS is not allowed with modern browsers.</strong></p> |
 | <p>3333/TCP<br />3334/TLS</p> | WebRTC Signaling (both ingest and streaming)                                                                                             |
 | 3478/TCP                    | WebRTC TCP relay (TURN Server, both ingest and streaming)                                                                                |
-| 10000 - 10009/UDP           | WebRTC Ice candidate (both ingest and streaming)                                                                                         |
+| 10000/UDP, 10000/TCP        | WebRTC Ice candidate (both ingest and streaming)                                                                                         |
 
 
 :::warning
@@ -172,5 +172,6 @@ $ sudo firewall-cmd --add-port=9999/udp
 $ sudo firewall-cmd --add-port=4000/udp
 $ sudo firewall-cmd --add-port=3478/tcp
 $ sudo firewall-cmd --add-port=9000/tcp
-$ sudo firewall-cmd --add-port=10000-10009/udp
+$ sudo firewall-cmd --add-port=10000/udp
+$ sudo firewall-cmd --add-port=10000/tcp
 ```

--- a/docs/getting-started/getting-started-with-docker.md
+++ b/docs/getting-started/getting-started-with-docker.md
@@ -9,7 +9,7 @@ OvenMediaEngine provides the Docker image from [OvenMedia Labs Docker Hub](https
 
 ```sh
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 
@@ -28,7 +28,7 @@ For example, to run a specific release:
 
 ```sh
 docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:v0.20.5
 ```
 
@@ -58,7 +58,8 @@ You can set the following environment variables.
 | `OME_WEBRTC_SIGNALLING_PORT`     | `3333`            |
 | `OME_WEBRTC_SIGNALLING_TLS_PORT` | `3334`            |
 | `OME_WEBRTC_TCP_RELAY_PORT`      | `3478`            |
-| `OME_WEBRTC_CANDIDATE_PORT`      | `10000-10004/udp` |
+| `OME_WEBRTC_CANDIDATE_PORT`      | `10000/udp`       |
+| `OME_WEBRTC_TCP_ICE_PORT`        | `10000/tcp`       |
 
 ## Getting Started with Complex Configuration
 
@@ -132,7 +133,7 @@ docker run -d -it --name ome -e OME_HOST_IP=Your.HOST.IP.Address \
 -v $OME_DOCKER_HOME/conf:/opt/ovenmediaengine/bin/origin_conf \
 -v $OME_DOCKER_HOME/logs:/var/log/ovenmediaengine \
 -p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 \
--p 10000-10009:10000-10009/udp \
+-p 10000:10000/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 

--- a/docs/getting-started/getting-started-with-ome-docker-launcher.md
+++ b/docs/getting-started/getting-started-with-ome-docker-launcher.md
@@ -158,14 +158,14 @@ $ ./ome_docker_launcher.sh start
   - SRT Provider is configured to use 9999 (Port)
   - WebRTC Provider is configured to use 3333 (Port)
   - WebRTC Provider is configured to use 3334 (TLSPort)
-  - WebRTC Provider is configured to use 10000-10004/UDP (IceCandidate)
+  - WebRTC Provider is configured to use 10000/UDP, 10000/TCP (IceCandidate)
   - WebRTC Provider is configured to use 3478 (TcpRelay)
   - OVT Publisher is configured to use 9000 (Port)
   - LLHLS Publisher is configured to use 3333 (Port)
   - LLHLS Publisher is configured to use 3334 (TLSPort)
   - WebRTC Publisher is configured to use 3333 (Port)
   - WebRTC Publisher is configured to use 3334 (TLSPort)
-  - WebRTC Publisher is configured to use 10000-10004/UDP (IceCandidate)
+  - WebRTC Publisher is configured to use 10000/UDP, 10000/TCP (IceCandidate)
   - WebRTC Publisher is configured to use 3478 (TcpRelay)
 • Starting a container: ovenemediaengine
   docker> 7235ff9f80762b6e7b27ba3a9773f5584033d55c113340dabf0779e8f5cf53bb
@@ -211,6 +211,7 @@ OME_HOST_IP
 OME_RTMP_PROV_PORT
 OME_WEBRTC_CANDIDATE_IP
 OME_WEBRTC_CANDIDATE_PORT
+OME_WEBRTC_TCP_ICE_PORT
 OME_WEBRTC_SIGNALLING_PORT
 OME_WEBRTC_SIGNALLING_TLS_PORT
 OME_WEBRTC_TCP_RELAY_PORT

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -262,8 +262,15 @@ The `WorkerCount` in `<Bind>` can set the thread responsible for sending and rec
                 <WorkerCount>1</WorkerCount>
             </Signalling>
             <IceCandidates>
-                <TcpRelay>*:3478</TcpRelay>
-                <IceCandidate>*:10000/udp</IceCandidate>
+                <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                <!-- Direct TCP ICE (RFC 6544) -->
+                <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                <TcpRelay>${PublicIP}:3478</TcpRelay>
+                <TcpRelayForce>false</TcpRelayForce>
+                <IceWorkerCount>1</IceWorkerCount>
+                <TcpIceWorkerCount>1</TcpIceWorkerCount>
                 <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
             </IceCandidates>
     ...

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -23,8 +23,8 @@ You can check the docker container status with the following command:
 
 ```bash
 $ docker ps -f name=ome
-CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS              PORTS                                                                                                                                                                                                                                                                                               NAMES
-c9dd9e56d7a0   ovenmedialabs/ovenmediaengine:latest   "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 0.0.0.0:9999-10000->9999-10000/udp, :::9999-10000->9999-10000/udp, 0.0.0.0:10000->10000/tcp, :::10000->10000/tcp    ome
+ CONTAINER ID   IMAGE                                 COMMAND                  CREATED              STATUS              PORTS                                                                                                                                                                                                                                                                                                                         NAMES
+ c9dd9e56d7a0   ovenmedialabs/ovenmediaengine:latest  "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   80/tcp, 3334/tcp, 4000-4005/udp, 10001-10010/udp, 0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 0.0.0.0:9999->9999/udp, :::9999->9999/udp, 0.0.0.0:10000->10000/udp, :::10000->10000/udp, 0.0.0.0:10000->10000/tcp, :::10000->10000/tcp   ome
 ```
 
 You can view the log with the command below. This is important because you can check the version of OvenMediaEngine that is running.

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -11,7 +11,7 @@ Run docker with the command below. `OME_HOST_IP` must be an IP address accessibl
 
 ```sh
 $ docker run --name ome -d -e OME_HOST_IP=Your.HOST.IP.Address \
--p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000-10009:10000-10009/udp \
+-p 1935:1935 -p 9999:9999/udp -p 9000:9000 -p 3333:3333 -p 3478:3478 -p 10000:10000/udp -p 10000:10000/tcp \
 ovenmedialabs/ovenmediaengine:latest
 ```
 
@@ -23,8 +23,8 @@ You can check the docker container status with the following command:
 
 ```bash
 $ docker ps -f name=ome
-CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS              PORTS                                                                                                                                                                                                                                                                                                           NAMES
-c9dd9e56d7a0   ovenmedialabs/ovenmediaengine:latest   "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 80/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 3334/tcp, 8080/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 4000-4005/udp, 8090/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 10010/udp, 0.0.0.0:9999-10009->9999-10009/udp, :::9999-10009->9999-10009/udp   ome
+CONTAINER ID   IMAGE                              COMMAND                  CREATED              STATUS              PORTS                                                                                                                                                                                                                                                                                               NAMES
+c9dd9e56d7a0   ovenmedialabs/ovenmediaengine:latest   "/opt/ovenmediaengin…"   About a minute ago   Up About a minute   0.0.0.0:1935->1935/tcp, :::1935->1935/tcp, 0.0.0.0:3333->3333/tcp, :::3333->3333/tcp, 0.0.0.0:3478->3478/tcp, :::3478->3478/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 0.0.0.0:9999-10000->9999-10000/udp, :::9999-10000->9999-10000/udp, 0.0.0.0:10000->10000/tcp, :::10000->10000/tcp    ome
 ```
 
 You can view the log with the command below. This is important because you can check the version of OvenMediaEngine that is running.

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -401,13 +401,16 @@ OME may sometimes not be able to get the server's public IP on its local interfa
             <WebRTC>
                 ...
             <IceCandidates>
-                <IceCandidate>*:10000-10005/udp</IceCandidate>
-                <IceCandidate>*:3479/tcp</IceCandidate>  <!-- Direct TCP ICE (RFC 6544) -->
-                <TcpRelay>Relay IP:3478</TcpRelay>       <!-- TURN relay -->
+                <!-- ${PublicIP} is resolved via <StunServer>. Falls back to all local IPs if STUN fails. -->
+                <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
+                <!-- Direct TCP ICE (RFC 6544) -->
+                <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
+                <!-- TURN relay for clients that do not support Direct TCP ICE -->
+                <TcpRelay>${PublicIP}:3478</TcpRelay>
                 <TcpRelayForce>false</TcpRelayForce>
-                <IceWorkerCount>1</IceWorkerCount>         <!-- Worker threads for UDP ICE -->
-                <TcpIceWorkerCount>1</TcpIceWorkerCount>   <!-- Worker threads for Direct TCP ICE -->
-                <TcpRelayWorkerCount>1</TcpRelayWorkerCount> <!-- Worker threads for TURN relay -->
+                <IceWorkerCount>1</IceWorkerCount>
+                <TcpIceWorkerCount>1</TcpIceWorkerCount>
+                <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
             </IceCandidates>
             </WebRTC>
         </Publishers>

--- a/docs/streaming/webrtc-publishing.md
+++ b/docs/streaming/webrtc-publishing.md
@@ -37,7 +37,7 @@ Add `<WebRTC>` under `<Bind><Publishers>` in `Server.xml`:
             <!-- Use a single port and raise IceWorkerCount for throughput scaling     -->
             <!-- instead of adding more ports.                                         -->
             <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
-            <IceCandidate>${PublicIP}:3479/tcp</IceCandidate>   <!-- Direct TCP ICE (RFC 6544) -->
+            <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>   <!-- Direct TCP ICE (RFC 6544) -->
             <TcpRelay>${PublicIP}:3478</TcpRelay>               <!-- TURN relay (WebRTC/TCP via TURN) -->
             <TcpRelayForce>false</TcpRelayForce>
             <IceWorkerCount>4</IceWorkerCount>           <!-- Increase for high viewer count -->
@@ -489,7 +489,7 @@ The `<DefaultTransport>` element sets the transport policy applied when no `?tra
 ```xml
 <IceCandidates>
     <IceCandidate>${PublicIP}:10000/udp</IceCandidate>
-    <IceCandidate>${PublicIP}:3479/tcp</IceCandidate>
+    <IceCandidate>${PublicIP}:10000/tcp</IceCandidate>
     <TcpRelay>${PublicIP}:3478</TcpRelay>
     <DefaultTransport>udptcp</DefaultTransport>  <!-- udptcp (default) | udp | tcp | relay | all -->
 </IceCandidates>
@@ -565,7 +565,7 @@ When sending `Request Offer` in the [signaling](webrtc-publishing.md#signalling-
   "sdp": { "..." },
   "candidates": [
     {"candidate": "candidate:0 1 UDP 2130706431 192.168.0.200 10000 typ host", "sdpMLineIndex": 0},
-    {"candidate": "candidate:1 1 TCP 1275068415 192.168.0.200 3479 typ host tcptype passive", "sdpMLineIndex": 0}
+    {"candidate": "candidate:1 1 TCP 1275068415 192.168.0.200 10000 typ host tcptype passive", "sdpMLineIndex": 0}
   ],
   "ice_servers": [{"credential": "airen", "urls": ["turn:192.168.0.200:3478?transport=tcp"], "user_name": "ome"}],
   "iceServers":  [{"credential": "airen", "urls": ["turn:192.168.0.200:3478?transport=tcp"], "username": "ome"}],

--- a/misc/ome_docker_launcher.sh
+++ b/misc/ome_docker_launcher.sh
@@ -774,6 +774,7 @@ _start()
 		-e OME_WEBRTC_SIGNALLING_TLS_PORT \
 		-e OME_WEBRTC_TCP_RELAY_PORT \
 		-e OME_WEBRTC_CANDIDATE_PORT \
+		-e OME_WEBRTC_TCP_ICE_PORT \
 		--restart=unless-stopped \
 		--mount=type=bind,source="${CONF_PATH}",target=/opt/ovenmediaengine/bin/origin_conf \
 		--mount=type=bind,source="${LOGS_PATH}",target=/var/log/ovenmediaengine \


### PR DESCRIPTION
## summary

update all documentation and example configs to reflect the new default WebRTC ICE candidate port introduced in e623d7b1bf4387994ec55c498b0ec2f8eabc5801.

## changes

### port mapping
- replace deprecated `10000-10009/udp` port ranges with single `10000/udp` and `10000/tcp`
- update docker `run` commands and `docker-compose.yml` port mappings accordingly

### IceCandidates examples
- replace wildcard `*` with `${PublicIP}` macro (resolved via `<StunServer>` at startup)
- add Direct TCP ICE (RFC 6544) candidate: `<IceCandidate>${PublicIP}:10000/tcp</IceCandidate>`
- replace deprecated `<TcpForce>` with `<TcpRelayForce>false</TcpRelayForce>`
- add `<IceWorkerCount>` and `<TcpIceWorkerCount>` elements

### docker / scripts
- add `OME_WEBRTC_TCP_ICE_PORT` env var to `docker-compose.yml` and `misc/ome_docker_launcher.sh`

## affected files

- `README.md`
- `docker-compose.yml`
- `misc/ome_docker_launcher.sh`
- `docs/configuration/README.md`
- `docs/getting-started/README.md`
- `docs/getting-started/getting-started-with-docker.md`
- `docs/getting-started/getting-started-with-ome-docker-launcher.md`
- `docs/performance-tuning.md`
- `docs/quick-start/README.md`
- `docs/streaming/webrtc-publishing.md`