### PR TITLE
fix(build): add missing libraries for NVIDIA and Whisper dependencies

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -347,7 +347,7 @@ if(OME_HWACCEL_NVIDIA)
         include_directories(${CUDA_ROOT}/include)
         link_directories(${CUDA_ROOT}/lib64)
 
-        set(OME_NVIDIA_LIBS cuda nvidia-ml ${NV_CUDART_LIB})
+        set(OME_NVIDIA_LIBS cuda nvidia-ml rt ${NV_CUDART_LIB})
     else()
         message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but required NVIDIA libraries/tools not found - disabled")
         set(OME_HWACCEL_NVIDIA OFF)
@@ -364,7 +364,8 @@ endif()
 if(PKG_WHISPER_FOUND)
     find_library(GGML_CPU_LIB   ggml-cpu        HINTS ${OME_DEP_PREFIX}/lib ${OME_DEP_PREFIX}/lib64)
     set_property(TARGET PkgConfig::PKG_WHISPER APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${GGML_CPU_LIB}")
-
+    set_property(TARGET PkgConfig::PKG_WHISPER APPEND PROPERTY INTERFACE_LINK_LIBRARIES gomp)
+    
     if(OME_HWACCEL_NVIDIA)  
         set(CUDA_ROOT "/usr/local/cuda")
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -347,7 +347,7 @@ if(OME_HWACCEL_NVIDIA)
         include_directories(${CUDA_ROOT}/include)
         link_directories(${CUDA_ROOT}/lib64)
 
-        set(OME_NVIDIA_LIBS cuda nvidia-ml rt ${NV_CUDART_LIB})
+        set(OME_NVIDIA_LIBS cuda nvidia-ml ${NV_CUDART_LIB} rt dl)
     else()
         message(WARNING "[OME] OME_HWACCEL_NVIDIA=ON but required NVIDIA libraries/tools not found - disabled")
         set(OME_HWACCEL_NVIDIA OFF)

--- a/src/projects/main/AMS.mk
+++ b/src/projects/main/AMS.mk
@@ -111,12 +111,12 @@ ifeq ($(and \
 $(call add_pkg_config,ffnvcodec)
 HWACCELS_NVIDIA_ENABLED := true
 PROJECT_CXXFLAGS += -I/usr/local/cuda/include -DHWACCELS_NVIDIA_ENABLED
-LOCAL_LDFLAGS += -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -Wl,-Bstatic -lcudart_static -Wl,-Bdynamic -lcuda -lnvidia-ml 
+LOCAL_LDFLAGS += -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -Wl,-Bstatic -lcudart_static -Wl,-Bdynamic -lcuda -lnvidia-ml -lrt -ldl 
 
 endif
 
 # Whisper GGML
-LOCAL_LDFLAGS += -lggml-cpu
+LOCAL_LDFLAGS += -lggml-cpu -lgomp
 ifeq ($(HWACCELS_NVIDIA_ENABLED), true)
 ifeq ($(call chk_file_exist,$(CONFIG_LIBRARY_PATHS),libwhisper.so), 0)
 LOCAL_LDFLAGS += -lggml-cuda

--- a/src/projects/main/AMS.mk
+++ b/src/projects/main/AMS.mk
@@ -111,7 +111,7 @@ ifeq ($(and \
 $(call add_pkg_config,ffnvcodec)
 HWACCELS_NVIDIA_ENABLED := true
 PROJECT_CXXFLAGS += -I/usr/local/cuda/include -DHWACCELS_NVIDIA_ENABLED
-LOCAL_LDFLAGS += -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -Wl,-Bstatic -lcudart_static -Wl,-Bdynamic -lcuda -lnvidia-ml -lrt -ldl 
+LOCAL_LDFLAGS += -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -Wl,-Bstatic -lcudart_static -Wl,-Bdynamic -lcuda -lnvidia-ml -lrt -ldl
 
 endif
 


### PR DESCRIPTION
### Summary
Fixes build link errors by adding missing system libraries (rt, dl, gomp) required by NVIDIA hardware acceleration and Whisper dependencies.

### Changes
- `cmake/Dependencies.cmake`: Added `rt `to OME_NVIDIA_LIBS, and linked `gomp `to Whisper
- `main/AMS.mk` : Added `-lrt -ldl` to NVIDIA link flags, and `-lgomp` for Whisper