### PR TITLE
fix(webrtc): improve WebRTC ICE connectivity stability

### DIFF
--- a/src/projects/modules/ice/CMakeLists.txt
+++ b/src/projects/modules/ice/CMakeLists.txt
@@ -8,3 +8,10 @@ ome_add_static_library(ice
         sdp
         ovlibrary
 )
+
+if(OME_BUILD_TESTS)
+    file(GLOB _srcs "${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp")
+    ome_add_tests(ome_test_modules
+        SRCS ${_srcs}
+    )
+endif()

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -63,3 +63,34 @@ bool IceCandidatePair::IsConnectable() const
 {
     return _received_binding_request && _received_binding_response;
 }
+
+void IceCandidatePair::SetTurnDataChannel(uint16_t channel_number)
+{
+    _turn_channel_number.store(channel_number);
+    _transport_type.store(TransportType::TurnDataChannel);
+}
+
+void IceCandidatePair::SetTurnSendIndication(const ov::SocketAddress &turn_peer_address)
+{
+    {
+        std::lock_guard<std::mutex> lock(_turn_peer_address_mutex);
+        _turn_peer_address = turn_peer_address;
+    }
+    _transport_type.store(TransportType::TurnSendIndication);
+}
+
+IceCandidatePair::TransportType IceCandidatePair::GetTransportType() const
+{
+    return _transport_type.load();
+}
+
+uint16_t IceCandidatePair::GetTurnChannelNumber() const
+{
+    return _turn_channel_number.load();
+}
+
+ov::SocketAddress IceCandidatePair::GetTurnPeerAddress() const
+{
+    std::lock_guard<std::mutex> lock(_turn_peer_address_mutex);
+    return _turn_peer_address;
+}

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -42,8 +42,8 @@ ov::SocketAddressPair IceCandidatePair::GetAddressPair() const
 
 ov::String IceCandidatePair::ToString() const
 {
-    return ov::String::FormatString("Socket: %s SocketAddressPair: %s State: %s", 
-                        _socket->ToString().CStr(),
+    return ov::String::FormatString("Socket: %s SocketAddressPair: %s State: %s",
+                        _socket != nullptr ? _socket->ToString().CStr() : "(null)",
                         _socket_address_pair.ToString().CStr(),
                         IceConnectionStateToString(GetState()));
 }

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -40,7 +40,7 @@ ov::String IceCandidatePair::ToString() const
     return ov::String::FormatString("Socket: %s SocketAddressPair: %s State: %s", 
                         _socket->ToString().CStr(),
                         _socket_address_pair.ToString().CStr(),
-                        IceConnectionStateToString(_state));
+                        IceConnectionStateToString(GetState()));
 }
 
 void IceCandidatePair::OnReceivedBindingRequest()

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -21,12 +21,12 @@ std::shared_ptr<ov::Socket> IceCandidatePair::GetSocket() const
 // State management
 void IceCandidatePair::SetState(IceConnectionState state)
 {
-    _state = state;
+    _state.store(state);
 }
 
 IceConnectionState IceCandidatePair::GetState() const
 {
-    return _state;
+    return _state.load();
 }
 
 // Socket Address Pair

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -61,7 +61,12 @@ void IceCandidatePair::OnReceivedBindingResponse()
 // Valid candidate pair
 bool IceCandidatePair::IsConnectable() const
 {
-    return _received_binding_request && _received_binding_response;
+    // A pair whose STUN check Failed (error response) must not be treated as
+    // connectable: otherwise the CONTROLLING role keeps advertising
+    // USE-CANDIDATE on it and the quick-connect path keeps retrying it, even
+    // though SelectActiveCandidatePair() rejects Failed pairs.
+    return _state.load() != IceConnectionState::Failed
+        && _received_binding_request && _received_binding_response;
 }
 
 void IceCandidatePair::SetTurnDataChannel(uint16_t channel_number)

--- a/src/projects/modules/ice/ice_candidate_pair.cpp
+++ b/src/projects/modules/ice/ice_candidate_pair.cpp
@@ -29,6 +29,11 @@ IceConnectionState IceCandidatePair::GetState() const
     return _state.load();
 }
 
+bool IceCandidatePair::CompareExchangeState(IceConnectionState expected, IceConnectionState desired)
+{
+    return _state.compare_exchange_strong(expected, desired);
+}
+
 // Socket Address Pair
 ov::SocketAddressPair IceCandidatePair::GetAddressPair() const
 {

--- a/src/projects/modules/ice/ice_candidate_pair.h
+++ b/src/projects/modules/ice/ice_candidate_pair.h
@@ -24,6 +24,9 @@ public:
 	// State management
 	void SetState(IceConnectionState state);
 	IceConnectionState GetState() const;
+	// Atomically transition expected -> desired. Returns true only if this call
+	// performed the transition (state was exactly `expected`).
+	bool CompareExchangeState(IceConnectionState expected, IceConnectionState desired);
 
 	// Socket Address Pair
     ov::SocketAddressPair GetAddressPair() const;

--- a/src/projects/modules/ice/ice_candidate_pair.h
+++ b/src/projects/modules/ice/ice_candidate_pair.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 
 #include <base/ovlibrary/ovlibrary.h>
 #include <base/ovsocket/ovsocket.h>
@@ -17,6 +18,16 @@
 class IceCandidatePair
 {
 public:
+	// How OME must frame outgoing packets on this pair. This is a property of
+	// the pair, not the session: a session may have a TURN-relayed pair and a
+	// direct pair at the same time and switch the active pair between them.
+	enum class TransportType : uint8_t
+	{
+		Direct,				 // send as-is (RFC 4571 framing for direct-TCP is decided by the socket)
+		TurnDataChannel,	 // wrap in a TURN ChannelData message
+		TurnSendIndication,	 // wrap in a TURN Send Indication to the TURN peer address
+	};
+
 	IceCandidatePair(const ov::SocketAddressPair &pair, std::shared_ptr<ov::Socket> socket);
 
 	std::shared_ptr<ov::Socket> GetSocket() const;
@@ -39,6 +50,14 @@ public:
     // Valid candidate pair
     bool IsConnectable() const;
 
+	// Outgoing framing for this pair. Set when TURN ChannelData / Send
+	// Indication is received on this pair; defaults to Direct.
+	void SetTurnDataChannel(uint16_t channel_number);
+	void SetTurnSendIndication(const ov::SocketAddress &turn_peer_address);
+	TransportType GetTransportType() const;
+	uint16_t GetTurnChannelNumber() const;
+	ov::SocketAddress GetTurnPeerAddress() const;
+
 private:
 
 	std::atomic<IceConnectionState> _state{IceConnectionState::New};
@@ -47,4 +66,9 @@ private:
 
     bool _received_binding_request = false;
     bool _received_binding_response = false;
+
+	std::atomic<TransportType> _transport_type{TransportType::Direct};
+	std::atomic<uint16_t> _turn_channel_number{0};
+	mutable std::mutex _turn_peer_address_mutex;
+	ov::SocketAddress _turn_peer_address;
 };

--- a/src/projects/modules/ice/ice_candidate_pair.h
+++ b/src/projects/modules/ice/ice_candidate_pair.h
@@ -8,6 +8,8 @@
 //==============================================================================
 #pragma once
 
+#include <atomic>
+
 #include <base/ovlibrary/ovlibrary.h>
 #include <base/ovsocket/ovsocket.h>
 #include "ice_types.h"
@@ -36,7 +38,7 @@ public:
 
 private:
 
-	IceConnectionState _state = IceConnectionState::New;
+	std::atomic<IceConnectionState> _state{IceConnectionState::New};
     ov::SocketAddressPair _socket_address_pair;
 	std::shared_ptr<ov::Socket> _socket = nullptr;
 

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -571,9 +571,21 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 		return false;
 	}
 
+	// Resolve the active pair once and frame the packet for THAT pair. The
+	// framing must follow the active pair, not the session: a session may hold
+	// a TURN-relayed pair and a direct pair at the same time and switch between
+	// them, so a session-global TURN flag would keep TURN-wrapping after a
+	// switch to a direct pair (the peer then drops every packet).
+	auto active_candidate_pair = ice_session->GetActiveCandidatePair();
+	if (active_candidate_pair == nullptr)
+	{
+		logte("IcePort::Send - No active candidate pair: %u", session_id);
+		return false;
+	}
+
 	// The underlying socket may already be closed (e.g. by GC) before OnDisconnected callback arrives.
 	// Check socket state to avoid sending data to a closed socket.
-	auto remote = ice_session->GetActiveSocket();
+	auto remote = active_candidate_pair->GetSocket();
 	if (remote == nullptr)
 	{
 		logte("IcePort::Send - Could not find connected remote socket: %u", session_id);
@@ -589,38 +601,34 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 
 	std::shared_ptr<const ov::Data> send_data = nullptr;
 
-	// Send throutgh TURN server Data Channel proxy
-	if (ice_session->IsTurnClient() == true && ice_session->IsDataChannelEnabled() == true)
+	switch (active_candidate_pair->GetTransportType())
 	{
-		send_data = CreateChannelDataMessage(ice_session->GetDataChannelNumber(), data);
-	}
-	// Send thourgh TURN server Data Indication proxy
-	else if (ice_session->IsTurnClient() == true && ice_session->IsDataChannelEnabled() == false)
-	{
-		send_data = CreateDataIndication(ice_session->GetTurnPeerAddress(), data);
-	}
-	// Send direct
-	else
-	{
-		// For direct TCP ICE candidate connections (RFC 6544), wrap in RFC 4571 framing.
-		if (remote->GetType() == ov::SocketType::Tcp && IsIceTcpCandidatePort(remote->GetLocalAddress()->Port()))
-		{
-			send_data = CreateRfc4571Frame(data);
-		}
-		else
-		{
-			send_data = data;
-		}
+		// Send through TURN server Data Channel proxy
+		case IceCandidatePair::TransportType::TurnDataChannel:
+			send_data = CreateChannelDataMessage(active_candidate_pair->GetTurnChannelNumber(), data);
+			break;
+
+		// Send through TURN server Send Indication proxy
+		case IceCandidatePair::TransportType::TurnSendIndication:
+			send_data = CreateDataIndication(active_candidate_pair->GetTurnPeerAddress(), data);
+			break;
+
+		// Send direct
+		case IceCandidatePair::TransportType::Direct:
+		default:
+			// For direct TCP ICE candidate connections (RFC 6544), wrap in RFC 4571 framing.
+			if (remote->GetType() == ov::SocketType::Tcp && IsIceTcpCandidatePort(remote->GetLocalAddress()->Port()))
+			{
+				send_data = CreateRfc4571Frame(data);
+			}
+			else
+			{
+				send_data = data;
+			}
+			break;
 	}
 
 	if (send_data == nullptr)
-	{
-		return false;
-	}
-
-	// TODO(Getroot) : Change to use Local / Remote address of candidate pair
-	auto active_candidate_pair = ice_session->GetActiveCandidatePair();
-	if (active_candidate_pair == nullptr)
 	{
 		return false;
 	}
@@ -807,14 +815,12 @@ void IcePort::OnChannelDataPacketReceived(const std::shared_ptr<ov::Socket> &rem
 	application_gate_info.channel_number = message.GetChannelNumber();
 	application_gate_info.packet_type = IcePacketIdentifier::FindPacketType(message.GetData());
 
-	// Update GateInfo
-	// If a request comes from a send indication or channel, this is through a turn. When transmitting a packet to the player, it must be sent through a data indication or channel, so it stores related information.
+	// Data arrived via a TURN ChannelData message: record on THIS pair that we
+	// must reply through the same TURN data channel.
 	auto ice_session = FindIceSession(address_pair);
 	if (ice_session != nullptr)
 	{
-		ice_session->SetTurnClient(true);
-		ice_session->SetDataChannelEnabled(true);
-		ice_session->SetDataChannelNumber(application_gate_info.channel_number);
+		ice_session->SetCandidatePairTurnDataChannel(address_pair, remote, application_gate_info.channel_number);
 	}
 
 	// Decapsulate and process the packet again.
@@ -922,8 +928,25 @@ bool IcePort::MarkNominated(const std::shared_ptr<IceSession> &ice_session, cons
 	// Ensure application packets on this pair can resolve the session
 	AddIceSession(address_pair, ice_session);
 
+	const char *transport = "";
+	auto candidate_pair = ice_session->FindCandidatePair(address_pair);
+	if (candidate_pair != nullptr)
+	{
+		switch (candidate_pair->GetTransportType())
+		{
+			case IceCandidatePair::TransportType::TurnDataChannel:
+				transport = " [TURN/ChannelData]";
+				break;
+			case IceCandidatePair::TransportType::TurnSendIndication:
+				transport = " [TURN/SendIndication]";
+				break;
+			default:
+				break;
+		}
+	}
+
 	logti("Session %u nominated candidate: %s%s", ice_session->GetSessionID(),
-		  address_pair.ToString().CStr(), ice_session->IsTurnClient() ? " [TURN]" : "");
+		  address_pair.ToString().CStr(), transport);
 
 	return true;
 }
@@ -1330,13 +1353,11 @@ bool IcePort::OnReceivedTurnSendIndication(const std::shared_ptr<ov::Socket> &re
 	gate_info.peer_address = xor_peer_attribute->GetAddress();
 
 	std::shared_ptr<IceSession> ice_session = FindIceSession(address_pair);
-	// Connected Session,
-	// if agent sends data to TURN server (Send Indication) then ome will respond to agent through TURN server (Send Indication)
+	// Data arrived via a TURN Send Indication: record on THIS pair that we must
+	// reply through a TURN Send Indication to the TURN peer address.
 	if (ice_session != nullptr)
 	{
-		ice_session->SetTurnClient(true);
-		ice_session->SetDataChannelEnabled(false);
-		ice_session->SetTurnPeerAddress(gate_info.peer_address);
+		ice_session->SetCandidatePairTurnSendIndication(address_pair, remote, gate_info.peer_address);
 	}
 
 	OnPacketReceived(remote, address_pair, gate_info, data);
@@ -1371,13 +1392,11 @@ bool IcePort::OnReceivedTurnChannelBindRequest(const std::shared_ptr<ov::Socket>
 	SendStunMessage(remote, address_pair, gate_info, response_message, _hmac_key);
 
 	std::shared_ptr<IceSession> ice_session = FindIceSession(address_pair);
-	// Connected Session,
-	// if agent sends data to TURN server (Data Channel) then ome will respond to agent through TURN server (Data Channel)
+	// Channel bound: record on THIS pair that we must reply through this TURN
+	// data channel.
 	if (ice_session != nullptr)
 	{
-		ice_session->SetTurnClient(true);
-		ice_session->SetDataChannelEnabled(true);
-		ice_session->SetDataChannelNumber(channel_number_attribute->GetChannelNumber());
+		ice_session->SetCandidatePairTurnDataChannel(address_pair, remote, channel_number_attribute->GetChannelNumber());
 	}
 
 	return true;

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -591,7 +591,7 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 	auto remote = active_candidate_pair->GetSocket();
 	if (remote == nullptr)
 	{
-		logte("IcePort::Send - Could not find connected remote socket: %u", session_id);
+		logte("IcePort::Send - Active candidate pair has no socket: %u", session_id);
 		return false;
 	}
 

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -540,12 +540,12 @@ void IcePort::CheckTimedOut()
 		{
 			terminated_session->SetState(IceConnectionState::Disconnected);
 
-			logtw("Agent [%s, %u] has expired", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
+			logtw("Agent [%s, %u] has expired", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknown", terminated_session->GetSessionID());
 		}
 		else
 		{
 			terminated_session->SetState(IceConnectionState::Closed);
-			logti("Agent [%s, %u] has closed", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
+			logti("Agent [%s, %u] has closed", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknown", terminated_session->GetSessionID());
 		}
 
 		NotifyIceSessionStateChanged(terminated_session);

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -438,9 +438,12 @@ bool IcePort::RemoveSession(session_id_t session_id)
 	}
 
 	{
-		// Close only TCP (TURN)
-		auto remote = ice_session->GetActiveSocket();
-		if (remote != nullptr)
+		// Close every per-connection socket this session owns, not just the
+		// active one. With multi-pair switching the active pair may be UDP
+		// while the session still holds TURN-over-TCP / direct-TCP sockets
+		// from earlier path switches; those would otherwise leak. Only TCP is
+		// closed here: the UDP socket is the process-wide shared listener.
+		for (const auto &remote : ice_session->GetCandidatePairSockets())
 		{
 			if (remote->GetSocket().GetType() == ov::SocketType::Tcp)
 			{

--- a/src/projects/modules/ice/ice_port.cpp
+++ b/src/projects/modules/ice/ice_port.cpp
@@ -420,20 +420,26 @@ bool IcePort::RemoveSession(session_id_t session_id)
 		ice_sessions_with_ufrag_size = _ice_sessions_with_ufrag.size();
 	}
 
-	// Remove from _ice_sessions_with_address_pair if it exists
+	// Erase every pair registered for this session, not just the connected one
 	{
 		std::lock_guard<std::shared_mutex> lock_guard(_ice_sessions_with_address_pair_lock);
-		auto connected_candidate_pair = ice_session->GetConnectedCandidatePair();
-		if (connected_candidate_pair != nullptr)
+		for (auto it = _ice_sessions_with_address_pair.begin(); it != _ice_sessions_with_address_pair.end();)
 		{
-			_ice_sessions_with_address_pair.erase(connected_candidate_pair->GetAddressPair());
+			if (it->second == ice_session)
+			{
+				it = _ice_sessions_with_address_pair.erase(it);
+			}
+			else
+			{
+				++it;
+			}
 		}
 		ice_sessions_with_address_pair_size = _ice_sessions_with_address_pair.size();
 	}
 
 	{
 		// Close only TCP (TURN)
-		auto remote = ice_session->GetConnectedSocket();
+		auto remote = ice_session->GetActiveSocket();
 		if (remote != nullptr)
 		{
 			if (remote->GetSocket().GetType() == ov::SocketType::Tcp)
@@ -528,18 +534,18 @@ void IcePort::CheckTimedOut()
 	{
 		RemoveSession(terminated_session->GetSessionID());
 
-		auto connected_candidate_pair = terminated_session->GetConnectedCandidatePair();
+		auto active_candidate_pair = terminated_session->GetActiveCandidatePair();
 
 		if (terminated_session->IsExpired())
 		{
 			terminated_session->SetState(IceConnectionState::Disconnected);
 
-			logtw("Agent [%s, %u] has expired", connected_candidate_pair != nullptr ? connected_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
+			logtw("Agent [%s, %u] has expired", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
 		}
 		else
 		{
 			terminated_session->SetState(IceConnectionState::Closed);
-			logti("Agent [%s, %u] has closed", connected_candidate_pair != nullptr ? connected_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
+			logti("Agent [%s, %u] has closed", active_candidate_pair != nullptr ? active_candidate_pair->ToString().CStr() : "Unknow", terminated_session->GetSessionID());
 		}
 
 		NotifyIceSessionStateChanged(terminated_session);
@@ -567,7 +573,7 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 
 	// The underlying socket may already be closed (e.g. by GC) before OnDisconnected callback arrives.
 	// Check socket state to avoid sending data to a closed socket.
-	auto remote = ice_session->GetConnectedSocket();
+	auto remote = ice_session->GetActiveSocket();
 	if (remote == nullptr)
 	{
 		logte("IcePort::Send - Could not find connected remote socket: %u", session_id);
@@ -613,13 +619,13 @@ bool IcePort::Send(session_id_t session_id, const std::shared_ptr<const ov::Data
 	}
 
 	// TODO(Getroot) : Change to use Local / Remote address of candidate pair
-	auto connected_candidate_pair = ice_session->GetConnectedCandidatePair();
-	if (connected_candidate_pair == nullptr)
+	auto active_candidate_pair = ice_session->GetActiveCandidatePair();
+	if (active_candidate_pair == nullptr)
 	{
 		return false;
 	}
 
-	return remote->SendFromTo(connected_candidate_pair->GetAddressPair(), send_data);
+	return remote->SendFromTo(active_candidate_pair->GetAddressPair(), send_data);
 }
 
 void IcePort::OnConnected(const std::shared_ptr<ov::Socket> &remote)
@@ -675,8 +681,8 @@ void IcePort::OnDisconnected(const std::shared_ptr<ov::Socket> &remote, Physical
 		std::shared_lock<std::shared_mutex> lock_guard(_ice_sessions_with_id_lock);
 		for (const auto &[session_id, ice_session] : _ice_seesions_with_id)
 		{
-			auto connected_socket = ice_session->GetConnectedSocket();
-			if (connected_socket != nullptr && connected_socket->GetNativeHandle() == remote->GetNativeHandle())
+			auto active_socket = ice_session->GetActiveSocket();
+			if (active_socket != nullptr && active_socket->GetNativeHandle() == remote->GetNativeHandle())
 			{
 				sessions_to_disconnect.push_back(session_id);
 			}
@@ -759,12 +765,23 @@ void IcePort::OnApplicationPacketReceived(const std::shared_ptr<ov::Socket> &rem
 		return;
 	}
 
-	// When the candidate pair is determined, the peer starts sending DTLS messages. This can be seen as a true connected.
-	if (ice_session->GetState() != IceConnectionState::Connected)
+	// An application packet on a pair other than the active one means the
+	// client switched its candidate pair, so we switch too.
+	// SelectActiveCandidatePair() also makes this pair the one we send on.
+	if (ice_session->IsActive(address_pair) == false)
 	{
-		// If the peer is not connected, it is not a valid packet.
-		logtw("Received application packet from invalid peer(%s). Dropping...", address_pair.ToString().CStr());
-		return;
+		auto old_state = ice_session->GetState();
+		if (ice_session->SelectActiveCandidatePair(address_pair) == false)
+		{
+			// Not a STUN-validated pair, so not a trusted path
+			logtw("Received application packet from invalid peer(%s). Dropping...", address_pair.ToString().CStr());
+			return;
+		}
+
+		if (old_state != ice_session->GetState())
+		{
+			NotifyIceSessionStateChanged(ice_session);
+		}
 	}
 
 	if (ice_session->GetObserver() != nullptr)
@@ -895,28 +912,18 @@ void IcePort::OnStunPacketReceived(const std::shared_ptr<ov::Socket> &remote, co
 	}
 }
 
-bool IcePort::UseCandidate(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair)
+bool IcePort::MarkNominated(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair)
 {
-	if (ice_session->GetState() == IceConnectionState::Connected && ice_session->GetConnectedCandidatePair()->GetAddressPair() == address_pair)
-	{
-		// Already connected
-		return true;
-	}
-
-	if (ice_session->UseCandidate(address_pair) == false)
+	if (ice_session->MarkNominated(address_pair) == false)
 	{
 		return false;
 	}
 
-	if (ice_session->IsTurnClient())
-	{
-		logti("Session %u uses candidate: %s [TURN]", ice_session->GetSessionID(), address_pair.ToString().CStr());
-	}
-	else
-	{
-		logti("Session %u uses candidate: %s", ice_session->GetSessionID(), address_pair.ToString().CStr());
-	}
+	// Ensure application packets on this pair can resolve the session
 	AddIceSession(address_pair, ice_session);
+
+	logti("Session %u nominated candidate: %s%s", ice_session->GetSessionID(),
+		  address_pair.ToString().CStr(), ice_session->IsTurnClient() ? " [TURN]" : "");
 
 	return true;
 }
@@ -967,13 +974,16 @@ bool IcePort::OnReceivedStunBindingRequest(const std::shared_ptr<ov::Socket> &re
 	auto old_state = ice_session->GetState();
 	ice_session->OnReceivedStunBindingRequest(address_pair, remote);
 
-	// Check the USE-CANDIDATE attribute if session role is controlled
+	// Register this validated pair so app packets on it resolve the session
+	AddIceSession(address_pair, ice_session);
+
+	// Peer (controlling) nominated this pair via USE-CANDIDATE
 	if (ice_session->GetRole() == IceSession::Role::CONTROLLED)
 	{
 		auto use_candidate_attr = message.GetAttribute<StunAttribute>(StunAttributeType::UseCandidate);
 		if (use_candidate_attr != nullptr)
 		{
-			UseCandidate(ice_session, address_pair);
+			MarkNominated(ice_session, address_pair);
 		}
 	}
 
@@ -1008,26 +1018,19 @@ bool IcePort::OnReceivedStunBindingRequest(const std::shared_ptr<ov::Socket> &re
 		SendStunMessage(remote, address_pair, gate_info, response_message, ice_session->GetLocalSdp()->GetIcePwd().ToData(false));
 	}
 
-	// Already connected, we don't send stun binding request to another peer address
-	if (ice_session->GetState() == IceConnectionState::Connected)
+	// Invariant: a Connected session always has an active pair.
+	if (ice_session->GetState() == IceConnectionState::Connected && ice_session->GetActiveCandidatePair() == nullptr)
 	{
-		auto connected_candidate_pair = ice_session->GetConnectedCandidatePair();
-		if (connected_candidate_pair == nullptr)
-		{
-			// This should not happen
-			logte("IceSession(%u) is in connected state, but connected candidate pair is null", ice_session->GetSessionID());
-			return false;
-		}
-
-		if (connected_candidate_pair->GetAddressPair() != address_pair)
-		{
-			logtt("Already connected with another address : Connected(%s) Bind Request(%s)", connected_candidate_pair->GetAddressPair().ToString().CStr(), address_pair.ToString().CStr());
-			// Didn't respond
-			return true;
-		}
+		// This should not happen
+		logte("IceSession(%u) is in connected state, but active candidate pair is null", ice_session->GetSessionID());
+		return false;
 	}
 
-	// OvenMediaEngine sends Stun Binding Request to peer at this point
+	// Always answer with our own binding request (ICE triggered check), even
+	// when already connected on another pair, so every pair the peer keeps
+	// checking stays a viable fallback it can switch to. For CONTROLLING this
+	// also re-advertises USE-CANDIDATE. The active pair is decided by where
+	// the peer actually sends data (SelectActiveCandidatePair).
 	SendStunBindingRequest(remote, address_pair, gate_info, ice_session);
 
 	return true;
@@ -1066,17 +1069,13 @@ bool IcePort::SendStunBindingRequest(const std::shared_ptr<ov::Socket> &remote, 
 		ice_controlling_attr->SetValue(0x0000000000000001);
 		message.AddAttribute(ice_controlling_attr);
 
-		// TODO(Getroot): For now, it connect to the first connectable candidate pair,
-		// but we have to select the best pair among all nominated pairs and connect.
-		if (ice_session->GetState() == IceConnectionState::Checking && ice_session->IsConnectable(address_pair))
+		// Nominate every connectable pair so the controlled peer can use
+		// whichever is valid for it (host/tcp/relay). The pair we send on is
+		// decided later by where the peer sends application data.
+		if (ice_session->IsConnectable(address_pair))
 		{
-			UseCandidate(ice_session, address_pair);
-		}
+			MarkNominated(ice_session, address_pair);
 
-		// Ice Session State can be changed upper code, so check it again.
-		if (ice_session->GetState() == IceConnectionState::Connected && ice_session->IsConnected(address_pair))
-		{
-			// USE-CANDIDATE Attribute
 			auto use_candidate_attr = std::make_shared<StunUseCandidateAttribute>();
 			message.AddAttribute(use_candidate_attr);
 
@@ -1152,11 +1151,11 @@ bool IcePort::OnReceivedStunBindingResponse(const std::shared_ptr<ov::Socket> &r
 	auto old_state = ice_session->GetState();
 	ice_session->OnReceivedStunBindingResponse(address_pair, remote);
 
-	if (ice_session->GetState() == IceConnectionState::Checking && ice_session->IsConnectable(address_pair))
+	// On the first time this pair is validated, nominate it and immediately
+	// send a binding request so the peer receives USE-CANDIDATE quickly.
+	// MarkNominated() is idempotent, so this burst happens once per pair.
+	if (ice_session->IsConnectable(address_pair) && MarkNominated(ice_session, address_pair))
 	{
-		UseCandidate(ice_session, address_pair);
-
-		// Send STUN Binding Request for quickly connect
 		SendStunBindingRequest(remote, address_pair, gate_info, ice_session);
 	}
 

--- a/src/projects/modules/ice/ice_port.h
+++ b/src/projects/modules/ice/ice_port.h
@@ -51,6 +51,9 @@ class RtcIceCandidate;
 
 class IcePort : protected PhysicalPortObserver
 {
+	// Unit-test access to the private session registry (see ice_port_test.cpp)
+	friend class IcePortTest;
+
 public:
 	IcePort();
 	~IcePort() override;
@@ -203,7 +206,7 @@ private:
 	bool OnReceivedTurnCreatePermissionRequest(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair, GateInfo &packet_info, const StunMessage &message);
 	bool OnReceivedTurnChannelBindRequest(const std::shared_ptr<ov::Socket> &remote, const ov::SocketAddressPair &address_pair, GateInfo &packet_info, const StunMessage &message);
 
-	bool UseCandidate(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair);
+	bool MarkNominated(const std::shared_ptr<IceSession> &ice_session, const ov::SocketAddressPair &address_pair);
 
 	// Related TURN
 	std::shared_ptr<ov::Data> _hmac_key;

--- a/src/projects/modules/ice/ice_port_test.cpp
+++ b/src/projects/modules/ice/ice_port_test.cpp
@@ -1,0 +1,158 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: IcePort session registry (id / ufrag / address-pair maps) and
+//  RemoveSession() cleanup, in particular that RemoveSession() erases EVERY
+//  address pair registered for a session (not just the active one).
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/ovsocket/ovsocket.h>
+#include <modules/sdp/session_description.h>
+
+#include "ice_port.h"
+#include "ice_session.h"
+
+// Fixture is friended by IcePort, so its (protected) helpers may touch the
+// private session registry. TEST_F bodies call the helpers.
+class IcePortTest : public ::testing::Test
+{
+protected:
+	static ov::SocketAddressPair Pair(uint16_t local_port, uint16_t remote_port)
+	{
+		return ov::SocketAddressPair(
+			ov::SocketAddress::CreateAndGetFirst("127.0.0.1", local_port),
+			ov::SocketAddress::CreateAndGetFirst("127.0.0.1", remote_port));
+	}
+
+	// RemoveSession() needs a non-null local SDP (GetLocalUfrag()).
+	static std::shared_ptr<IceSession> MakeSession(session_id_t id, const ov::String &ufrag)
+	{
+		auto sdp = std::make_shared<SessionDescription>(SessionDescription::SdpType::Offer);
+		sdp->SetIceUfrag(ufrag);
+		return std::make_shared<IceSession>(
+			id, IceSession::Role::CONTROLLED, sdp, sdp, 600000, 0, std::any{}, nullptr);
+	}
+
+	bool AddId(IcePort &p, session_id_t id, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(id, s); }
+	bool AddUfrag(IcePort &p, const ov::String &u, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(u, s); }
+	bool AddPair(IcePort &p, const ov::SocketAddressPair &ap, const std::shared_ptr<IceSession> &s) { return p.AddIceSession(ap, s); }
+
+	std::shared_ptr<IceSession> FindId(IcePort &p, session_id_t id) { return p.FindIceSession(id); }
+	std::shared_ptr<IceSession> FindUfrag(IcePort &p, const ov::String &u) { return p.FindIceSession(u); }
+	std::shared_ptr<IceSession> FindPair(IcePort &p, const ov::SocketAddressPair &ap) { return p.FindIceSession(ap); }
+
+	bool MarkNom(IcePort &p, const std::shared_ptr<IceSession> &s, const ov::SocketAddressPair &ap) { return p.MarkNominated(s, ap); }
+};
+
+// Add / Find across the three indices, including idempotent inserts.
+TEST_F(IcePortTest, RegistryAddFind)
+{
+	IcePort port;
+	auto s = MakeSession(1, "ufragA");
+
+	EXPECT_TRUE(AddId(port, 1, s));
+	EXPECT_TRUE(AddUfrag(port, "ufragA", s));
+	EXPECT_TRUE(AddPair(port, Pair(10000, 20000), s));
+
+	EXPECT_EQ(FindId(port, 1), s);
+	EXPECT_EQ(FindUfrag(port, "ufragA"), s);
+	EXPECT_EQ(FindPair(port, Pair(10000, 20000)), s);
+
+	// Unknown lookups
+	EXPECT_EQ(FindId(port, 999), nullptr);
+	EXPECT_EQ(FindUfrag(port, "nope"), nullptr);
+	EXPECT_EQ(FindPair(port, Pair(10000, 59999)), nullptr);
+
+	// Duplicate inserts are rejected / idempotent
+	EXPECT_FALSE(AddId(port, 1, s));
+	EXPECT_FALSE(AddPair(port, Pair(10000, 20000), s));
+}
+
+// The core of the fix: RemoveSession() must erase every address pair
+// registered for the session, not just the active/connected one, and must
+// not touch other sessions.
+TEST_F(IcePortTest, RemoveSessionErasesAllAddressPairs)
+{
+	IcePort port;
+
+	auto s1 = MakeSession(1, "ufrag1");
+	auto a	= Pair(10000, 20000);  // e.g. direct UDP
+	auto b	= Pair(10001, 20001);  // e.g. direct TCP
+	auto c	= Pair(13478, 20002);  // e.g. TURN-relayed
+
+	ASSERT_TRUE(AddId(port, 1, s1));
+	ASSERT_TRUE(AddUfrag(port, "ufrag1", s1));
+	ASSERT_TRUE(AddPair(port, a, s1));
+	ASSERT_TRUE(AddPair(port, b, s1));
+	ASSERT_TRUE(AddPair(port, c, s1));
+
+	// A second, unrelated session that must survive intact.
+	auto s2 = MakeSession(2, "ufrag2");
+	auto d	= Pair(10000, 30000);
+	ASSERT_TRUE(AddId(port, 2, s2));
+	ASSERT_TRUE(AddUfrag(port, "ufrag2", s2));
+	ASSERT_TRUE(AddPair(port, d, s2));
+
+	EXPECT_TRUE(port.RemoveSession(1));
+
+	// Every index entry for session 1 is gone (no leaked pair)
+	EXPECT_EQ(FindId(port, 1), nullptr);
+	EXPECT_EQ(FindUfrag(port, "ufrag1"), nullptr);
+	EXPECT_EQ(FindPair(port, a), nullptr);
+	EXPECT_EQ(FindPair(port, b), nullptr);
+	EXPECT_EQ(FindPair(port, c), nullptr);
+
+	// Session 2 untouched
+	EXPECT_EQ(FindId(port, 2), s2);
+	EXPECT_EQ(FindUfrag(port, "ufrag2"), s2);
+	EXPECT_EQ(FindPair(port, d), s2);
+
+	// Removing again / unknown is a no-op false
+	EXPECT_FALSE(port.RemoveSession(1));
+	EXPECT_FALSE(port.RemoveSession(999));
+}
+
+// DisconnectSession marks the session Disconnecting (deferred removal).
+TEST_F(IcePortTest, DisconnectSessionMarksDisconnecting)
+{
+	IcePort port;
+	auto s = MakeSession(1, "ufragA");
+	ASSERT_TRUE(AddId(port, 1, s));
+	ASSERT_TRUE(AddUfrag(port, "ufragA", s));
+
+	EXPECT_TRUE(port.DisconnectSession(1));
+	EXPECT_EQ(s->GetState(), IceConnectionState::Disconnecting);
+
+	EXPECT_FALSE(port.DisconnectSession(999));
+}
+
+// Nominating a pair via IcePort must register it in the address-pair index so
+// an application packet on it resolves the session (the link that makes a
+// TURN-relayed DTLS path reachable). Idempotent; a pair the session never
+// validated is not registered.
+TEST_F(IcePortTest, MarkNominatedRegistersPair)
+{
+	IcePort port;
+	auto s	   = MakeSession(1, "ufragA");
+	auto known = Pair(13478, 20000);  // validated on the session
+	auto other = Pair(13478, 20001);  // never validated on the session
+
+	// The session must already know the pair (created by an inbound binding)
+	s->OnReceivedStunBindingRequest(known, nullptr);
+
+	EXPECT_EQ(FindPair(port, known), nullptr);
+
+	EXPECT_TRUE(MarkNom(port, s, known));
+	EXPECT_EQ(FindPair(port, known), s);
+
+	// Idempotent: already nominated -> false, still registered
+	EXPECT_FALSE(MarkNom(port, s, known));
+	EXPECT_EQ(FindPair(port, known), s);
+
+	// A pair the session never validated cannot be nominated/registered
+	EXPECT_FALSE(MarkNom(port, s, other));
+	EXPECT_EQ(FindPair(port, other), nullptr);
+}

--- a/src/projects/modules/ice/ice_port_test.cpp
+++ b/src/projects/modules/ice/ice_port_test.cpp
@@ -45,12 +45,18 @@ protected:
 	std::shared_ptr<IceSession> FindPair(IcePort &p, const ov::SocketAddressPair &ap) { return p.FindIceSession(ap); }
 
 	bool MarkNom(IcePort &p, const std::shared_ptr<IceSession> &s, const ov::SocketAddressPair &ap) { return p.MarkNominated(s, ap); }
+
+	// Stop the background sweeper so these registry tests are deterministic and
+	// free of a data race between CheckTimedOut() and the helpers below. The
+	// idempotent ~IcePort() Stop() afterwards is a harmless no-op.
+	void StopSweeper(IcePort &p) { p._timer.Stop(); }
 };
 
 // Add / Find across the three indices, including idempotent inserts.
 TEST_F(IcePortTest, RegistryAddFind)
 {
 	IcePort port;
+	StopSweeper(port);
 	auto s = MakeSession(1, "ufragA");
 
 	EXPECT_TRUE(AddId(port, 1, s));
@@ -77,6 +83,7 @@ TEST_F(IcePortTest, RegistryAddFind)
 TEST_F(IcePortTest, RemoveSessionErasesAllAddressPairs)
 {
 	IcePort port;
+	StopSweeper(port);
 
 	auto s1 = MakeSession(1, "ufrag1");
 	auto a	= Pair(10000, 20000);  // e.g. direct UDP
@@ -119,6 +126,7 @@ TEST_F(IcePortTest, RemoveSessionErasesAllAddressPairs)
 TEST_F(IcePortTest, DisconnectSessionMarksDisconnecting)
 {
 	IcePort port;
+	StopSweeper(port);
 	auto s = MakeSession(1, "ufragA");
 	ASSERT_TRUE(AddId(port, 1, s));
 	ASSERT_TRUE(AddUfrag(port, "ufragA", s));
@@ -136,6 +144,7 @@ TEST_F(IcePortTest, DisconnectSessionMarksDisconnecting)
 TEST_F(IcePortTest, MarkNominatedRegistersPair)
 {
 	IcePort port;
+	StopSweeper(port);
 	auto s	   = MakeSession(1, "ufragA");
 	auto known = Pair(13478, 20000);  // validated on the session
 	auto other = Pair(13478, 20001);  // never validated on the session

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -151,6 +151,40 @@ std::shared_ptr<IceCandidatePair> IceSession::FindCandidatePair(const ov::Socket
 	return nullptr;
 }
 
+std::vector<std::shared_ptr<ov::Socket>> IceSession::GetCandidatePairSockets() const
+{
+	std::shared_lock lock(_candidate_pairs_mutex);
+
+	std::vector<std::shared_ptr<ov::Socket>> sockets;
+	for (const auto& [address_pair, candidate_pair] : _candidate_pairs)
+	{
+		auto socket = candidate_pair->GetSocket();
+		if (socket == nullptr)
+		{
+			continue;
+		}
+
+		// Distinct sockets only (the same socket can back multiple pairs,
+		// e.g. the shared UDP listener or one TCP connection).
+		bool already_added = false;
+		for (const auto& s : sockets)
+		{
+			if (s == socket)
+			{
+				already_added = true;
+				break;
+			}
+		}
+
+		if (already_added == false)
+		{
+			sockets.push_back(socket);
+		}
+	}
+
+	return sockets;
+}
+
 std::shared_ptr<IceCandidatePair> IceSession::CreateAndAddCandidatePair(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket)
 {
 	std::scoped_lock lock(_candidate_pairs_mutex);

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -97,49 +97,28 @@ std::any IceSession::GetUserData() const
 	return _user_data;
 }
 
-void IceSession::SetTurnClient(bool is_turn_client)
+void IceSession::SetCandidatePairTurnDataChannel(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket, uint16_t channel_number)
 {
-	_is_turn_client = is_turn_client;
+	auto candidate_pair = FindCandidatePair(address_pair);
+	if (candidate_pair == nullptr)
+	{
+		// TURN ChannelBind/ChannelData can arrive before the relayed STUN
+		// connectivity check that would otherwise create the pair.
+		candidate_pair = CreateAndAddCandidatePair(address_pair, socket);
+	}
+
+	candidate_pair->SetTurnDataChannel(channel_number);
 }
 
-bool IceSession::IsTurnClient() const
+void IceSession::SetCandidatePairTurnSendIndication(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket, const ov::SocketAddress& turn_peer_address)
 {
-	return _is_turn_client;
-}
+	auto candidate_pair = FindCandidatePair(address_pair);
+	if (candidate_pair == nullptr)
+	{
+		candidate_pair = CreateAndAddCandidatePair(address_pair, socket);
+	}
 
-// Is data channel enabled
-void IceSession::SetDataChannelEnabled(bool is_data_channel_enabled)
-{
-	_is_data_channel_enabled = is_data_channel_enabled;	
-}
-
-bool IceSession::IsDataChannelEnabled() const
-{
-	return _is_data_channel_enabled;
-}
-
-// Data channel number
-void IceSession::SetDataChannelNumber(uint16_t data_channel_number)
-{
-	_data_channel_number = data_channel_number;
-}
-
-uint16_t IceSession::GetDataChannelNumber() const
-{
-	return _data_channel_number;
-}
-
-// TURN peer address
-void IceSession::SetTurnPeerAddress(const ov::SocketAddress& peer_address)
-{
-	std::scoped_lock lock(_turn_peer_address_mutex);
-	_turn_peer_address = peer_address;
-}
-
-ov::SocketAddress IceSession::GetTurnPeerAddress() const
-{
-	std::shared_lock lock(_turn_peer_address_mutex);
-	return _turn_peer_address;
+	candidate_pair->SetTurnSendIndication(turn_peer_address);
 }
 
 std::shared_ptr<IceCandidatePair> IceSession::GetActiveCandidatePair() const
@@ -327,14 +306,16 @@ bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair& address_
 	_active_candidate_pair = candidate_pair;
 	SetState(IceConnectionState::Connected);
 
+	// ToString() includes the socket (TCP/UDP + addresses), useful for tracing
+	// which path the peer moved to.
 	if (previous == nullptr)
 	{
-		logti("ICE session : %u | active pair selected: %s", GetSessionID(), address_pair.ToString().CStr());
+		logti("ICE session %u | active pair selected: %s", GetSessionID(), candidate_pair->ToString().CStr());
 	}
 	else
 	{
-		logti("ICE session : %u | active pair switched: %s -> %s",
-			  GetSessionID(), previous->GetAddressPair().ToString().CStr(), address_pair.ToString().CStr());
+		logti("ICE session %u | active pair switched: %s -> %s",
+			  GetSessionID(), previous->ToString().CStr(), candidate_pair->ToString().CStr());
 	}
 
 	return true;

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -295,9 +295,11 @@ bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 		return false;
 	}
 
-	if (candidate_pair->GetState() == IceConnectionState::Connected)
+	// Only a freshly validated (Checking) pair is newly nominated. Already
+	// Connected is a no-op, Failed must not be resurrected, and an unvalidated
+	// pair must not be nominated. All return false (caller: "nothing changed").
+	if (candidate_pair->GetState() != IceConnectionState::Checking)
 	{
-		// Already nominated
 		return false;
 	}
 

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -286,8 +286,6 @@ bool IceSession::IsActive(const ov::SocketAddressPair& address_pair)
 // is newly nominated (idempotent: false if it was already nominated).
 bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 {
-	std::scoped_lock lock(_active_candidate_pair_mutex);
-
 	auto candidate_pair = FindCandidatePair(address_pair);
 	if (candidate_pair == nullptr)
 	{
@@ -295,16 +293,12 @@ bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 		return false;
 	}
 
-	// Only a freshly validated (Checking) pair is newly nominated. Already
-	// Connected is a no-op, Failed must not be resurrected, and an unvalidated
-	// pair must not be nominated. All return false (caller: "nothing changed").
-	if (candidate_pair->GetState() != IceConnectionState::Checking)
-	{
-		return false;
-	}
-
-	candidate_pair->SetState(IceConnectionState::Connected);
-	return true;
+	// Atomically nominate only a freshly validated (Checking) pair. The CAS
+	// makes this race-free against a concurrent MarkNominated() and against
+	// OnReceivedStunBindingErrorResponse() setting Failed: an already Connected
+	// pair is a no-op and a Failed pair is never resurrected. false means
+	// "nothing changed" (the caller runs the quick-connect burst once per pair).
+	return candidate_pair->CompareExchangeState(IceConnectionState::Checking, IceConnectionState::Connected);
 }
 
 // Make a nominated pair the active pair (the one we send on). Called when the

--- a/src/projects/modules/ice/ice_session.cpp
+++ b/src/projects/modules/ice/ice_session.cpp
@@ -23,16 +23,16 @@ IceSession::IceSession(session_id_t session_id, IceSession::Role role,
 
 ov::String IceSession::ToString() const
 {
-	auto connected_candidate_pair = GetConnectedCandidatePair();
+	auto active_candidate_pair = GetActiveCandidatePair();
 
-	return ov::String::FormatString("IceSession: session_id=%u, role=%s, state=%s, local_ufrag=%s, expire_after_ms=%d, lifetime_epoch_ms=%" PRIu64 ", ConnectedCandidatePair=%s",
+	return ov::String::FormatString("IceSession: session_id=%u, role=%s, state=%s, local_ufrag=%s, expire_after_ms=%d, lifetime_epoch_ms=%" PRIu64 ", ActivePair=%s",
 		_session_id, 
 		_role == Role::CONTROLLED ? "CONTROLLED" : "CONTROLLING",
 		IceConnectionStateToString(_state.load()),
 		GetLocalUfrag().CStr(),
 		_expire_after_ms,
 		_lifetime_epoch_ms, 
-		(connected_candidate_pair != nullptr) ? connected_candidate_pair->ToString().CStr() : "None");
+		(active_candidate_pair != nullptr) ? active_candidate_pair->ToString().CStr() : "None");
 }
 
 void IceSession::Refresh()
@@ -142,21 +142,21 @@ ov::SocketAddress IceSession::GetTurnPeerAddress() const
 	return _turn_peer_address;
 }
 
-std::shared_ptr<IceCandidatePair> IceSession::GetConnectedCandidatePair() const
+std::shared_ptr<IceCandidatePair> IceSession::GetActiveCandidatePair() const
 {
-	std::shared_lock lock(_connected_candidate_pair_mutex);
-	return _connected_candidate_pair;
+	std::shared_lock lock(_active_candidate_pair_mutex);
+	return _active_candidate_pair;
 }
 
-std::shared_ptr<ov::Socket> IceSession::GetConnectedSocket() const
+std::shared_ptr<ov::Socket> IceSession::GetActiveSocket() const
 {
-	auto connected_candidate_pair = GetConnectedCandidatePair();
-	if (connected_candidate_pair == nullptr)
+	auto active_candidate_pair = GetActiveCandidatePair();
+	if (active_candidate_pair == nullptr)
 	{
 		return nullptr;
 	}
 	
-	return connected_candidate_pair->GetSocket();
+	return active_candidate_pair->GetSocket();
 }
 
 std::shared_ptr<IceCandidatePair> IceSession::FindCandidatePair(const ov::SocketAddressPair& address_pair) const
@@ -269,42 +269,77 @@ bool IceSession::IsConnectable(const ov::SocketAddressPair& address_pair)
 	return candidate_pair->IsConnectable();
 }
 
-bool IceSession::IsConnected(const ov::SocketAddressPair& address_pair)
+bool IceSession::IsActive(const ov::SocketAddressPair& address_pair)
 {
-	auto connected_candidate_pair = GetConnectedCandidatePair();
-	if (connected_candidate_pair == nullptr)
+	auto active_candidate_pair = GetActiveCandidatePair();
+	if (active_candidate_pair == nullptr)
 	{
 		return false;
 	}
 
-	return connected_candidate_pair->GetAddressPair() == address_pair;
+	return active_candidate_pair->GetAddressPair() == address_pair;
 }
 
-// USE-CANDIDATE, used for controlling role
-bool IceSession::UseCandidate(const ov::SocketAddressPair& address_pair)
+// Mark a STUN-validated pair as nominated/eligible. Multiple pairs may be
+// nominated; the one we actually send on is chosen by SelectActiveCandidatePair()
+// when the peer sends application data on it. Returns true only when the pair
+// is newly nominated (idempotent: false if it was already nominated).
+bool IceSession::MarkNominated(const ov::SocketAddressPair& address_pair)
 {
-	std::scoped_lock lock(_connected_candidate_pair_mutex);
-
-	// TODO(Getroot) : Consider the case where the ICE restart occurs
-	if (GetState() != IceConnectionState::Checking)
-	{
-		logte("ICE session : %u | UseCandidate() | Invalid state: %s", GetSessionID(), IceConnectionStateToString(GetState()));
-		return false;
-	}
+	std::scoped_lock lock(_active_candidate_pair_mutex);
 
 	auto candidate_pair = FindCandidatePair(address_pair);
 	if (candidate_pair == nullptr)
 	{
-		logte("ICE session : %u | UseCandidate() | No candidate pair found for address pair: %s", GetSessionID(), address_pair.ToString().CStr());
+		logtw("ICE session : %u | MarkNominated() | No candidate pair for %s", GetSessionID(), address_pair.ToString().CStr());
 		return false;
 	}
 
-	// candidate state
-	candidate_pair->SetState(IceConnectionState::Connected);
-	_connected_candidate_pair = candidate_pair;
+	if (candidate_pair->GetState() == IceConnectionState::Connected)
+	{
+		// Already nominated
+		return false;
+	}
 
-	// Global state
+	candidate_pair->SetState(IceConnectionState::Connected);
+	return true;
+}
+
+// Make a nominated pair the active pair (the one we send on). Called when the
+// peer sends application data on it, so OME follows the pair the peer chose
+// and switches if the peer moves.
+bool IceSession::SelectActiveCandidatePair(const ov::SocketAddressPair& address_pair)
+{
+	std::scoped_lock lock(_active_candidate_pair_mutex);
+
+	if (_active_candidate_pair != nullptr && _active_candidate_pair->GetAddressPair() == address_pair)
+	{
+		// Already the active pair
+		return true;
+	}
+
+	// Must be a STUN-validated pair (candidate pairs are created only after
+	// ufrag + MESSAGE-INTEGRITY pass) that has not failed its check.
+	auto candidate_pair = FindCandidatePair(address_pair);
+	if (candidate_pair == nullptr || candidate_pair->GetState() == IceConnectionState::Failed)
+	{
+		return false;
+	}
+
+	auto previous = _active_candidate_pair;
+
+	_active_candidate_pair = candidate_pair;
 	SetState(IceConnectionState::Connected);
+
+	if (previous == nullptr)
+	{
+		logti("ICE session : %u | active pair selected: %s", GetSessionID(), address_pair.ToString().CStr());
+	}
+	else
+	{
+		logti("ICE session : %u | active pair switched: %s -> %s",
+			  GetSessionID(), previous->GetAddressPair().ToString().CStr(), address_pair.ToString().CStr());
+	}
 
 	return true;
 }

--- a/src/projects/modules/ice/ice_session.h
+++ b/src/projects/modules/ice/ice_session.h
@@ -77,15 +77,19 @@ public:
 	void OnReceivedStunBindingErrorResponse(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket);
 
 	bool IsConnectable(const ov::SocketAddressPair& address_pair);
-	bool IsConnected(const ov::SocketAddressPair& address_pair);
+	bool IsActive(const ov::SocketAddressPair& address_pair);
 
-	// USE-CANDIDATE, used for controlling role
-	bool UseCandidate(const ov::SocketAddressPair& address_pair);
+	// Mark a STUN-validated pair as nominated/eligible (multiple allowed).
+	bool MarkNominated(const ov::SocketAddressPair& address_pair);
 
-	// Connected candidate pairs
-	std::shared_ptr<IceCandidatePair> GetConnectedCandidatePair() const;
+	// Make a STUN-validated pair the active pair (the one we send on).
+	// False if the pair is unknown or has failed its STUN check.
+	bool SelectActiveCandidatePair(const ov::SocketAddressPair& address_pair);
+
+	// Active candidate pair (the single pair we send on)
+	std::shared_ptr<IceCandidatePair> GetActiveCandidatePair() const;
 	// Socket
-	std::shared_ptr<ov::Socket> GetConnectedSocket() const;
+	std::shared_ptr<ov::Socket> GetActiveSocket() const;
 
 	ov::String ToString() const;
 
@@ -105,8 +109,8 @@ private:
     std::atomic<IceConnectionState> _state{IceConnectionState::New};
 
     // Candidate pairs
-	mutable std::shared_mutex _connected_candidate_pair_mutex;
-    std::shared_ptr<IceCandidatePair> _connected_candidate_pair;
+	mutable std::shared_mutex _active_candidate_pair_mutex;
+    std::shared_ptr<IceCandidatePair> _active_candidate_pair;
 
 	mutable std::shared_mutex _candidate_pairs_mutex;
     std::map<ov::SocketAddressPair, std::shared_ptr<IceCandidatePair>> _candidate_pairs;

--- a/src/projects/modules/ice/ice_session.h
+++ b/src/projects/modules/ice/ice_session.h
@@ -53,21 +53,13 @@ public:
 	// User data
 	std::any GetUserData() const;
 
-	// TURN client
-	void SetTurnClient(bool is_turn_client);
-	bool IsTurnClient() const;
-
-	// Is data channel enabled
-	void SetDataChannelEnabled(bool is_data_channel_enabled);
-	bool IsDataChannelEnabled() const;
-
-	// Data channel number
-	void SetDataChannelNumber(uint16_t data_channel_number);
-	uint16_t GetDataChannelNumber() const;
-
-	// TURN peer address
-	void SetTurnPeerAddress(const ov::SocketAddress& peer_address);
-	ov::SocketAddress GetTurnPeerAddress() const;
+	// TURN framing is per candidate pair, not per session: a session can hold a
+	// TURN-relayed pair and a direct pair simultaneously and switch the active
+	// pair between them. These find-or-create the pair for address_pair and
+	// record how to send on it (the inner packet is later routed by the same
+	// address_pair, so this is the pair that becomes active for that path).
+	void SetCandidatePairTurnDataChannel(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket, uint16_t channel_number);
+	void SetCandidatePairTurnSendIndication(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket, const ov::SocketAddress& turn_peer_address);
 
 	std::shared_ptr<IceCandidatePair> FindCandidatePair(const ov::SocketAddressPair& address_pair) const;
 
@@ -123,11 +115,4 @@ private:
     // interfaces
     std::any _user_data;
     std::shared_ptr<IcePortObserver> _observer;
-
-	// Connection information with TURN server
-	std::atomic<bool> _is_turn_client = false;
-	std::atomic<bool> _is_data_channel_enabled = false;
-	mutable std::shared_mutex _turn_peer_address_mutex;
-	ov::SocketAddress _turn_peer_address;
-	std::atomic<uint16_t> _data_channel_number = 0;
 };

--- a/src/projects/modules/ice/ice_session.h
+++ b/src/projects/modules/ice/ice_session.h
@@ -63,6 +63,11 @@ public:
 
 	std::shared_ptr<IceCandidatePair> FindCandidatePair(const ov::SocketAddressPair& address_pair) const;
 
+	// Distinct non-null sockets across all candidate pairs. Used on teardown:
+	// the active pair may be UDP while the session still owns per-connection
+	// TCP sockets (TURN-over-TCP / direct-TCP) from earlier path switches.
+	std::vector<std::shared_ptr<ov::Socket>> GetCandidatePairSockets() const;
+
 	// Candidate pairs
 	void OnReceivedStunBindingRequest(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket);
 	void OnReceivedStunBindingResponse(const ov::SocketAddressPair& address_pair, const std::shared_ptr<ov::Socket>& socket);

--- a/src/projects/modules/ice/ice_session_test.cpp
+++ b/src/projects/modules/ice/ice_session_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <base/ovsocket/ovsocket.h>
+#include <modules/sdp/session_description.h>
 
 #include "ice_session.h"
 
@@ -23,9 +24,14 @@ namespace
 
 	std::shared_ptr<IceSession> MakeSession()
 	{
+		// A real (minimal) SDP so any code path that touches the SDP
+		// (e.g. GetLocalUfrag()) stays safe, instead of a null that only
+		// works as long as the tested paths never dereference it.
+		auto sdp = std::make_shared<SessionDescription>(SessionDescription::SdpType::Offer);
+		sdp->SetIceUfrag("ufragT");
 		return std::make_shared<IceSession>(
 			1, IceSession::Role::CONTROLLED,
-			nullptr, nullptr,
+			sdp, sdp,
 			30000, 0,
 			std::any{}, nullptr);
 	}

--- a/src/projects/modules/ice/ice_session_test.cpp
+++ b/src/projects/modules/ice/ice_session_test.cpp
@@ -1,0 +1,156 @@
+//==============================================================================
+//
+//  OvenMediaEngine - Unit Tests
+//
+//  Covers: IceSession nomination / active-pair selection
+//  (MarkNominated, SelectActiveCandidatePair, IsActive)
+//
+//==============================================================================
+#include <gtest/gtest.h>
+
+#include <base/ovsocket/ovsocket.h>
+
+#include "ice_session.h"
+
+namespace
+{
+	ov::SocketAddressPair MakePair(uint16_t local_port, uint16_t remote_port)
+	{
+		auto local	= ov::SocketAddress::CreateAndGetFirst("127.0.0.1", local_port);
+		auto remote = ov::SocketAddress::CreateAndGetFirst("127.0.0.1", remote_port);
+		return ov::SocketAddressPair(local, remote);
+	}
+
+	std::shared_ptr<IceSession> MakeSession()
+	{
+		return std::make_shared<IceSession>(
+			1, IceSession::Role::CONTROLLED,
+			nullptr, nullptr,
+			30000, 0,
+			std::any{}, nullptr);
+	}
+
+	// Make the pair known to the session (creates the IceCandidatePair in
+	// Checking state, the same way an inbound STUN binding request would).
+	void Validate(const std::shared_ptr<IceSession> &session, const ov::SocketAddressPair &pair)
+	{
+		session->OnReceivedStunBindingRequest(pair, nullptr);
+	}
+}  // namespace
+
+// MarkNominated only works on a STUN-validated pair, is idempotent, and never
+// touches the active pair or the session state.
+TEST(IceSessionNomination, MarkNominated)
+{
+	auto session = MakeSession();
+	auto a		 = MakePair(10000, 20000);
+
+	// Not validated yet
+	EXPECT_FALSE(session->MarkNominated(a));
+
+	Validate(session, a);
+
+	EXPECT_TRUE(session->MarkNominated(a));	  // newly nominated
+	EXPECT_FALSE(session->MarkNominated(a));	  // idempotent
+
+	// Nomination must not pick the active pair nor flip session state
+	EXPECT_EQ(session->GetActiveCandidatePair(), nullptr);
+	EXPECT_NE(session->GetState(), IceConnectionState::Connected);
+}
+
+// SelectActiveCandidatePair accepts any STUN-validated pair (no explicit
+// nomination needed) and sets the active pair + session state together.
+TEST(IceSessionNomination, SelectRequiresValidated)
+{
+	auto session = MakeSession();
+	auto a		 = MakePair(10000, 20000);
+	auto b		 = MakePair(10000, 30000);
+
+	// Unknown (never STUN-validated) pair cannot be selected
+	EXPECT_FALSE(session->SelectActiveCandidatePair(a));
+	EXPECT_EQ(session->GetActiveCandidatePair(), nullptr);
+	EXPECT_NE(session->GetState(), IceConnectionState::Connected);
+
+	// A STUN-validated pair is selectable without explicit nomination
+	Validate(session, a);
+	ASSERT_TRUE(session->SelectActiveCandidatePair(a));
+
+	// Invariant: state == Connected  =>  active pair is set
+	EXPECT_EQ(session->GetState(), IceConnectionState::Connected);
+	ASSERT_NE(session->GetActiveCandidatePair(), nullptr);
+	EXPECT_EQ(session->GetActiveCandidatePair()->GetAddressPair(), a);
+	EXPECT_TRUE(session->IsActive(a));
+	EXPECT_FALSE(session->IsActive(b));
+
+	// Re-select the same pair is a no-op success
+	EXPECT_TRUE(session->SelectActiveCandidatePair(a));
+	EXPECT_EQ(session->GetActiveCandidatePair()->GetAddressPair(), a);
+}
+
+// The active pair follows the client: when application data arrives on a
+// different validated pair, OME switches to it (both directions, repeatable).
+TEST(IceSessionNomination, FollowClientSwitch)
+{
+	auto session = MakeSession();
+	auto a		 = MakePair(10000, 20000);
+	auto b		 = MakePair(10001, 30000);
+
+	Validate(session, a);
+	Validate(session, b);
+
+	ASSERT_TRUE(session->SelectActiveCandidatePair(a));
+	EXPECT_EQ(session->GetActiveCandidatePair()->GetAddressPair(), a);
+
+	// Client moved to b
+	ASSERT_TRUE(session->SelectActiveCandidatePair(b));
+	EXPECT_EQ(session->GetActiveCandidatePair()->GetAddressPair(), b);
+	EXPECT_TRUE(session->IsActive(b));
+	EXPECT_FALSE(session->IsActive(a));
+
+	// Client moved back to a
+	ASSERT_TRUE(session->SelectActiveCandidatePair(a));
+	EXPECT_EQ(session->GetActiveCandidatePair()->GetAddressPair(), a);
+}
+
+// A fresh session is not Connected and has no active pair until the first
+// successful selection.
+TEST(IceSessionNomination, InvariantBeforeSelection)
+{
+	auto session = MakeSession();
+	auto a		 = MakePair(10000, 20000);
+
+	EXPECT_NE(session->GetState(), IceConnectionState::Connected);
+	EXPECT_EQ(session->GetActiveCandidatePair(), nullptr);
+
+	Validate(session, a);
+	ASSERT_TRUE(session->SelectActiveCandidatePair(a));
+
+	EXPECT_EQ(session->GetState(), IceConnectionState::Connected);
+	EXPECT_NE(session->GetActiveCandidatePair(), nullptr);
+}
+
+// While a session is active on one pair, an unknown (never STUN-validated)
+// pair or a pair that has Failed its STUN check must NOT hijack the session:
+// the active pair stays put.
+TEST(IceSessionNomination, RejectFailedOrUnknownWhileActive)
+{
+	auto session = MakeSession();
+	auto a		 = MakePair(10000, 20000);	 // becomes active
+	auto b		 = MakePair(10001, 20001);	 // validated, then Failed
+	auto u		 = MakePair(10002, 20002);	 // never validated
+
+	Validate(session, a);
+	Validate(session, b);
+	ASSERT_TRUE(session->SelectActiveCandidatePair(a));
+	ASSERT_TRUE(session->IsActive(a));
+
+	// Unknown pair cannot hijack the active session
+	EXPECT_FALSE(session->SelectActiveCandidatePair(u));
+	EXPECT_TRUE(session->IsActive(a));
+
+	// A pair whose STUN check Failed cannot become active
+	session->OnReceivedStunBindingErrorResponse(b, nullptr);
+	EXPECT_FALSE(session->SelectActiveCandidatePair(b));
+	EXPECT_TRUE(session->IsActive(a));
+	EXPECT_EQ(session->GetState(), IceConnectionState::Connected);
+}

--- a/src/projects/modules/ice/ice_session_test.cpp
+++ b/src/projects/modules/ice/ice_session_test.cpp
@@ -56,6 +56,12 @@ TEST(IceSessionNomination, MarkNominated)
 	// Nomination must not pick the active pair nor flip session state
 	EXPECT_EQ(session->GetActiveCandidatePair(), nullptr);
 	EXPECT_NE(session->GetState(), IceConnectionState::Connected);
+
+	// A pair whose STUN check failed must not be resurrected by nomination
+	auto f = MakePair(10001, 20001);
+	Validate(session, f);
+	session->OnReceivedStunBindingErrorResponse(f, nullptr);
+	EXPECT_FALSE(session->MarkNominated(f));
 }
 
 // SelectActiveCandidatePair accepts any STUN-validated pair (no explicit

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -559,8 +559,10 @@ std::shared_ptr<MediaDescription> RtcStream::MakeVideoDescription() const
 	video_media_desc->SetConnection(4, "0.0.0.0");
 	video_media_desc->SetMid(ov::Random::GenerateString(6));
 	video_media_desc->SetMsid(_msid, ov::Random::GenerateString(36));
-	// Offer passive: OME DTLS is server-only
-	video_media_desc->SetSetup(MediaDescription::SetupType::Passive);
+	// RFC 5763 / RFC 8842: the offerer must use actpass. OME's DTLS is
+	// currently server-only, which is safe because browsers answer with
+	// active. DTLS active mode is planned.
+	video_media_desc->SetSetup(MediaDescription::SetupType::ActPass);
 	video_media_desc->UseDtls(true);
 	video_media_desc->UseRtcpMux(true);
 	video_media_desc->UseRtcpRsize(true);
@@ -604,8 +606,8 @@ std::shared_ptr<MediaDescription> RtcStream::MakeAudioDescription() const
 	// TODO(dimiden): Need to prevent duplication
 	audio_media_desc->SetMid(ov::Random::GenerateString(6));
 	audio_media_desc->SetMsid(_msid, ov::Random::GenerateString(36));
-	// Offer passive: OME DTLS is server-only
-	audio_media_desc->SetSetup(MediaDescription::SetupType::Passive);
+	// See MakeVideoDescription(): offerer must use actpass (RFC 5763 / 8842).
+	audio_media_desc->SetSetup(MediaDescription::SetupType::ActPass);
 	audio_media_desc->UseDtls(true);
 	audio_media_desc->UseRtcpMux(true);
 	audio_media_desc->UseRtcpRsize(true);

--- a/src/projects/publishers/webrtc/rtc_stream.cpp
+++ b/src/projects/publishers/webrtc/rtc_stream.cpp
@@ -559,15 +559,8 @@ std::shared_ptr<MediaDescription> RtcStream::MakeVideoDescription() const
 	video_media_desc->SetConnection(4, "0.0.0.0");
 	video_media_desc->SetMid(ov::Random::GenerateString(6));
 	video_media_desc->SetMsid(_msid, ov::Random::GenerateString(36));
-	/*
-	https://tools.ietf.org/html/rfc5763#section-5
-	
-	The endpoint MUST use the setup attribute defined in [RFC4145].
-	The endpoint that is the offerer MUST use the setup attribute
-	value of setup:actpass and be prepared to receive a client_hello
-	before it receives the answer.
-	*/
-	video_media_desc->SetSetup(MediaDescription::SetupType::ActPass);
+	// Offer passive: OME DTLS is server-only
+	video_media_desc->SetSetup(MediaDescription::SetupType::Passive);
 	video_media_desc->UseDtls(true);
 	video_media_desc->UseRtcpMux(true);
 	video_media_desc->UseRtcpRsize(true);
@@ -611,7 +604,8 @@ std::shared_ptr<MediaDescription> RtcStream::MakeAudioDescription() const
 	// TODO(dimiden): Need to prevent duplication
 	audio_media_desc->SetMid(ov::Random::GenerateString(6));
 	audio_media_desc->SetMsid(_msid, ov::Random::GenerateString(36));
-	audio_media_desc->SetSetup(MediaDescription::SetupType::ActPass);
+	// Offer passive: OME DTLS is server-only
+	audio_media_desc->SetSetup(MediaDescription::SetupType::Passive);
 	audio_media_desc->UseDtls(true);
 	audio_media_desc->UseRtcpMux(true);
 	audio_media_desc->UseRtcpRsize(true);


### PR DESCRIPTION
## Problem

OME latched the first nominated ICE candidate pair and could not follow the peer when it actually ran DTLS/media over a different pair. With mixed UDP/TCP/relay candidates (iceTransportPolicy=all) or a TURN-TCP relay path while UDP was nominated, WHIP ingest and WebRTC playback failed or stalled, and the session was torn down.

## Solution

Decouple nomination from the active pair:

- Any STUN-validated pair becomes the active pair when the peer sends application data on it, and the active pair switches if the peer moves (role independent, both ICE roles).
- CONTROLLING keeps advertising USE-CANDIDATE on every connectable pair so the peer always has a fallback path to switch to.
- `IceCandidatePair` state is now atomic, and `MarkNominated()` transitions it with a single compare_exchange so a Failed pair is never resurrected by a concurrent nomination.
- `RemoveSession` erases every address pair registered for a session, not only the connected one, preventing leaked map entries.

The WebRTC publisher continues to offer `setup:actpass`, which the offerer is required to use by RFC 5763 / RFC 8842. OME DTLS is currently server only, which is safe because browsers answer with `active`; DTLS active mode is planned separately.

Adds IceSession and IcePort unit tests covering nomination, active-pair selection/switch, the connected-state invariant, and the session-registry cleanup.
