### PR TITLE
fix: resolve issue where one push session delay affects other push sessions

### DIFF
--- a/src/projects/base/info/push.cpp
+++ b/src/projects/base/info/push.cpp
@@ -317,11 +317,9 @@ namespace info
 
 	const ov::String Push::GetInfoString()
 	{
-		ov::String info = "";
-
-		info.AppendFormat("uid(%s), vhost(%s) app(%s) stream(%s) -> protocol(%s) url(%s) streamKey(%s) variantNames(%s)",
-						  _id.CStr(), GetVhost().CStr(), GetApplication().CStr(), GetStreamName().CStr(), GetProtocol().CStr(), GetUrl().CStr(), GetStreamKey().CStr(),
-						  GetVariantNames().empty() ? "all" : ov::String::Join(GetVariantNames(), ",").CStr());
+		ov::String info = ov::String::FormatString("uid(%s), vhost(%s) app(%s) stream(%s) -> protocol(%s) url(%s) streamKey(%s), variantNames(%s)",
+								  _id.CStr(), GetVhost().CStr(), GetApplication().CStr(), GetStreamName().CStr(), GetProtocol().CStr(), GetUrl().CStr(), GetStreamKey().CStr(),
+								  GetVariantNames().empty() ? "all" : ov::String::Join(GetVariantNames(), ",").CStr());
 
 		return info;
 	}

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -361,10 +361,17 @@ namespace ov
 			auto shared_lock = std::shared_lock(_name_mutex);
 
 			ov::String urn_str = (_urn != nullptr) ? _urn->ToString() : ov::String("NoUrn");
+
+			ov::String threshold_info = ov::String::FormatString("%zu (%s %zu%s", _threshold, GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? "ms" : "");
+			if(_buffering_delay > 0)
+			{
+				threshold_info.AppendFormat(" + delay %dms", _buffering_delay);
+			}
+			threshold_info.Append(")");
+
 			return ov::String::FormatString(
-				"ManagedQueue [Id: %u, Size: %zu, Threshold: %zu (%s %zu%s + delay %dms), Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
-				GetId(), _size, _threshold,
-				GetThresholdModeString(), _threshold_value, (_threshold_mode == ThresholdMode::TimeBased) ? " ms" : "", _buffering_delay,
+				"ManagedQueue [Id: %u, Size: %zu, Threshold: %s, Peak: %zu, Imps: %zu, Omps: %zu, Wait: %s, Urn: %s]",
+				GetId(), _size, threshold_info.CStr(),
 				_peak, _input_message_per_second, _output_message_per_second, _exceed_threshold_and_wait_enabled ? "On" : "Off",
 				urn_str.CStr());
 		}
@@ -537,13 +544,20 @@ namespace ov
 			_output_message_per_second = 0;
 			_input_message_count = 0;
 			_output_message_count = 0;
+
+			_last_input_message_count = 0;
+			_last_output_message_count = 0;
 			_threshold_exceeded_time_in_us = 0;
+
+			_last_logging_time = 0;
+			_last_logged_peak = 0;
+
+			_timer.Stop();
 
 			MonitorInstance->OnQueueUpdated(*this);
 		}
 
-	private:
-
+	public:
 		// Check if the queue has exceeded the threshold.
 		// _threshold == 0 means no threshold.
 		bool IsThresholdExceeded() const
@@ -551,7 +565,8 @@ namespace ov
 			if (_threshold == 0) return false;
 			return _size >= _threshold;
 		}
-
+		
+	private:
 		// Compute the threshold
 		void UpdateThreshold()
 		{

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -19,7 +19,7 @@
 #include "base/info/managed_queue.h"
 #include "base/ovlibrary/ovlibrary.h"
 
-#define MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 1000
+#define MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100
 #define MANAGED_QUEUE_LOG_INTERVAL_IN_MSEC 5000
 
 
@@ -296,6 +296,13 @@ namespace ov
 			return (_size == 0);
 		}
 
+		// Returns true if the queue has been over its threshold for at least `duration`.
+		// Notes: exceeded time is updated only on each stats tick (MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100ms)
+		bool IsThresholdExceededFor(std::chrono::milliseconds duration) const
+		{
+			return _threshold_exceeded_time_in_us >= static_cast<int64_t>(duration.count());
+		}
+
 		// Cleared all items in the queue
 		void Clear()
 		{
@@ -511,10 +518,10 @@ namespace ov
 
 				if (IsThresholdExceeded())
 				{
-					_threshold_exceeded_time_in_us += _stats_metric_interval;
+					_threshold_exceeded_time_in_us += elapsed_time;
 
 					// Logging
-					_last_logging_time += _stats_metric_interval;
+					_last_logging_time += elapsed_time;
 					if ((_last_logging_time >= _log_interval) && (_last_logged_peak < _peak))
 					{
 						_last_logging_time = 0;
@@ -557,7 +564,7 @@ namespace ov
 			MonitorInstance->OnQueueUpdated(*this);
 		}
 
-	public:
+	private:
 		// Check if the queue has exceeded the threshold.
 		// _threshold == 0 means no threshold.
 		bool IsThresholdExceeded() const
@@ -565,8 +572,7 @@ namespace ov
 			if (_threshold == 0) return false;
 			return _size >= _threshold;
 		}
-		
-	private:
+
 		// Compute the threshold
 		void UpdateThreshold()
 		{

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -19,7 +19,7 @@
 #include "base/info/managed_queue.h"
 #include "base/ovlibrary/ovlibrary.h"
 
-#define MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 100
+#define MANAGED_QUEUE_METRICS_UPDATE_INTERVAL_IN_MSEC 1000
 #define MANAGED_QUEUE_LOG_INTERVAL_IN_MSEC 5000
 
 

--- a/src/projects/publishers/push/push_application.cpp
+++ b/src/projects/publishers/push/push_application.cpp
@@ -237,11 +237,12 @@ namespace pub
 				logti("Push started. %s connectionTimeout(%d) sendTimeout(%d)", push->GetInfoString().CStr(), push->GetConnectionTimeout(), push->GetSendTimeout());
 				session->Start();			
 				break;
-			// State of stopped
-			case pub::Session::SessionState::Stopped:
-				[[fallthrough]];
 			// State of failed (connection refused, disconnected)
 			case pub::Session::SessionState::Error:
+				session->Stop();
+				[[fallthrough]];
+			// State of stopped
+			case pub::Session::SessionState::Stopped:
 				logti("Push restarted. %s connectionTimeout(%d) sendTimeout(%d)", push->GetInfoString().CStr(), push->GetConnectionTimeout(), push->GetSendTimeout());
 				session->Start();
 				break;

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -317,7 +317,7 @@ namespace pub
 
 			if (_sender_packet_queue.IsThresholdExceededFor(kThresholdGraceDuration))
 			{
-				logte("Push session queue exceeded state persisted for more than %lld seconds. Terminating session. %s",
+				logte("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
 					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -172,9 +172,20 @@ namespace pub
 			return false;
 		}
 
+		if (StartSenderThread() == false)
+		{
+			writer->Stop();
+			SetState(SessionState::Error);
+			push->SetState(info::Push::PushState::Error);
+			
+			logte("Failed to start sender thread. %s", push->GetInfoString().CStr());
+			
+			return false;
+		}
+
 		push->SetState(info::Push::PushState::Pushing);
 
-		logtt("PushSession(%d) has started.", GetId());
+		logtd("PushSession(%d) has started.", GetId());
 
 		return Session::Start();
 	}
@@ -191,6 +202,8 @@ namespace pub
 				push->UpdatePushStartTime();
 			}
 
+			StopSenderThread();
+
 			writer->Stop();
 
 			if (push != nullptr)
@@ -201,7 +214,7 @@ namespace pub
 
 			DestoryWriter();
 
-			logtt("PushSession(%d) has stopped", GetId());
+			logtd("PushSession(%d) has stopped", GetId());
 		}
 
 		return Session::Stop();
@@ -210,6 +223,11 @@ namespace pub
 	void PushSession::SendOutgoingData(const std::any &packet)
 	{
 		if (GetState() != SessionState::Started)
+		{
+			return;
+		}
+
+		if (_sender_stop_flag.load())
 		{
 			return;
 		}
@@ -231,37 +249,139 @@ namespace pub
 			return;
 		}
 
-		auto writer = GetWriter();
-		if (writer == nullptr)
+		_sender_packet_queue.Enqueue(std::move(session_packet));
+	}
+
+	bool PushSession::StartSenderThread()
+	{
+		StopSenderThread();
+
+		auto stream = GetStream();
+		if (stream != nullptr)
 		{
-			return;
+			auto urn = std::make_shared<info::ManagedQueue::URN>(
+				stream->GetApplicationInfo().GetVHostAppName(),
+				stream->GetName(),
+				"pub",
+				ov::String::FormatString("push_session_%u", GetId()).LowerCaseString());
+			_sender_packet_queue.SetUrn(urn);
 		}
 
-		auto push = GetPush();
-		if (push == nullptr)
+		_sender_packet_queue.SetThresholdByTime(5000);
+		_sender_packet_queue.Clear();
+
+		_threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
+
+		_sender_stop_flag = false;
+		_sender_thread = std::thread(&PushSession::SenderThread, this);
+		pthread_setname_np(_sender_thread.native_handle(), ov::String::FormatString("PushSess-%u", GetId()).CStr());
+
+		return true;
+	}
+
+	void PushSession::StopSenderThread()
+	{
+		_sender_stop_flag = true;
+
+		if (_sender_thread.joinable())
 		{
-			return;
+			_sender_thread.join();
 		}
 
-		uint64_t sent_bytes = 0;
+		_sender_packet_queue.Clear();
+	}
 
-		bool ret = writer->SendPacket(session_packet, &sent_bytes);
-		if (ret == false)
+	bool PushSession::IsSenderQueueExceededFor(std::chrono::milliseconds duration)
+	{
+		if (_sender_packet_queue.IsThresholdExceeded() == false)
 		{
-			logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
-
-			writer->Stop();
-
-			SetState(SessionState::Error);
-			push->SetState(info::Push::PushState::Error);
-
-			return;
+			_threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
+			return false;
 		}
 
-		push->UpdatePushTime();
-		push->IncreasePushBytes(sent_bytes);
+		auto now = std::chrono::steady_clock::now();
+		if (_threshold_exceeded_start == std::chrono::steady_clock::time_point::min())
+		{
+			_threshold_exceeded_start = now;
+			return false;
+		}
 
-		MonitorInstance->IncreaseBytesOut(*GetStream(), PublisherType::Push, sent_bytes);
+		return (now - _threshold_exceeded_start) >= duration;
+	}
+
+	void PushSession::SenderThread()
+	{
+		ov::logger::ThreadHelper thread_helper;
+
+		constexpr auto kThresholdGraceDuration = std::chrono::seconds(10);
+
+		while (_sender_stop_flag.load() == false)
+		{
+			auto item = _sender_packet_queue.Dequeue(100);
+			if (item.has_value() == false)
+			{
+				// Timeout or Stop is called. 
+				continue;
+			}
+
+			auto session_packet = item.value();
+			if (session_packet == nullptr)
+			{
+				continue;
+			}
+
+			auto writer = GetWriter();
+			if (writer == nullptr)
+			{
+				continue;
+			}
+
+			auto push = GetPush();
+			if (push == nullptr)
+			{
+				continue;
+			}
+
+			// If the queue stays over the limit for 10 seconds (for example, because of a slow network), the PUSH session is closed.
+			if (IsSenderQueueExceededFor(kThresholdGraceDuration))
+			{
+				logte("Push session queue exceeded %ld sec. Terminating session. %s",
+					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
+
+				writer->Stop();
+
+				SetState(SessionState::Error);
+				push->SetState(info::Push::PushState::Error);
+
+				_sender_stop_flag = true;
+
+				continue;
+			}
+			
+			// Debug sleep to simulate slow network or processing. Remove this in production.
+			// std::this_thread::sleep_for(std::chrono::milliseconds(ov::Random::GenerateUInt32(2, 15)));
+
+			uint64_t sent_bytes = 0;
+			bool ret = writer->SendPacket(session_packet, &sent_bytes);
+			if (ret == false)
+			{
+				logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
+
+				writer->Stop();
+
+				SetState(SessionState::Error);
+				push->SetState(info::Push::PushState::Error);
+
+				_sender_stop_flag = true;
+
+				continue;
+			}
+
+			push->UpdatePushTime();
+			push->IncreasePushBytes(sent_bytes);
+
+			MonitorInstance->IncreaseBytesOut(*GetStream(), PublisherType::Push, sent_bytes);
+		}
 	}
 
 	std::shared_ptr<ffmpeg::Writer> PushSession::CreateWriter()
@@ -401,7 +521,7 @@ namespace pub
 			}
 		}
 
-		logtd("PushSession(%d) - Adding track. trackId:%d, variantName: %s", GetId(), track->GetId(), track->GetVariantName().CStr());
+		logtd("PushSession(%d) Adding track. trackId:%d, variantName: %s", GetId(), track->GetId(), track->GetVariantName().CStr());
 
 		return writer->AddTrack(track);
 	}

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -70,16 +70,14 @@ namespace pub
 		auto writer = CreateWriter();
 		if (writer == nullptr)
 		{
-			SetState(SessionState::Error);
-			push->SetState(info::Push::PushState::Error);
+			SetErrorState(push);
 			logte("Failed to create session. %s", push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (writer->SetUrl(dest_url, ffmpeg::compat::GetFormatByProtocolType(push->GetProtocolType())) == false)
 		{
-			SetState(SessionState::Error);
-			push->SetState(info::Push::PushState::Error);
+			SetErrorState(push);
 			logte("Failed to set URL. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
@@ -166,20 +164,15 @@ namespace pub
 		// Notice: If there are more than one video track, RTMP Push is not created and returns an error. You must use 1 video track.
 		if (writer->Start() == false)
 		{
-			SetState(SessionState::Error);
-			push->SetState(info::Push::PushState::Error);
+			SetErrorState(push);
 			logte("Failed to start session. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 			return false;
 		}
 
 		if (StartSenderThread() == false)
 		{
-			writer->Stop();
-			SetState(SessionState::Error);
-			push->SetState(info::Push::PushState::Error);
-			
+			SetErrorState(push, writer);
 			logte("Failed to start sender thread. %s", push->GetInfoString().CStr());
-			
 			return false;
 		}
 
@@ -348,11 +341,7 @@ namespace pub
 				logte("Push session queue exceeded %ld sec. Terminating session. %s",
 					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
 
-				writer->Stop();
-
-				SetState(SessionState::Error);
-				push->SetState(info::Push::PushState::Error);
-
+				SetErrorState(push, writer);
 				_sender_stop_flag = true;
 
 				continue;
@@ -367,11 +356,7 @@ namespace pub
 			{
 				logte("Failed to send packet. session will be terminated. Reason(%s), %s", writer->GetErrorMessage().CStr(), push->GetInfoString().CStr());
 
-				writer->Stop();
-
-				SetState(SessionState::Error);
-				push->SetState(info::Push::PushState::Error);
-
+				SetErrorState(push, writer);
 				_sender_stop_flag = true;
 
 				continue;
@@ -381,6 +366,19 @@ namespace pub
 			push->IncreasePushBytes(sent_bytes);
 
 			MonitorInstance->IncreaseBytesOut(*GetStream(), PublisherType::Push, sent_bytes);
+		}
+	}
+
+	void PushSession::SetErrorState(const std::shared_ptr<info::Push> &push, const std::shared_ptr<ffmpeg::Writer> &writer)
+	{
+		if (writer != nullptr)
+		{
+			writer->Stop();
+		}
+		SetState(SessionState::Error);
+		if (push != nullptr)
+		{
+			push->SetState(info::Push::PushState::Error);
 		}
 	}
 

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -260,10 +260,8 @@ namespace pub
 			_sender_packet_queue.SetUrn(urn);
 		}
 
-		_sender_packet_queue.SetThresholdByTime(5000);
+		_sender_packet_queue.SetThreshold(100);
 		_sender_packet_queue.Clear();
-
-		_threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
 
 		_sender_stop_flag = false;
 		_sender_thread = std::thread(&PushSession::SenderThread, this);
@@ -282,24 +280,6 @@ namespace pub
 		}
 
 		_sender_packet_queue.Clear();
-	}
-
-	bool PushSession::IsSenderQueueExceededFor(std::chrono::milliseconds duration)
-	{
-		if (_sender_packet_queue.IsThresholdExceeded() == false)
-		{
-			_threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
-			return false;
-		}
-
-		auto now = std::chrono::steady_clock::now();
-		if (_threshold_exceeded_start == std::chrono::steady_clock::time_point::min())
-		{
-			_threshold_exceeded_start = now;
-			return false;
-		}
-
-		return (now - _threshold_exceeded_start) >= duration;
 	}
 
 	void PushSession::SenderThread()
@@ -335,10 +315,9 @@ namespace pub
 				continue;
 			}
 
-			// If the queue stays over the limit for 10 seconds (for example, because of a slow network), the PUSH session is closed.
-			if (IsSenderQueueExceededFor(kThresholdGraceDuration))
+			if (_sender_packet_queue.IsThresholdExceededFor(kThresholdGraceDuration))
 			{
-				logte("Push session queue exceeded %ld sec. Terminating session. %s",
+				logte("Push session queue exceeded state persisted for more than %ld seconds. Terminating session. %s",
 					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -338,8 +338,8 @@ namespace pub
 			// If the queue stays over the limit for 10 seconds (for example, because of a slow network), the PUSH session is closed.
 			if (IsSenderQueueExceededFor(kThresholdGraceDuration))
 			{
-				logte("Push session queue exceeded %ld sec. Terminating session. %s",
-					  std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count(), push->GetInfoString().CStr());
+				logte("Push session queue exceeded %lld sec. Terminating session. %s",
+					  static_cast<long long>(std::chrono::duration_cast<std::chrono::seconds>(kThresholdGraceDuration).count()), push->GetInfoString().CStr());
 
 				SetErrorState(push, writer);
 				_sender_stop_flag = true;

--- a/src/projects/publishers/push/push_session.cpp
+++ b/src/projects/publishers/push/push_session.cpp
@@ -195,9 +195,9 @@ namespace pub
 				push->UpdatePushStartTime();
 			}
 
-			StopSenderThread();
-
 			writer->Stop();
+
+			StopSenderThread();
 
 			if (push != nullptr)
 			{

--- a/src/projects/publishers/push/push_session.h
+++ b/src/projects/publishers/push/push_session.h
@@ -13,6 +13,7 @@
 #include <base/publisher/session.h>
 #include <modules/ffmpeg/writer.h>
 #include <modules/ffmpeg/compat.h>
+#include <modules/managed_queue/managed_queue.h>
 
 #include "base/info/push.h"
 
@@ -48,10 +49,24 @@ namespace pub
 		bool IsSupportTrack(const info::Push::ProtocolType protocol_type, const std::shared_ptr<MediaTrack> &track);
 		bool IsSupportCodec(const info::Push::ProtocolType protocol_type, cmn::MediaCodecId codec_id);
 
+		bool StartSenderThread();
+		void StopSenderThread();
+		void SenderThread();
+
+		// Returns true if the sender queue has been continuously over its threshold for at least `duration`.
+		bool IsSenderQueueExceededFor(std::chrono::milliseconds duration);
+
 		std::shared_ptr<info::Push> _push = nullptr;
-		std::shared_mutex _push_mutex;		
+		std::shared_mutex _push_mutex;
 
 		std::shared_ptr<ffmpeg::Writer> _writer = nullptr;
 		std::shared_mutex _writer_mutex;
+
+		ov::ManagedQueue<std::shared_ptr<MediaPacket>> _sender_packet_queue;
+		std::thread _sender_thread;
+		std::atomic<bool> _sender_stop_flag{true};
+
+		// Variable used to check if the queue threshold stays exceeded
+		std::chrono::steady_clock::time_point _threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
 	};
 }  // namespace pub

--- a/src/projects/publishers/push/push_session.h
+++ b/src/projects/publishers/push/push_session.h
@@ -55,9 +55,6 @@ namespace pub
 		void StopSenderThread();
 		void SenderThread();
 
-		// Returns true if the sender queue has been continuously over its threshold for at least `duration`.
-		bool IsSenderQueueExceededFor(std::chrono::milliseconds duration);
-
 		std::shared_ptr<info::Push> _push = nullptr;
 		std::shared_mutex _push_mutex;
 
@@ -67,8 +64,5 @@ namespace pub
 		ov::ManagedQueue<std::shared_ptr<MediaPacket>> _sender_packet_queue;
 		std::thread _sender_thread;
 		std::atomic<bool> _sender_stop_flag{true};
-
-		// Variable used to check if the queue threshold stays exceeded
-		std::chrono::steady_clock::time_point _threshold_exceeded_start = std::chrono::steady_clock::time_point::min();
 	};
 }  // namespace pub

--- a/src/projects/publishers/push/push_session.h
+++ b/src/projects/publishers/push/push_session.h
@@ -49,6 +49,8 @@ namespace pub
 		bool IsSupportTrack(const info::Push::ProtocolType protocol_type, const std::shared_ptr<MediaTrack> &track);
 		bool IsSupportCodec(const info::Push::ProtocolType protocol_type, cmn::MediaCodecId codec_id);
 
+		void SetErrorState(const std::shared_ptr<info::Push> &push, const std::shared_ptr<ffmpeg::Writer> &writer = nullptr);
+
 		bool StartSenderThread();
 		void StopSenderThread();
 		void SenderThread();

--- a/src/projects/publishers/push/push_stream.cpp
+++ b/src/projects/publishers/push/push_stream.cpp
@@ -44,7 +44,7 @@ namespace pub
 			return false;
 		}
 
-		if (!CreateStreamWorker(2))
+		if (!CreateStreamWorker(1))
 		{
 			return false;
 		}


### PR DESCRIPTION
### Summary
Multiple push sessions shared a common stream worker thread. When one session experienced network send delays (slow/congested destination), it blocked the shared worker and caused all other push sessions to slow down as well. This is a regression introduced by the shared-worker architecture and reported in issue #2102.

To fix this, each push session now owns a dedicated sender thread and an internal packet queue. Incoming packets are enqueued immediately, and each session drains its own queue independently — so a slow session no longer blocks any other session.

Related: #2102

### Changes
- Dedicated sender thread per push session (push_session.cpp, push_session.h)
-- Added SenderThread, StartSenderThread, StopSenderThread methods

- Stream worker count reduced from 2 → 1 (push_stream.cpp)
-- Since packet dispatch now only writes to a queue (fast, non-blocking), a single stream worker is sufficient

- Error state transition fix (push_application.cpp)
--  Error state now calls session->Stop() before restarting, ensuring proper cleanup on reconnect

- Refactoring
--  Extracted SetErrorState() helper to eliminate duplicate error handling code across push_session.cpp