### PR TITLE
fix: fixed regression where framerate did not work during image encoding

### DIFF
--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/image_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/image_profile.h
@@ -61,7 +61,7 @@ namespace cfg
 												   logw("Config", "Use SkipFrames in the settings, the Framerate is ignored.");
 											   }
 
-											   return (_skip_frames >= 0 && _skip_frames <= 120) ? nullptr : CreateConfigErrorPtr("SkipFrames must be between 0 and 120");
+											   return (_skip_frames >= -1 && _skip_frames <= 120) ? nullptr : CreateConfigErrorPtr("SkipFrames must be -1 or between 0 and 120");
 										   });
 						Register<Optional>("BypassIfMatch", &_bypass_if_match);
 					}

--- a/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/image_profile.h
+++ b/src/projects/config/items/virtual_hosts/applications/output_profiles/encodes/image_profile.h
@@ -28,7 +28,7 @@ namespace cfg
 					int _height		  = 0;
 					double _framerate = 0.0;
 					BypassIfMatch _bypass_if_match;
-					int _skip_frames = 0;
+					int _skip_frames = -1;
 
 				public:
 					CFG_DECLARE_CONST_REF_GETTER_OF(GetName, _name)


### PR DESCRIPTION
### Summary 
`skip_frames `was set to 0 by default in the image encoding settings, so image encoding used the source frame rate instead of the configured framerate.

### Changes
- Change the default value of `skip_frames `in image encoding options from 0 (Auto) to -1 (Disabled).
