### PR TITLE
refactor: allow provider modules to register after `StartServer`

### DIFF
--- a/src/projects/base/provider/provider.cpp
+++ b/src/projects/base/provider/provider.cpp
@@ -34,6 +34,14 @@ namespace pvd
 
 	bool Provider::Start()
 	{
+		// Push providers call this both from their own `Start()` (infrastructure)
+		// and again from `PushProvider::Start()` invoked inside `Bind()`.
+		// Guard to avoid re-swapping `_access_controller` and logging a duplicate "has been started" line.
+		if (IsModuleAvailable())
+		{
+			return true;
+		}
+
 		logti("%s has been started.", GetProviderName());
 
 		SetModuleAvailable(true);

--- a/src/projects/base/provider/push_provider/provider.cpp
+++ b/src/projects/base/provider/push_provider/provider.cpp
@@ -27,6 +27,13 @@ namespace pvd
         return Provider::Start();
     }
 
+	bool PushProvider::Bind()
+	{
+		// Default no-op for push providers without their own listener split. Concrete providers
+		// that hold sockets (WebRTC, MpegTs, Srt, Rtmp) override this to bind their listeners.
+		return true;
+	}
+
 	bool PushProvider::Stop()
     {
 		_run_task_runner.store(false);

--- a/src/projects/base/provider/push_provider/provider.h
+++ b/src/projects/base/provider/push_provider/provider.h
@@ -35,8 +35,8 @@ namespace pvd
 		// notified the module of existing vhosts/apps. `main.cpp` calls this explicitly after
 		// `RestorePullStreams()` (Enterprise) or after `StartServer()` (OSS) so push providers'
 		// listeners only accept traffic once their internal state is fully populated.
-		// Default implementation calls `PushProvider::Start()` (task runner thread) for providers
-		// that have no listener of their own; subclasses with sockets override to bind first.
+		// Default implementation is a no-op. Subclasses with sockets must override to bind their
+		// listener and then call `PushProvider::Start()` to spin up the task runner.
 		virtual bool Bind();
 		virtual bool Stop() override;
 

--- a/src/projects/base/provider/push_provider/provider.h
+++ b/src/projects/base/provider/push_provider/provider.h
@@ -29,8 +29,15 @@ namespace pvd
 			return ocst::ModuleType::PushProvider;
 		}
 
-		// Call CreateServer and store the server 
+		// Call CreateServer and store the server
 		virtual bool Start() override;
+		// Opens listeners after `Start()` has set up infrastructure and the orchestrator has
+		// notified the module of existing vhosts/apps. `main.cpp` calls this explicitly after
+		// `RestorePullStreams()` (Enterprise) or after `StartServer()` (OSS) so push providers'
+		// listeners only accept traffic once their internal state is fully populated.
+		// Default implementation calls `PushProvider::Start()` (task runner thread) for providers
+		// that have no listener of their own; subclasses with sockets override to bind first.
+		virtual bool Bind();
 		virtual bool Stop() override;
 
 		// Get Application by name

--- a/src/projects/base/provider/stream.cpp
+++ b/src/projects/base/provider/stream.cpp
@@ -65,7 +65,20 @@ namespace pvd
 		logti("%s/%s(%u) has been stopped playing stream", GetApplicationName(), GetName().CStr(), GetId());
 		ResetSourceStreamTimestamp();
 
-		_state = State::STOPPED;
+		// Preserve `TERMINATED`:
+		// demoting to `STOPPED` would let the reconnect loop revive a stream
+		// that was explicitly terminated (e.g. via API `DELETE`).
+		// Other callers reach here in non-terminal states (`PLAYING`/`ERROR`) and still transition to `STOPPED`.
+		// Compare-exchange loop closes the TOCTOU window where `Terminate()` lands between a plain
+		// load and the assignment: if another thread flips `_state` to `TERMINATED` mid-loop,
+		// `compare_exchange_weak` fails, the loop re-reads, sees `TERMINATED`, and exits without
+		// demoting.
+		auto current = _state.load();
+
+		while ((current != State::TERMINATED) &&
+			   (_state.compare_exchange_weak(current, State::STOPPED) == false))
+		{
+		}
 
 		return true;
 	}

--- a/src/projects/main/init_utilities.h
+++ b/src/projects/main/init_utilities.h
@@ -6,10 +6,9 @@
 //  Copyright (c) 2020 AirenSoft. All rights reserved.
 //
 //==============================================================================
-// Creates and registers a module.
-// The variable must already be declared - for modules whose creation must be deferred
-// (e.g. push providers created after `Orchestrator::StartServer()`).
-#define CREATE_MODULE(variable, name, create)                        \
+#define INIT_MODULE(variable, name, create)                          \
+	decltype(create) variable = nullptr;                             \
+                                                                     \
 	if (succeeded)                                                   \
 	{                                                                \
 		logti("Trying to create " name "...");                       \
@@ -28,6 +27,9 @@
 				if (orchestrator->RegisterModule(variable) == false) \
 				{                                                    \
 					logte("Failed to register " name);               \
+					/* `Create()` ran Start(); */                    \
+					/* RELEASE_MODULE skips */                       \
+					/* `Stop()` for unregistered modules. */         \
 					variable->Stop();                                \
 					variable.reset();                                \
 					succeeded = false;                               \
@@ -39,11 +41,6 @@
 			}                                                        \
 		}                                                            \
 	}
-
-// Declares the module variable and creates/registers it in one step.
-#define INIT_MODULE(variable, name, create) \
-	decltype(create) variable = nullptr;    \
-	CREATE_MODULE(variable, name, create)
 
 #define RELEASE_MODULE(variable, name)                         \
 	if (variable != nullptr)                                   \

--- a/src/projects/main/init_utilities.h
+++ b/src/projects/main/init_utilities.h
@@ -8,7 +8,7 @@
 //==============================================================================
 // Creates and registers a module.
 // The variable must already be declared - for modules whose creation must be deferred
-// (e.g. ingest providers created after `Orchestrator::StartServer()`).
+// (e.g. push providers created after `Orchestrator::StartServer()`).
 #define CREATE_MODULE(variable, name, create)                        \
 	if (succeeded)                                                   \
 	{                                                                \
@@ -28,6 +28,8 @@
 				if (orchestrator->RegisterModule(variable) == false) \
 				{                                                    \
 					logte("Failed to register " name);               \
+					variable->Stop();                                \
+					variable.reset();                                \
 					succeeded = false;                               \
 				}                                                    \
 			}                                                        \

--- a/src/projects/main/init_utilities.h
+++ b/src/projects/main/init_utilities.h
@@ -6,9 +6,10 @@
 //  Copyright (c) 2020 AirenSoft. All rights reserved.
 //
 //==============================================================================
-#define INIT_MODULE(variable, name, create)                          \
-	decltype(create) variable = nullptr;                             \
-                                                                     \
+// Creates and registers a module.
+// The variable must already be declared - for modules whose creation must be deferred
+// (e.g. ingest providers created after `Orchestrator::StartServer()`).
+#define CREATE_MODULE(variable, name, create)                        \
 	if (succeeded)                                                   \
 	{                                                                \
 		logti("Trying to create " name "...");                       \
@@ -37,6 +38,11 @@
 		}                                                            \
 	}
 
+// Declares the module variable and creates/registers it in one step.
+#define INIT_MODULE(variable, name, create) \
+	decltype(create) variable = nullptr;    \
+	CREATE_MODULE(variable, name, create)
+
 #define RELEASE_MODULE(variable, name)                         \
 	if (variable != nullptr)                                   \
 	{                                                          \
@@ -48,7 +54,7 @@
 		}                                                      \
 		else                                                   \
 		{                                                      \
-			logte("Failed to unregister " name);                \
+			logte("Failed to unregister " name);               \
 		}                                                      \
 	}
 

--- a/src/projects/main/main.cpp
+++ b/src/projects/main/main.cpp
@@ -143,22 +143,23 @@ int main(int argc, char *argv[])
 	// Initialize Transcoder
 	INIT_MODULE(transcoder, "Transcoder", Transcoder::Create(media_router));
 
-	// Pull providers must be registered before `StartServer()`
-	// so other modules that resolve URL schemes via `Orchestrator::GetProviderForScheme()`
-	// find them when applications are created.
+	// Providers are all `INIT_MODULE`d before `StartServer()`. Each provider's `Start()` performs
+	// only infrastructure setup (config parse, internal state, certificates etc.) - listener
+	// binding for push providers is deferred to `Bind()`, which `main.cpp` calls explicitly after
+	// the server has finished its `CreateVirtualHosts()` notification pass. This way, push
+	// listeners only accept traffic once their internal state is fully populated.
 	INIT_MODULE(ovt_provider, "OVT Provider", pvd::OvtProvider::Create(*server_config, media_router));
 	INIT_MODULE(rtspc_provider, "RTSPC Provider", pvd::RtspcProvider::Create(*server_config, media_router));
 
-	auto api_server = std::make_shared<api::Server>();
+	INIT_MODULE(webrtc_provider, "WebRTC Provider", pvd::WebRTCProvider::Create(*server_config, media_router));
+	INIT_MODULE(mpegts_provider, "MPEG-TS Provider", pvd::MpegTsProvider::Create(*server_config, media_router));
+	INIT_MODULE(srt_provider, "SRT Provider", pvd::SrtProvider::Create(*server_config, media_router));
+	INIT_MODULE(rtmp_provider, "RTMP Provider", pvd::RtmpProvider::Create(*server_config, media_router));
+	INIT_MODULE(scheduled_provider, "Scheduled Provider", pvd::ScheduledProvider::Create(*server_config, media_router));
+	INIT_MODULE(multiplex_provider, "Multiplex Provider", pvd::MultiplexProvider::Create(*server_config, media_router));
+	// PENDING : INIT_MODULE(rtsp_provider, "RTSP Provider", pvd::RtspProvider::Create(*server_config, media_router));
 
-	// Declared here to stay in scope for `RELEASE_MODULE` on shutdown;
-	// created later by `CREATE_MODULE` after `StartServer()`.
-	std::shared_ptr<pvd::Provider> webrtc_provider;
-	std::shared_ptr<pvd::Provider> mpegts_provider;
-	std::shared_ptr<pvd::Provider> srt_provider;
-	std::shared_ptr<pvd::Provider> rtmp_provider;
-	std::shared_ptr<pvd::Provider> scheduled_provider;
-	std::shared_ptr<pvd::Provider> multiplex_provider;
+	auto api_server = std::make_shared<api::Server>();
 
 	if (succeeded)
 	{
@@ -166,16 +167,22 @@ int main(int argc, char *argv[])
 
 		if (orchestrator->StartServer(server_config))
 		{
-			// Push providers, deferred to after `StartServer()`.
-			// `Orchestrator::RegisterModule()` back-fills them with the existing vhosts/apps.
-			// Scheduled/Multiplex have no external listener; they sit in the same group for symmetry.
-			CREATE_MODULE(webrtc_provider, "WebRTC Provider", pvd::WebRTCProvider::Create(*server_config, media_router));
-			CREATE_MODULE(mpegts_provider, "MPEG-TS Provider", pvd::MpegTsProvider::Create(*server_config, media_router));
-			CREATE_MODULE(srt_provider, "SRT Provider", pvd::SrtProvider::Create(*server_config, media_router));
-			CREATE_MODULE(rtmp_provider, "RTMP Provider", pvd::RtmpProvider::Create(*server_config, media_router));
-			CREATE_MODULE(scheduled_provider, "Scheduled Provider", pvd::ScheduledProvider::Create(*server_config, media_router));
-			CREATE_MODULE(multiplex_provider, "Multiplex Provider", pvd::MultiplexProvider::Create(*server_config, media_router));
-			// PENDING : CREATE_MODULE(rtsp_provider, "RTSP Provider", pvd::RtspProvider::Create(*server_config, media_router));
+			// Open push provider listeners. By this point `StartServer()`'s `CreateVirtualHosts()`
+			// has notified every registered module of existing vhosts/apps, so push providers
+			// have populated state before accepting any traffic. Pull providers and the
+			// scheduled/multiplex providers do not have listeners of their own and skip this.
+			bool bind_ok = true;
+
+			bind_ok &= (webrtc_provider == nullptr) || webrtc_provider->Bind();
+			bind_ok &= (mpegts_provider == nullptr) || mpegts_provider->Bind();
+			bind_ok &= (srt_provider == nullptr) || srt_provider->Bind();
+			bind_ok &= (rtmp_provider == nullptr) || rtmp_provider->Bind();
+
+			if (bind_ok == false)
+			{
+				logte("Failed to bind one or more push provider listeners");
+				succeeded = false;
+			}
 
 			if (succeeded)
 			{

--- a/src/projects/main/main.cpp
+++ b/src/projects/main/main.cpp
@@ -143,34 +143,54 @@ int main(int argc, char *argv[])
 	// Initialize Transcoder
 	INIT_MODULE(transcoder, "Transcoder", Transcoder::Create(media_router));
 
-	// Initialize Providers
-	INIT_MODULE(webrtc_provider, "WebRTC Provider", pvd::WebRTCProvider::Create(*server_config, media_router));
-	INIT_MODULE(mpegts_provider, "MPEG-TS Provider", pvd::MpegTsProvider::Create(*server_config, media_router));
-	INIT_MODULE(srt_provider, "SRT Provider", pvd::SrtProvider::Create(*server_config, media_router));
-	INIT_MODULE(rtmp_provider, "RTMP Provider", pvd::RtmpProvider::Create(*server_config, media_router));
+	// Pull providers must be registered before `StartServer()`
+	// so other modules that resolve URL schemes via `Orchestrator::GetProviderForScheme()`
+	// find them when applications are created.
 	INIT_MODULE(ovt_provider, "OVT Provider", pvd::OvtProvider::Create(*server_config, media_router));
 	INIT_MODULE(rtspc_provider, "RTSPC Provider", pvd::RtspcProvider::Create(*server_config, media_router));
-	INIT_MODULE(scheduled_provider, "Scheduled Provider", pvd::ScheduledProvider::Create(*server_config, media_router));
-	INIT_MODULE(multiplex_provider, "Multiplex Provider", pvd::MultiplexProvider::Create(*server_config, media_router));
-	// PENDING : INIT_MODULE(rtsp_provider, "RTSP Provider", pvd::RtspProvider::Create(*server_config, media_router));
 
 	auto api_server = std::make_shared<api::Server>();
 
+	// Declared here to stay in scope for `RELEASE_MODULE` on shutdown;
+	// created later by `CREATE_MODULE` after `StartServer()`.
+	std::shared_ptr<pvd::Provider> webrtc_provider;
+	std::shared_ptr<pvd::Provider> mpegts_provider;
+	std::shared_ptr<pvd::Provider> srt_provider;
+	std::shared_ptr<pvd::Provider> rtmp_provider;
+	std::shared_ptr<pvd::Provider> scheduled_provider;
+	std::shared_ptr<pvd::Provider> multiplex_provider;
+
 	if (succeeded)
 	{
-		logti("All modules are initialized successfully");
+		logti("All pre-server modules are initialized successfully");
 
 		if (orchestrator->StartServer(server_config))
 		{
-			if (api_server->Start(server_config))
-			{
-				if (parse_option.start_service)
-				{
-					ov::Daemon::SetEvent();
-				}
+			// Push providers, deferred to after `StartServer()`.
+			// `Orchestrator::RegisterModule()` back-fills them with the existing vhosts/apps.
+			// Scheduled/Multiplex have no external listener; they sit in the same group for symmetry.
+			CREATE_MODULE(webrtc_provider, "WebRTC Provider", pvd::WebRTCProvider::Create(*server_config, media_router));
+			CREATE_MODULE(mpegts_provider, "MPEG-TS Provider", pvd::MpegTsProvider::Create(*server_config, media_router));
+			CREATE_MODULE(srt_provider, "SRT Provider", pvd::SrtProvider::Create(*server_config, media_router));
+			CREATE_MODULE(rtmp_provider, "RTMP Provider", pvd::RtmpProvider::Create(*server_config, media_router));
+			CREATE_MODULE(scheduled_provider, "Scheduled Provider", pvd::ScheduledProvider::Create(*server_config, media_router));
+			CREATE_MODULE(multiplex_provider, "Multiplex Provider", pvd::MultiplexProvider::Create(*server_config, media_router));
+			// PENDING : CREATE_MODULE(rtsp_provider, "RTSP Provider", pvd::RtspProvider::Create(*server_config, media_router));
 
-				while (ov::sig::WaitAndStop(1000) == false)
+			if (succeeded)
+			{
+				logti("All modules are initialized successfully");
+
+				if (api_server->Start(server_config))
 				{
+					if (parse_option.start_service)
+					{
+						ov::Daemon::SetEvent();
+					}
+
+					while (ov::sig::WaitAndStop(1000) == false)
+					{
+					}
 				}
 			}
 		}

--- a/src/projects/main/main.cpp
+++ b/src/projects/main/main.cpp
@@ -171,12 +171,10 @@ int main(int argc, char *argv[])
 			// has notified every registered module of existing vhosts/apps, so push providers
 			// have populated state before accepting any traffic. Pull providers and the
 			// scheduled/multiplex providers do not have listeners of their own and skip this.
-			bool bind_ok = true;
-
-			bind_ok &= (webrtc_provider == nullptr) || webrtc_provider->Bind();
-			bind_ok &= (mpegts_provider == nullptr) || mpegts_provider->Bind();
-			bind_ok &= (srt_provider == nullptr) || srt_provider->Bind();
-			bind_ok &= (rtmp_provider == nullptr) || rtmp_provider->Bind();
+			bool bind_ok = ((webrtc_provider == nullptr) || webrtc_provider->Bind()) &&
+						   ((mpegts_provider == nullptr) || mpegts_provider->Bind()) &&
+						   ((srt_provider == nullptr) || srt_provider->Bind()) &&
+						   ((rtmp_provider == nullptr) || rtmp_provider->Bind());
 
 			if (bind_ok == false)
 			{

--- a/src/projects/modules/ice/ice_port_manager.cpp
+++ b/src/projects/modules/ice/ice_port_manager.cpp
@@ -75,6 +75,7 @@ bool IcePortManager::CreateIceCandidates(
 
 		logte("Could not create ICE candidates for %s. Check your ICE configuration", server_name);
 		OV_ASSERT2(false);
+		return false;
 	}
 	else
 	{

--- a/src/projects/modules/ice/ice_port_manager.cpp
+++ b/src/projects/modules/ice/ice_port_manager.cpp
@@ -114,6 +114,12 @@ bool IcePortManager::BindTurnServers(
 	const std::shared_ptr<IcePortObserver> &observer,
 	const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config)
 {
+	if (_ice_port == nullptr)
+	{
+		logte("IcePort should be created before binding TURN servers");
+		return false;
+	}
+
 	auto &ice_candidates_config = webrtc_bind_config.GetIceCandidates();
 
 	return CreateIceCandidates(server_name, observer, server_config, ice_candidates_config) &&

--- a/src/projects/modules/ice/ice_port_manager.cpp
+++ b/src/projects/modules/ice/ice_port_manager.cpp
@@ -110,14 +110,13 @@ bool IcePortManager::CreateTurnServer(std::shared_ptr<IcePortObserver> observer,
 
 bool IcePortManager::BindTurnServers(
 	const char *server_name,
-	const std::shared_ptr<IcePort> &ice_port,
 	const std::shared_ptr<IcePortObserver> &observer,
 	const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config)
 {
 	auto &ice_candidates_config = webrtc_bind_config.GetIceCandidates();
 
 	return CreateIceCandidates(server_name, observer, server_config, ice_candidates_config) &&
-		   CreateTurnServersInternal(server_name, ice_port, observer, server_config, webrtc_bind_config);
+		   CreateTurnServersInternal(server_name, _ice_port, observer, server_config, webrtc_bind_config);
 }
 
 bool IcePortManager::CreateTurnServersInternal(

--- a/src/projects/modules/ice/ice_port_manager.cpp
+++ b/src/projects/modules/ice/ice_port_manager.cpp
@@ -120,6 +120,12 @@ bool IcePortManager::BindTurnServers(
 		return false;
 	}
 
+	if (IsRegisteredObserver(observer) == false)
+	{
+		logte("IcePort observer should be registered before binding TURN servers");
+		return false;
+	}
+
 	auto &ice_candidates_config = webrtc_bind_config.GetIceCandidates();
 
 	return CreateIceCandidates(server_name, observer, server_config, ice_candidates_config) &&

--- a/src/projects/modules/ice/ice_port_manager.cpp
+++ b/src/projects/modules/ice/ice_port_manager.cpp
@@ -108,6 +108,18 @@ bool IcePortManager::CreateTurnServer(std::shared_ptr<IcePortObserver> observer,
 	return true;
 }
 
+bool IcePortManager::BindTurnServers(
+	const char *server_name,
+	const std::shared_ptr<IcePort> &ice_port,
+	const std::shared_ptr<IcePortObserver> &observer,
+	const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config)
+{
+	auto &ice_candidates_config = webrtc_bind_config.GetIceCandidates();
+
+	return CreateIceCandidates(server_name, observer, server_config, ice_candidates_config) &&
+		   CreateTurnServersInternal(server_name, ice_port, observer, server_config, webrtc_bind_config);
+}
+
 bool IcePortManager::CreateTurnServersInternal(
 	const char *server_name,
 	const std::shared_ptr<IcePort> &ice_port,

--- a/src/projects/modules/ice/ice_port_manager.h
+++ b/src/projects/modules/ice/ice_port_manager.h
@@ -33,6 +33,15 @@ public:
 		std::shared_ptr<IcePortObserver> observer,
 		const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config);
 
+	// Binds TURN listeners for an `ice_port` that was already created by `CreatePort()`. Used by
+	// callers that need to split ICE port construction from listener binding (e.g. providers that
+	// must hand the `ice_port` to module-create callbacks before opening sockets).
+	bool BindTurnServers(
+		const char *server_name,
+		const std::shared_ptr<IcePort> &ice_port,
+		const std::shared_ptr<IcePortObserver> &observer,
+		const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config);
+
 	// TODO(Getroot): In the future, each IceCandidate and TurnServer can be released flexibly.
 	// In the future, each IceCandidate and TurnServer can be released flexibly.
 	// Currently, WebRTC publisher and provider use IcePortManager until the server is shut down,

--- a/src/projects/modules/ice/ice_port_manager.h
+++ b/src/projects/modules/ice/ice_port_manager.h
@@ -33,12 +33,12 @@ public:
 		std::shared_ptr<IcePortObserver> observer,
 		const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config);
 
-	// Binds TURN listeners for an `ice_port` that was already created by `CreatePort()`. Used by
-	// callers that need to split ICE port construction from listener binding (e.g. providers that
-	// must hand the `ice_port` to module-create callbacks before opening sockets).
+	// Binds TURN listeners for the singleton `_ice_port` that was already created by
+	// `CreatePort()`. Used by callers that need to split ICE port construction from listener
+	// binding (e.g. providers that must hand the `ice_port` to module-create callbacks before
+	// opening sockets).
 	bool BindTurnServers(
 		const char *server_name,
-		const std::shared_ptr<IcePort> &ice_port,
 		const std::shared_ptr<IcePortObserver> &observer,
 		const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config);
 

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -1177,26 +1177,27 @@ namespace ocst
 
 	Result Orchestrator::CreateVirtualHost(const info::Host &vhost_info)
 	{
-		// Serialize existence check, vhost insertion, and module notifications against late
-		// `RegisterModule()` and `DeleteVirtualHost()`.
-		std::scoped_lock lock(_late_module_registration_mutex);
-
-		if(GetVirtualHost(vhost_info.GetName()) != nullptr)
 		{
-			// Duplicated VirtualHostName
-			return Result::Exists;
-		}
+			// Serialize existence check, vhost insertion, and module notifications against late
+			// `RegisterModule()` and `DeleteVirtualHost()`. Scoped so monitoring runs outside the
+			// lock - it does not participate in the serialization invariant.
+			std::scoped_lock lock(_late_module_registration_mutex);
 
-		auto vhost = std::make_shared<VirtualHost>(vhost_info);
+			if (GetVirtualHost(vhost_info.GetName()) != nullptr)
+			{
+				// Duplicated VirtualHostName
+				return Result::Exists;
+			}
 
-		{
-			std::lock_guard<std::shared_mutex> guard(_virtual_host_mutex);
-			_virtual_host_map[vhost_info.GetName()] = vhost;
-			_virtual_host_list.push_back(vhost);
-		}
+			auto vhost = std::make_shared<VirtualHost>(vhost_info);
 
-		// Notification
-		{
+			{
+				std::lock_guard<std::shared_mutex> guard(_virtual_host_mutex);
+				_virtual_host_map[vhost_info.GetName()] = vhost;
+				_virtual_host_list.push_back(vhost);
+			}
+
+			// Notification
 			auto module_list = GetModuleList();
 			for (auto &module : module_list)
 			{
@@ -1223,57 +1224,58 @@ namespace ocst
 
 	Result Orchestrator::DeleteVirtualHost(const info::Host &vhost_info)
 	{
-		// Serialize vhost removal and module notifications against late `RegisterModule()` and
-		// `CreateVirtualHost()`.
-		std::scoped_lock lock(_late_module_registration_mutex);
-
 		bool found = false;
 		{
-			std::lock_guard<std::shared_mutex> guard(_virtual_host_mutex);
-			auto it = _virtual_host_list.begin();
-			while(it != _virtual_host_list.end())
+			// Serialize vhost removal and module notifications against late `RegisterModule()` and
+			// `CreateVirtualHost()`. Scoped so monitoring runs outside the lock - it does not
+			// participate in the serialization invariant.
+			std::scoped_lock lock(_late_module_registration_mutex);
+
 			{
-				auto vhost_item = *it;
-				if(vhost_item->GetName() == vhost_info.GetName())
+				std::lock_guard<std::shared_mutex> guard(_virtual_host_mutex);
+				auto it = _virtual_host_list.begin();
+				while (it != _virtual_host_list.end())
 				{
-					_virtual_host_list.erase(it);
-					_virtual_host_map.erase(vhost_item->GetName());
-					found = true;
-					break;
+					auto vhost_item = *it;
+					if (vhost_item->GetName() == vhost_info.GetName())
+					{
+						_virtual_host_list.erase(it);
+						_virtual_host_map.erase(vhost_item->GetName());
+						found = true;
+						break;
+					}
+
+					it++;
 				}
-
-				it++;
 			}
-		}
 
-		if (found)
-		{
+			if (found == false)
+			{
+				return Result::NotExists;
+			}
+
 			// Notification
+			auto module_list = GetModuleList();
+			for (auto &module : module_list)
 			{
-				auto module_list = GetModuleList();
-				for (auto &module : module_list)
+				auto module_interface = module.GetModuleInterface();
+
+				logtt("Notifying %p (%s) for the delete event (%s)", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), vhost_info.GetName().CStr());
+
+				if (module_interface->OnDeleteHost(vhost_info))
 				{
-					auto module_interface = module.GetModuleInterface();
-
-					logtt("Notifying %p (%s) for the create event (%s)", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), vhost_info.GetName().CStr());
-
-					if (module_interface->OnDeleteHost(vhost_info))
-					{
-						logtt("The module %p (%s) returns true", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr());
-					}
-					else
-					{
-						logte("The module %p (%s) returns error while deleting the vhost [%s]",
-							module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), vhost_info.GetName().CStr());
-					}
+					logtt("The module %p (%s) returns true", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr());
+				}
+				else
+				{
+					logte("The module %p (%s) returns error while deleting the vhost [%s]",
+						module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), vhost_info.GetName().CStr());
 				}
 			}
-			
-			mon::Monitoring::GetInstance()->OnHostDeleted(vhost_info);
-			return Result::Succeeded;
 		}
 
-		return Result::NotExists;
+		mon::Monitoring::GetInstance()->OnHostDeleted(vhost_info);
+		return Result::Succeeded;
 	}
 
 	CommonErrorCode Orchestrator::ReloadAllCertificates()

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -412,7 +412,7 @@ namespace ocst
 
 		// Serialize against `CreateApplication()` / `DeleteApplication()`
 		// so the new module sees exactly one create/delete pair per application.
-		std::scoped_lock reg_lock(_late_module_registration_mutex);
+		std::scoped_lock lock(_late_module_registration_mutex);
 
 		// Before `StartServer()`, the normal `CreateApplication()` path will notify this module
 		// during server start, so just insert.
@@ -1163,6 +1163,10 @@ namespace ocst
 
 	Result Orchestrator::CreateVirtualHost(const info::Host &vhost_info)
 	{
+		// Serialize existence check, vhost insertion, and module notifications against late
+		// `RegisterModule()` and `DeleteVirtualHost()`.
+		std::scoped_lock reg_lock(_late_module_registration_mutex);
+
 		if(GetVirtualHost(vhost_info.GetName()) != nullptr)
 		{
 			// Duplicated VirtualHostName
@@ -1177,7 +1181,7 @@ namespace ocst
 			_virtual_host_list.push_back(vhost);
 		}
 
-		// Notification 
+		// Notification
 		{
 			auto module_list = GetModuleList();
 			for (auto &module : module_list)
@@ -1205,6 +1209,10 @@ namespace ocst
 
 	Result Orchestrator::DeleteVirtualHost(const info::Host &vhost_info)
 	{
+		// Serialize vhost removal and module notifications against late `RegisterModule()` and
+		// `CreateVirtualHost()`.
+		std::scoped_lock reg_lock(_late_module_registration_mutex);
+
 		bool found = false;
 		{
 			std::lock_guard<std::shared_mutex> guard(_virtual_host_mutex);
@@ -1455,24 +1463,20 @@ namespace ocst
 			return Result::Failed;
 		}
 
-		if (vhost->GetApplication(app_info.GetVHostAppName()) != nullptr)
-		{
-			logtw("Application %s already exists", app_info.GetVHostAppName().CStr());
-			return Result::Exists;
-		}
-
-		logti("Trying to create an application: [%s]", app_info.GetVHostAppName().CStr());
-
 		bool succeeded = true;
 		{
-			// Hold `_late_module_registration_mutex` from the moment the application becomes
-			// visible in the vhost until every module has been notified, so a concurrent late
-			// `RegisterModule()` either runs entirely before this block (its back-fill does not
-			// see this app, but its module is already in `_module_list` so the loop below
-			// notifies it), or entirely after this block (its back-fill snapshot includes this
-			// app; the loop below could not have notified the module because it was not yet
-			// in `_module_list`).
-			std::scoped_lock reg_lock(_late_module_registration_mutex);
+			// Serialize existence check, vhost mutation, and module notifications against
+			// `DeleteApplication()` and late `RegisterModule()`. Scoped so the rollback path at the
+			// bottom can re-enter `DeleteApplication()` without recursive locking.
+			std::scoped_lock lock(_late_module_registration_mutex);
+
+			if (vhost->GetApplication(app_info.GetVHostAppName()) != nullptr)
+			{
+				logtw("Application %s already exists", app_info.GetVHostAppName().CStr());
+				return Result::Exists;
+			}
+
+			logti("Trying to create an application: [%s]", app_info.GetVHostAppName().CStr());
 
 			if (vhost->CreateApplication(this, app_info) == false)
 			{

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -1471,15 +1471,15 @@ namespace ocst
 	ocst::Result Orchestrator::CreateApplication(const ov::String &vhost_name, const info::Application &app_info)
 	{
 		bool succeeded = true;
-		std::shared_ptr<VirtualHost> vhost;
 		{
-			// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
-			// `DeleteVirtualHost()` cannot remove the vhost between the lookup and the app create +
-			// notifications below. Scoped so the rollback path at the bottom can re-enter
-			// `DeleteApplication()` without recursive locking.
+			// Hold `_late_module_registration_mutex` across the entire create flow - lookup,
+			// existence check, app creation, module notifications, AND MediaRouter observer
+			// registration - so a concurrent `DeleteApplication()` cannot interleave between
+			// app creation and observer registration. Scoped so the rollback path at the
+			// bottom can re-enter `DeleteApplication()` without recursive locking.
 			std::scoped_lock lock(_late_module_registration_mutex);
 
-			vhost = GetVirtualHost(vhost_name);
+			auto vhost = GetVirtualHost(vhost_name);
 			if (vhost == nullptr)
 			{
 				logtw("Host not found for vhost: %s", vhost_name.CStr());
@@ -1522,26 +1522,26 @@ namespace ocst
 					break;
 				}
 			}
-		}
 
-		// TODO: Need to be refactored
-		// Since Orchestrator registers itself as MediaRouter observer last, OnStreamCreated and OnStreamDeleted events are received last.
-		// Orchestrator::OnStreamDeleted and application deletion can proceed simultaneously if the orchestrator does not receive the event at the 
-		// very end, so if stream deletion is still in progress in another module, this may cause a conflict.
-		// Therefore, we need a guaranteed way Orchestrator to receive the event last, 
-		// not the way the orchestrator registers itself with the MediaRouter last and receives the event last. 
-		// (Now, it's working because MediaRouter registers an observer using push_back to the vector.)
-		if (_media_router != nullptr)
-		{
-			auto new_app = vhost->GetApplication(app_info.GetId());
-			if (new_app != nullptr)
+			// TODO: Need to be refactored
+			// Since Orchestrator registers itself as MediaRouter observer last, OnStreamCreated and OnStreamDeleted events are received last.
+			// Orchestrator::OnStreamDeleted and application deletion can proceed simultaneously if the orchestrator does not receive the event at the
+			// very end, so if stream deletion is still in progress in another module, this may cause a conflict.
+			// Therefore, we need a guaranteed way Orchestrator to receive the event last,
+			// not the way the orchestrator registers itself with the MediaRouter last and receives the event last.
+			// (Now, it's working because MediaRouter registers an observer using push_back to the vector.)
+			if (succeeded && (_media_router != nullptr))
 			{
-				_media_router->RegisterObserverApp(app_info, new_app->GetSharedPtrAs<MediaRouterApplicationObserver>());
-			}
-			else
-			{
-				logte("Could not find the application [%s] after creating it", app_info.GetVHostAppName().CStr());
-				succeeded = false;
+				auto new_app = vhost->GetApplication(app_info.GetId());
+				if (new_app != nullptr)
+				{
+					_media_router->RegisterObserverApp(app_info, new_app->GetSharedPtrAs<MediaRouterApplicationObserver>());
+				}
+				else
+				{
+					logte("Could not find the application [%s] after creating it", app_info.GetVHostAppName().CStr());
+					succeeded = false;
+				}
 			}
 		}
 

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -296,15 +296,16 @@ namespace ocst
 
 	ocst::Result Orchestrator::DeleteApplication(const ov::String &vhost_name, info::application_id_t app_id)
 	{
+		// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
+		// `DeleteVirtualHost()` cannot remove the vhost and emit `OnDeleteHost()` between the
+		// lookup and the app-delete notifications below.
+		std::scoped_lock lock(_late_module_registration_mutex);
+
 		auto vhost = GetVirtualHost(vhost_name);
 		if (vhost == nullptr)
 		{
 			return Result::NotExists;
 		}
-
-		// Serialize existence check, vhost mutation, and module notifications against
-		// `CreateApplication()` and late `RegisterModule()`.
-		std::scoped_lock lock(_late_module_registration_mutex);
 
 		auto app = vhost->GetApplication(app_id);
 		if (app == nullptr)
@@ -375,6 +376,17 @@ namespace ocst
 		}
 
 		auto type = module_interface->GetModuleType();
+
+		// `_media_router` is read unsynchronized from many call sites (e.g. `CreateApplication()`,
+		// `MirrorStream()`). MediaRouter must be registered pre-`StartServer()` so the pointer is
+		// effectively immutable by the time any reader runs. Reject late MediaRouter registration
+		// rather than introducing a torn-write race.
+		if ((type == ModuleType::MediaRouter) && _server_started)
+		{
+			logte("MediaRouter cannot be registered after `StartServer()`");
+			OV_ASSERT2(false);
+			return false;
+		}
 
 		auto try_insert_module = [&]() -> bool {
 			std::scoped_lock lock(_module_list_mutex);
@@ -1167,7 +1179,7 @@ namespace ocst
 	{
 		// Serialize existence check, vhost insertion, and module notifications against late
 		// `RegisterModule()` and `DeleteVirtualHost()`.
-		std::scoped_lock reg_lock(_late_module_registration_mutex);
+		std::scoped_lock lock(_late_module_registration_mutex);
 
 		if(GetVirtualHost(vhost_info.GetName()) != nullptr)
 		{
@@ -1213,7 +1225,7 @@ namespace ocst
 	{
 		// Serialize vhost removal and module notifications against late `RegisterModule()` and
 		// `CreateVirtualHost()`.
-		std::scoped_lock reg_lock(_late_module_registration_mutex);
+		std::scoped_lock lock(_late_module_registration_mutex);
 
 		bool found = false;
 		{
@@ -1458,19 +1470,21 @@ namespace ocst
 
 	ocst::Result Orchestrator::CreateApplication(const ov::String &vhost_name, const info::Application &app_info)
 	{
-		auto vhost = GetVirtualHost(vhost_name);
-		if (vhost == nullptr)
-		{
-			logtw("Host not found for vhost: %s", vhost_name.CStr());
-			return Result::Failed;
-		}
-
 		bool succeeded = true;
+		std::shared_ptr<VirtualHost> vhost;
 		{
-			// Serialize existence check, vhost mutation, and module notifications against
-			// `DeleteApplication()` and late `RegisterModule()`. Scoped so the rollback path at the
-			// bottom can re-enter `DeleteApplication()` without recursive locking.
+			// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
+			// `DeleteVirtualHost()` cannot remove the vhost between the lookup and the app create +
+			// notifications below. Scoped so the rollback path at the bottom can re-enter
+			// `DeleteApplication()` without recursive locking.
 			std::scoped_lock lock(_late_module_registration_mutex);
+
+			vhost = GetVirtualHost(vhost_name);
+			if (vhost == nullptr)
+			{
+				logtw("Host not found for vhost: %s", vhost_name.CStr());
+				return Result::Failed;
+			}
 
 			if (vhost->GetApplication(app_info.GetVHostAppName()) != nullptr)
 			{

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -300,6 +300,10 @@ namespace ocst
 			return Result::NotExists;
 		}
 
+		// Serialize existence check, vhost mutation, and module notifications against
+		// `CreateApplication()` and late `RegisterModule()`.
+		std::scoped_lock lock(_late_module_registration_mutex);
+
 		auto app = vhost->GetApplication(app_id);
 		if (app == nullptr)
 		{
@@ -313,45 +317,36 @@ namespace ocst
 
 		mon::Monitoring::GetInstance()->OnApplicationDeleted(app_info);
 
+		if (vhost->DeleteApplication(app_id) == false)
 		{
-			// Hold `_late_module_registration_mutex` for vhost removal + module-notification, symmetric
-			// to `CreateApplication()`. Without this, a concurrent late `RegisterModule()` could
-			// back-fill the new module with this application (whose snapshot still includes it) after
-			// the delete-side notification loop has already iterated and skipped the not-yet-registered
-			// module, leaving a stale create-notification with no matching delete-notification.
-			std::scoped_lock reg_lock(_late_module_registration_mutex);
+			logte("Could not delete an application: [%s]", app_info.GetVHostAppName().CStr());
+			return Result::Failed;
+		}
 
-			if (vhost->DeleteApplication(app_id) == false)
+		if (_media_router != nullptr)
+		{
+			_media_router->UnregisterObserverApp(app_info, app->GetSharedPtrAs<MediaRouterApplicationObserver>());
+		}
+
+		logtt("Notifying modules for the delete event...");
+		auto module_list = GetModuleList();
+		// Notify modules of deletion events
+		for (auto module = module_list.rbegin(); module != module_list.rend(); ++module)
+		{
+			auto module_interface = module->GetModuleInterface();
+
+			logtt("Notifying %p (%s) for the delete event (%s)", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), app_info.GetVHostAppName().CStr());
+
+			if (module_interface->OnDeleteApplication(app_info) == false)
 			{
-				logte("Could not delete an application: [%s]", app_info.GetVHostAppName().CStr());
-				return Result::Failed;
+				logte("The module %p (%s) returns error while deleting the application [%s]",
+					  module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), app_info.GetVHostAppName().CStr());
+
+				// Ignore this error - some providers may not have generated the app
 			}
-
-			if (_media_router != nullptr)
+			else
 			{
-				_media_router->UnregisterObserverApp(app_info, app->GetSharedPtrAs<MediaRouterApplicationObserver>());
-			}
-
-			logtt("Notifying modules for the delete event...");
-			auto module_list = GetModuleList();
-			// Notify modules of deletion events
-			for (auto module = module_list.rbegin(); module != module_list.rend(); ++module)
-			{
-				auto module_interface = module->GetModuleInterface();
-
-				logtt("Notifying %p (%s) for the delete event (%s)", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), app_info.GetVHostAppName().CStr());
-
-				if (module_interface->OnDeleteApplication(app_info) == false)
-				{
-					logte("The module %p (%s) returns error while deleting the application [%s]",
-						module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr(), app_info.GetVHostAppName().CStr());
-
-					// Ignore this error - some providers may not have generated the app
-				}
-				else
-				{
-					logtt("The module %p (%s) returns true", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr());
-				}
+				logtt("The module %p (%s) returns true", module_interface.get(), GetModuleTypeName(module_interface->GetModuleType()).CStr());
 			}
 		}
 
@@ -379,9 +374,6 @@ namespace ocst
 
 		auto type = module_interface->GetModuleType();
 
-		// Atomic check + insert under exclusive `_module_list_mutex`.
-		// Doing both in one critical section closes the race where two concurrent
-		// `RegisterModule()` calls could both pass a shared-lock duplicate check and both insert.
 		auto try_insert_module = [&]() -> bool {
 			std::scoped_lock lock(_module_list_mutex);
 
@@ -418,18 +410,12 @@ namespace ocst
 			}
 		};
 
-		// Hold `_late_module_registration_mutex` for the full registration regardless of timing:
-		// - Pre-`StartServer()`: there is no concurrent `CreateApplication()` yet, but acquiring the
-		//   same mutex keeps `RegisterModule()` calls serialized so a stray multi-threaded boot path
-		//   cannot race two concurrent registrations.
-		// - Post-`StartServer()`: serialized against `CreateApplication()` / `DeleteApplication()`
-		//   so the new module gets exactly one `OnCreateApplication()` per existing application
-		//   (either via the back-fill below or via the normal create path after this returns) and
-		//   `OnDeleteApplication()` only for apps it actually saw create for.
+		// Serialize against `CreateApplication()` / `DeleteApplication()`
+		// so the new module sees exactly one create/delete pair per application.
 		std::scoped_lock reg_lock(_late_module_registration_mutex);
 
-		// Modules registered before `StartServer()` are notified by the normal `CreateApplication()`
-		// path during the upcoming server start, so just insert and return.
+		// Before `StartServer()`, the normal `CreateApplication()` path will notify this module
+		// during server start, so just insert.
 		if (_server_started.load() == false)
 		{
 			if (try_insert_module() == false)
@@ -444,19 +430,32 @@ namespace ocst
 			return true;
 		}
 
-		// Late registration: replay `OnCreateApplication()` for existing applications.
-		//
-		// Order is back-fill first, then insert. The module is NOT yet in `_module_list` during
-		// back-fill, so this loop is the ONLY notification path for these applications - no risk of
-		// the normal create path firing for them in parallel (it would have to acquire `reg_lock`,
-		// which we hold). Inserting only after a fully successful back-fill keeps registration
-		// atomic: on failure we roll back `OnCreateApplication()` calls already made and return
-		// without inserting, so the caller sees a clean "not registered" outcome.
+		// Late registration: back-fill before insert so a failed registration leaves no module in the list.
+		// `OnCreateHost()` precedes `OnCreateApplication()` because per-vhost setup
+		// (e.g. certificates) must run before app-level callbacks.
+		std::vector<info::Host> notified_hosts;
 		std::vector<info::Application> notified_apps;
 		bool back_fill_ok = true;
 
 		for (const auto &vhost : GetVirtualHostList())
 		{
+			const auto &host_info = vhost->GetHostInfo();
+
+			logtt("Back-filling %s module (%p) with the existing vhost (%s)",
+				  GetModuleTypeName(type).CStr(), module_interface.get(), host_info.GetName().CStr());
+
+			if (module_interface->OnCreateHost(host_info) == false)
+			{
+				logte("The %s module (%p) returned an error while back-filling the vhost [%s]",
+					  GetModuleTypeName(type).CStr(), module_interface.get(), host_info.GetName().CStr());
+
+				back_fill_ok = false;
+
+				break;
+			}
+
+			notified_hosts.push_back(host_info);
+
 			for (const auto &app : vhost->GetApplicationList())
 			{
 				const auto &app_info = app->GetAppInfo();
@@ -481,8 +480,6 @@ namespace ocst
 			}
 		}
 
-		// Best-effort rollback helper. Called on any failure between this point and successful insert
-		// so the module does not retain per-application state for a registration that never landed.
 		auto rollback_notifications = [&]() {
 			for (auto it = notified_apps.rbegin(); it != notified_apps.rend(); ++it)
 			{
@@ -490,6 +487,15 @@ namespace ocst
 				{
 					logte("%s module (%p) returned an error during rollback for application [%s]; continuing best-effort",
 						  GetModuleTypeName(type).CStr(), module_interface.get(), it->GetVHostAppName().CStr());
+				}
+			}
+
+			for (auto it = notified_hosts.rbegin(); it != notified_hosts.rend(); ++it)
+			{
+				if (module_interface->OnDeleteHost(*it) == false)
+				{
+					logte("%s module (%p) returned an error during rollback for vhost [%s]; continuing best-effort",
+						  GetModuleTypeName(type).CStr(), module_interface.get(), it->GetName().CStr());
 				}
 			}
 		};
@@ -500,9 +506,6 @@ namespace ocst
 			return false;
 		}
 
-		// Commit: insert under exclusive `_module_list_mutex`. `reg_lock` serializes against other
-		// `RegisterModule()` calls; a duplicate here would mean the module was registered through
-		// some other path between our checks, which is defensive only and rolls back the back-fill.
 		if (try_insert_module() == false)
 		{
 			rollback_notifications();

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -379,9 +379,12 @@ namespace ocst
 
 		auto type = module_interface->GetModuleType();
 
-		{
-			std::shared_lock<std::shared_mutex> lock(_module_list_mutex);
-			// Check if module exists
+		// Atomic check + insert under exclusive `_module_list_mutex`.
+		// Doing both in one critical section closes the race where two concurrent
+		// `RegisterModule()` calls could both pass a shared-lock duplicate check and both insert.
+		auto try_insert_module = [&]() -> bool {
+			std::scoped_lock lock(_module_list_mutex);
+
 			for (auto &module : _module_list)
 			{
 				if (module.GetModuleInterface() == module_interface)
@@ -399,14 +402,12 @@ namespace ocst
 					return false;
 				}
 			}
-		}
 
-		auto insert_module = [&]() {
-			{
-				std::scoped_lock lock(_module_list_mutex);
-				_module_list.emplace_back(type, module_interface);
-			}
+			_module_list.emplace_back(type, module_interface);
+			return true;
+		};
 
+		auto apply_media_router_side_effect = [&]() {
 			if (module_interface->GetModuleType() == ModuleType::MediaRouter)
 			{
 				auto media_router = std::dynamic_pointer_cast<MediaRouter>(module_interface);
@@ -415,32 +416,45 @@ namespace ocst
 
 				_media_router = media_router;
 			}
-
-			logtt("%s module (%p) is registered", GetModuleTypeName(type).CStr(), module_interface.get());
 		};
+
+		// Hold `_late_module_registration_mutex` for the full registration regardless of timing:
+		// - Pre-`StartServer()`: there is no concurrent `CreateApplication()` yet, but acquiring the
+		//   same mutex keeps `RegisterModule()` calls serialized so a stray multi-threaded boot path
+		//   cannot race two concurrent registrations.
+		// - Post-`StartServer()`: serialized against `CreateApplication()` / `DeleteApplication()`
+		//   so the new module gets exactly one `OnCreateApplication()` per existing application
+		//   (either via the back-fill below or via the normal create path after this returns) and
+		//   `OnDeleteApplication()` only for apps it actually saw create for.
+		std::scoped_lock reg_lock(_late_module_registration_mutex);
 
 		// Modules registered before `StartServer()` are notified by the normal `CreateApplication()`
 		// path during the upcoming server start, so just insert and return.
 		if (_server_started.load() == false)
 		{
-			insert_module();
+			if (try_insert_module() == false)
+			{
+				return false;
+			}
+
+			apply_media_router_side_effect();
+
+			logtt("%s module (%p) is registered", GetModuleTypeName(type).CStr(), module_interface.get());
+
 			return true;
 		}
 
-		// Late registration: the module missed `OnCreateApplication()` notifications fired during
-		// application creation, so replay them here.
-		// Serialize against `CreateApplication()`'s vhost mutation + module-notification block via
-		// `_late_module_registration_mutex` so the new module is either inserted before the new
-		// app's notification fires (normal path covers it) or inserted+back-filled before the new
-		// app exists in any vhost (no double/missed delivery).
-		std::scoped_lock reg_lock(_late_module_registration_mutex);
-
-		insert_module();
-
-		// Back-fill: a failure here is a startup-level error, same as the normal `CreateApplication()`
-		// notification path which aborts on the first failing module (see `CreateApplication()`).
-		// Propagate the failure to the caller so `CREATE_MODULE` can flip `succeeded` to false.
+		// Late registration: replay `OnCreateApplication()` for existing applications.
+		//
+		// Order is back-fill first, then insert. The module is NOT yet in `_module_list` during
+		// back-fill, so this loop is the ONLY notification path for these applications - no risk of
+		// the normal create path firing for them in parallel (it would have to acquire `reg_lock`,
+		// which we hold). Inserting only after a fully successful back-fill keeps registration
+		// atomic: on failure we roll back `OnCreateApplication()` calls already made and return
+		// without inserting, so the caller sees a clean "not registered" outcome.
+		std::vector<info::Application> notified_apps;
 		bool back_fill_ok = true;
+
 		for (const auto &vhost : GetVirtualHostList())
 		{
 			for (const auto &app : vhost->GetApplicationList())
@@ -455,11 +469,51 @@ namespace ocst
 					logte("The %s module (%p) returned an error while back-filling the application [%s]",
 						  GetModuleTypeName(type).CStr(), module_interface.get(), app_info.GetVHostAppName().CStr());
 					back_fill_ok = false;
+					break;
 				}
+
+				notified_apps.push_back(app_info);
+			}
+
+			if (back_fill_ok == false)
+			{
+				break;
 			}
 		}
 
-		return back_fill_ok;
+		// Best-effort rollback helper. Called on any failure between this point and successful insert
+		// so the module does not retain per-application state for a registration that never landed.
+		auto rollback_notifications = [&]() {
+			for (auto it = notified_apps.rbegin(); it != notified_apps.rend(); ++it)
+			{
+				if (module_interface->OnDeleteApplication(*it) == false)
+				{
+					logte("%s module (%p) returned an error during rollback for application [%s]; continuing best-effort",
+						  GetModuleTypeName(type).CStr(), module_interface.get(), it->GetVHostAppName().CStr());
+				}
+			}
+		};
+
+		if (back_fill_ok == false)
+		{
+			rollback_notifications();
+			return false;
+		}
+
+		// Commit: insert under exclusive `_module_list_mutex`. `reg_lock` serializes against other
+		// `RegisterModule()` calls; a duplicate here would mean the module was registered through
+		// some other path between our checks, which is defensive only and rolls back the back-fill.
+		if (try_insert_module() == false)
+		{
+			rollback_notifications();
+			return false;
+		}
+
+		apply_media_router_side_effect();
+
+		logtt("%s module (%p) is registered", GetModuleTypeName(type).CStr(), module_interface.get());
+
+		return true;
 	}
 
 	bool Orchestrator::UnregisterModule(const std::shared_ptr<ModuleInterface> &module_interface)

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -69,6 +69,11 @@ namespace ocst
 
 		mon::Monitoring::GetInstance()->OnServerStarted(server_config);
 
+		// Flip before `CreateVirtualHosts()` so a concurrent late `RegisterModule()` takes the
+		// back-fill path instead of insert-only, otherwise it could miss notifications for vhosts
+		// created in this call.
+		_server_started = true;
+
 		auto &vhost_conf_list = _server_config->GetVirtualHostList();
 
 		if (CreateVirtualHosts(vhost_conf_list) == false)
@@ -88,9 +93,6 @@ namespace ocst
 				10000);
 			_timer.Start();
 		}
-
-		// From here, any later `RegisterModule()` is back-filled with existing apps.
-		_server_started = true;
 
 		return true;
 	}

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -78,6 +78,7 @@ namespace ocst
 
 		if (CreateVirtualHosts(vhost_conf_list) == false)
 		{
+			_server_started = false;
 			return false;
 		}
 

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -89,6 +89,9 @@ namespace ocst
 			_timer.Start();
 		}
 
+		// From here, any later `RegisterModule()` is back-filled with existing apps.
+		_server_started = true;
+
 		return true;
 	}
 
@@ -310,18 +313,25 @@ namespace ocst
 
 		mon::Monitoring::GetInstance()->OnApplicationDeleted(app_info);
 
-		if (vhost->DeleteApplication(app_id) == false)
 		{
-			logte("Could not delete an application: [%s]", app_info.GetVHostAppName().CStr());
-			return Result::Failed;
-		}
+			// Hold `_late_module_registration_mutex` for vhost removal + module-notification, symmetric
+			// to `CreateApplication()`. Without this, a concurrent late `RegisterModule()` could
+			// back-fill the new module with this application (whose snapshot still includes it) after
+			// the delete-side notification loop has already iterated and skipped the not-yet-registered
+			// module, leaving a stale create-notification with no matching delete-notification.
+			std::scoped_lock reg_lock(_late_module_registration_mutex);
 
-		if (_media_router != nullptr)
-		{
-			_media_router->UnregisterObserverApp(app_info, app->GetSharedPtrAs<MediaRouterApplicationObserver>());
-		}
+			if (vhost->DeleteApplication(app_id) == false)
+			{
+				logte("Could not delete an application: [%s]", app_info.GetVHostAppName().CStr());
+				return Result::Failed;
+			}
 
-		{
+			if (_media_router != nullptr)
+			{
+				_media_router->UnregisterObserverApp(app_info, app->GetSharedPtrAs<MediaRouterApplicationObserver>());
+			}
+
 			logtt("Notifying modules for the delete event...");
 			auto module_list = GetModuleList();
 			// Notify modules of deletion events
@@ -391,23 +401,65 @@ namespace ocst
 			}
 		}
 
+		auto insert_module = [&]() {
+			{
+				std::scoped_lock lock(_module_list_mutex);
+				_module_list.emplace_back(type, module_interface);
+			}
+
+			if (module_interface->GetModuleType() == ModuleType::MediaRouter)
+			{
+				auto media_router = std::dynamic_pointer_cast<MediaRouter>(module_interface);
+
+				OV_ASSERT2(media_router != nullptr);
+
+				_media_router = media_router;
+			}
+
+			logtt("%s module (%p) is registered", GetModuleTypeName(type).CStr(), module_interface.get());
+		};
+
+		// Modules registered before `StartServer()` are notified by the normal `CreateApplication()`
+		// path during the upcoming server start, so just insert and return.
+		if (_server_started.load() == false)
 		{
-			std::lock_guard<std::shared_mutex> lock(_module_list_mutex);
-			_module_list.emplace_back(type, module_interface);
+			insert_module();
+			return true;
 		}
 
-		if (module_interface->GetModuleType() == ModuleType::MediaRouter)
+		// Late registration: the module missed `OnCreateApplication()` notifications fired during
+		// application creation, so replay them here.
+		// Serialize against `CreateApplication()`'s vhost mutation + module-notification block via
+		// `_late_module_registration_mutex` so the new module is either inserted before the new
+		// app's notification fires (normal path covers it) or inserted+back-filled before the new
+		// app exists in any vhost (no double/missed delivery).
+		std::scoped_lock reg_lock(_late_module_registration_mutex);
+
+		insert_module();
+
+		// Back-fill: a failure here is a startup-level error, same as the normal `CreateApplication()`
+		// notification path which aborts on the first failing module (see `CreateApplication()`).
+		// Propagate the failure to the caller so `CREATE_MODULE` can flip `succeeded` to false.
+		bool back_fill_ok = true;
+		for (const auto &vhost : GetVirtualHostList())
 		{
-			auto media_router = std::dynamic_pointer_cast<MediaRouter>(module_interface);
+			for (const auto &app : vhost->GetApplicationList())
+			{
+				const auto &app_info = app->GetAppInfo();
 
-			OV_ASSERT2(media_router != nullptr);
+				logtt("Back-filling %s module (%p) with the existing application (%s)",
+					  GetModuleTypeName(type).CStr(), module_interface.get(), app_info.GetVHostAppName().CStr());
 
-			_media_router = media_router;
+				if (module_interface->OnCreateApplication(app_info) == false)
+				{
+					logte("The %s module (%p) returned an error while back-filling the application [%s]",
+						  GetModuleTypeName(type).CStr(), module_interface.get(), app_info.GetVHostAppName().CStr());
+					back_fill_ok = false;
+				}
+			}
 		}
 
-		logtt("%s module (%p) is registered", GetModuleTypeName(type).CStr(), module_interface.get());
-
-		return true;
+		return back_fill_ok;
 	}
 
 	bool Orchestrator::UnregisterModule(const std::shared_ptr<ModuleInterface> &module_interface)
@@ -1354,17 +1406,26 @@ namespace ocst
 
 		logti("Trying to create an application: [%s]", app_info.GetVHostAppName().CStr());
 
-		if (vhost->CreateApplication(this, app_info) == false)
-		{
-			logte("Could not create an application: [%s]", app_info.GetVHostAppName().CStr());
-			return Result::Failed;
-		}
-
-		mon::Monitoring::GetInstance()->OnApplicationCreated(app_info);
-
-		// Notify modules of creation events
 		bool succeeded = true;
 		{
+			// Hold `_late_module_registration_mutex` from the moment the application becomes
+			// visible in the vhost until every module has been notified, so a concurrent late
+			// `RegisterModule()` either runs entirely before this block (its back-fill does not
+			// see this app, but its module is already in `_module_list` so the loop below
+			// notifies it), or entirely after this block (its back-fill snapshot includes this
+			// app; the loop below could not have notified the module because it was not yet
+			// in `_module_list`).
+			std::scoped_lock reg_lock(_late_module_registration_mutex);
+
+			if (vhost->CreateApplication(this, app_info) == false)
+			{
+				logte("Could not create an application: [%s]", app_info.GetVHostAppName().CStr());
+				return Result::Failed;
+			}
+
+			mon::Monitoring::GetInstance()->OnApplicationCreated(app_info);
+
+			// Notify modules of creation events
 			auto module_list = GetModuleList();
 			for (auto &module : module_list)
 			{

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -62,10 +62,12 @@ namespace ocst
 	public:
 		/// Register the module
 		///
-		/// @param module Module to register
+		/// @param module Module to register. May be called before or after `StartServer()`; in the
+		/// latter case, the module is back-filled with `OnCreateHost()` / `OnCreateApplication()`
+		/// for every existing vhost / application before being inserted.
 		///
-		/// @return If the module is registered or passed a different type from the previously registered type, false is returned.
-		/// Otherwise, true is returned.
+		/// @return `false` if the module is null, already registered (or registered as a different
+		/// type), or a back-fill notification returned false; true otherwise.
 		bool RegisterModule(const std::shared_ptr<ModuleInterface> &module);
 
 		/// Unregister the module
@@ -76,7 +78,8 @@ namespace ocst
 		bool UnregisterModule(const std::shared_ptr<ModuleInterface> &module);
 
 		// Create VirtualHost in the settings and instruct application creation to all registered modules.
-		// So, StartServer should be called after registering all modules with RegisterModule.
+		// Modules registered before this call are notified through the normal create path; modules
+		// registered after this call (`RegisterModule()` post-`StartServer()`) are back-filled.
 		bool StartServer(const std::shared_ptr<const cfg::Server> &server_config);
 		Result Release();
 
@@ -281,18 +284,16 @@ namespace ocst
 		std::vector<Module> _module_list;
 		mutable std::shared_mutex _module_list_mutex;
 
-		// Once `true` (after `StartServer()`), `RegisterModule()` back-fills new modules with existing apps.
+		// Flipped at the start of `StartServer()`, before any vhost/app is created. While `false`,
+		// `RegisterModule()` only inserts; while `true`, it back-fills the new module with existing
+		// vhosts and apps.
 		std::atomic<bool> _server_started{false};
 
-		// Serializes the back-fill in `RegisterModule()`'s late path against the vhost mutation +
-		// module-notification blocks in `CreateApplication()` and `DeleteApplication()`
-		// so that for every (module, application) pair, `OnCreateApplication()` is delivered exactly once
-		// (via back-fill or via the normal create path) and `OnDeleteApplication()` is delivered
-		// exactly when the matching create was delivered - never with a stale create surviving
-		// past a concurrent delete.
-		// `_virtual_host_mutex` does not work for this because `CreateApplication()` only takes it
-		// in shared mode (via `GetVirtualHost()`), so a shared hold from the back-fill would not
-		// exclude it.
+		// Serializes `RegisterModule()`'s late back-fill against the vhost/app mutation and
+		// module-notification blocks in `CreateVirtualHost()`, `DeleteVirtualHost()`,
+		// `CreateApplication()`, and `DeleteApplication()`. Guarantees that for every
+		// (module, vhost) and (module, application) pair, `OnCreate*()` and `OnDelete*()` are
+		// delivered exactly once and only as matched pairs.
 		mutable std::mutex _late_module_registration_mutex;
 
 		// key: vhost_name

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -289,13 +289,15 @@ namespace ocst
 		// vhosts and apps.
 		std::atomic<bool> _server_started{false};
 
-		// Serializes `RegisterModule()`'s late back-fill against the vhost/app mutation and
-		// module-notification blocks in `CreateVirtualHost()`, `DeleteVirtualHost()`,
-		// `CreateApplication()`, and `DeleteApplication()`.
-		// From the moment a module is registered until either `UnregisterModule()` or process shutdown,
-		// every `OnCreate*()` is paired with the matching `OnDelete*()`.
-		// `UnregisterModule()` removes the module without replaying `OnDelete*()`,
-		// so callers that unregister at runtime are responsible for any cleanup the module needs.
+		// Serializes `RegisterModule()`'s late back-fill against the module-notification blocks in
+		// `Create/DeleteVirtualHost()` and `Create/DeleteApplication()`, so a registered module
+		// observes a consistent view of vhost/app create-delete events going through those
+		// runtime paths. Pairing is best-effort outside those paths:
+		//   - `Release()` (shutdown) calls `DeleteApplication()` per app but does not call
+		//     `DeleteVirtualHost()`, so prior `OnCreateHost()` is not paired with `OnDeleteHost()`.
+		//   - `UnregisterModule()` removes the module without replaying any `OnDelete*()`.
+		// Callers shutting down or unregistering at runtime are responsible for any cleanup the
+		// module needs.
 		mutable std::mutex _late_module_registration_mutex;
 
 		// key: vhost_name

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -281,6 +281,20 @@ namespace ocst
 		std::vector<Module> _module_list;
 		mutable std::shared_mutex _module_list_mutex;
 
+		// Once `true` (after `StartServer()`), `RegisterModule()` back-fills new modules with existing apps.
+		std::atomic<bool> _server_started{false};
+
+		// Serializes the back-fill in `RegisterModule()`'s late path against the vhost mutation +
+		// module-notification blocks in `CreateApplication()` and `DeleteApplication()`
+		// so that for every (module, application) pair, `OnCreateApplication()` is delivered exactly once
+		// (via back-fill or via the normal create path) and `OnDeleteApplication()` is delivered
+		// exactly when the matching create was delivered - never with a stale create surviving
+		// past a concurrent delete.
+		// `_virtual_host_mutex` does not work for this because `CreateApplication()` only takes it
+		// in shared mode (via `GetVirtualHost()`), so a shared hold from the back-fill would not
+		// exclude it.
+		mutable std::mutex _late_module_registration_mutex;
+
 		// key: vhost_name
 		std::map<ov::String, std::shared_ptr<VirtualHost>> _virtual_host_map;
 		// ordered vhost list

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -291,9 +291,11 @@ namespace ocst
 
 		// Serializes `RegisterModule()`'s late back-fill against the vhost/app mutation and
 		// module-notification blocks in `CreateVirtualHost()`, `DeleteVirtualHost()`,
-		// `CreateApplication()`, and `DeleteApplication()`. Guarantees that for every
-		// (module, vhost) and (module, application) pair, `OnCreate*()` and `OnDelete*()` are
-		// delivered exactly once and only as matched pairs.
+		// `CreateApplication()`, and `DeleteApplication()`.
+		// From the moment a module is registered until either `UnregisterModule()` or process shutdown,
+		// every `OnCreate*()` is paired with the matching `OnDelete*()`.
+		// `UnregisterModule()` removes the module without replaying `OnDelete*()`,
+		// so callers that unregister at runtime are responsible for any cleanup the module needs.
 		mutable std::mutex _late_module_registration_mutex;
 
 		// key: vhost_name

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -84,7 +84,7 @@ namespace pvd
 
 				if (physical_port == nullptr)
 				{
-					logte("Could not initialize phyiscal port for MPEG-TS server: %s/%s", address.ToString().CStr(), ov::StringFromSocketType(socket_type));
+					logte("Could not initialize physical port for MPEG-TS server: %s/%s", address.ToString().CStr(), ov::StringFromSocketType(socket_type));
 					result = false;
 					break;
 				}

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -41,21 +41,27 @@ namespace pvd
 
 	bool MpegTsProvider::BindMpegTSPorts()
 	{
-		auto &server_config = GetServerConfig();
-		auto &ip_list = server_config.GetIPList();
+		auto &server_config			 = GetServerConfig();
+		auto &ip_list				 = server_config.GetIPList();
 		auto &mpegts_provider_config = server_config.GetBind().GetProviders().GetMpegts();
-		auto &port_config = mpegts_provider_config.GetPort();
-		auto &port_list_config = port_config.GetPortList();
-		auto socket_type = port_config.GetSocketType();
+		auto &port_config			 = mpegts_provider_config.GetPort();
+		auto socket_type			 = port_config.GetSocketType();
 
-		std::map<uint16_t, std::shared_ptr<MpegTsStreamPortItem>> stream_port_map;
 		std::vector<ov::String> address_string_list;
-
 		auto physical_port_manager = PhysicalPortManager::GetInstance();
+
+		// Snapshot to bind. Items were populated by `PrepareInfrastructure()` with empty
+		// `_physical_port_list`; here we create the physical ports and attach them via
+		// `SetPhysicalPortList()`.
+		decltype(_stream_port_map) stream_port_map_snapshot;
+		{
+			std::shared_lock lock(_stream_port_map_lock);
+			stream_port_map_snapshot = _stream_port_map;
+		}
 
 		bool result = true;
 
-		for (const auto &port : port_list_config)
+		for (auto &[port, stream_port_item] : stream_port_map_snapshot)
 		{
 			std::vector<ov::SocketAddress> address_list;
 
@@ -66,7 +72,8 @@ namespace pvd
 			catch (const ov::Error &e)
 			{
 				logte("Could not create socket address: %s", e.What());
-				return false;
+				result = false;
+				break;
 			}
 
 			std::vector<std::shared_ptr<PhysicalPort>> physical_port_list;
@@ -81,41 +88,39 @@ namespace pvd
 					result = false;
 					break;
 				}
-				else
-				{
-					address_string_list.emplace_back(address.ToString());
-				}
 
+				address_string_list.emplace_back(address.ToString());
 				physical_port->AddObserver(this);
-
 				physical_port_list.emplace_back(physical_port);
 			}
 
-			stream_port_map.emplace(port, std::make_shared<MpegTsStreamPortItem>(socket_type, port, physical_port_list));
+			stream_port_item->SetPhysicalPortList(physical_port_list);
+
+			if (result == false)
+			{
+				break;
+			}
 		}
 
 		if (result)
 		{
 			auto socket_type_string = ov::StringFromSocketType(socket_type);
-			ov::String suffix = ov::String::FormatString("/%s, ", socket_type_string);
+			ov::String suffix		= ov::String::FormatString("/%s, ", socket_type_string);
 			logti("%s is listening on %s/%s", GetProviderName(), ov::String::Join(address_string_list, suffix).CStr(), socket_type_string);
-
-			{
-				std::unique_lock lock_guard{_stream_port_map_lock};
-				_stream_port_map = std::move(stream_port_map);
-			}
 			return true;
 		}
 
-		for (const auto &stream_port : stream_port_map)
+		// Rollback: tear down any ports we managed to create.
+		for (const auto &[port, stream_port_item] : stream_port_map_snapshot)
 		{
-			auto physical_port_list = stream_port.second->GetPhysicalPortList();
+			auto physical_port_list = stream_port_item->GetPhysicalPortList();
 
 			for (auto &physical_port : physical_port_list)
 			{
 				physical_port->RemoveObserver(this);
 				physical_port_manager->DeletePort(physical_port);
 			}
+			stream_port_item->SetPhysicalPortList({});
 		}
 
 		return false;
@@ -140,11 +145,44 @@ namespace pvd
 
 	bool MpegTsProvider::Start()
 	{
+		// Infrastructure setup only - populate `_stream_port_map` with metadata-only items
+		// so `OnCreateProviderApplication()` can attach apps to ports during the StartServer
+		// notification pass. Physical port binding is deferred to `Bind()`.
+		auto &server_config			 = GetServerConfig();
+		auto &mpegts_provider_config = server_config.GetBind().GetProviders().GetMpegts();
+
+		if (mpegts_provider_config.IsParsed() == false)
+		{
+			logtw("%s is disabled by configuration", GetProviderName());
+			return true;
+		}
+
+		auto &port_config	   = mpegts_provider_config.GetPort();
+		auto &port_list_config = port_config.GetPortList();
+		auto socket_type	   = port_config.GetSocketType();
+
+		std::map<uint16_t, std::shared_ptr<MpegTsStreamPortItem>> stream_port_map;
+
+		for (const auto &port : port_list_config)
+		{
+			stream_port_map.emplace(port,
+				std::make_shared<MpegTsStreamPortItem>(socket_type, port, std::vector<std::shared_ptr<PhysicalPort>>{}));
+		}
+
+		{
+			std::unique_lock lock_guard{_stream_port_map_lock};
+			_stream_port_map = std::move(stream_port_map);
+		}
+
+		return Provider::Start();
+	}
+
+	bool MpegTsProvider::Bind()
+	{
 		auto &server_config = GetServerConfig();
 
 		if (server_config.GetBind().GetProviders().GetMpegts().IsParsed() == false)
 		{
-			logtw("%s is disabled by configuration", GetProviderName());
 			return true;
 		}
 

--- a/src/projects/providers/mpegts/mpegts_provider.cpp
+++ b/src/projects/providers/mpegts/mpegts_provider.cpp
@@ -50,7 +50,7 @@ namespace pvd
 		std::vector<ov::String> address_string_list;
 		auto physical_port_manager = PhysicalPortManager::GetInstance();
 
-		// Snapshot to bind. Items were populated by `PrepareInfrastructure()` with empty
+		// Snapshot to bind. Items were populated by `Start()` with empty
 		// `_physical_port_list`; here we create the physical ports and attach them via
 		// `SetPhysicalPortList()`.
 		decltype(_stream_port_map) stream_port_map_snapshot;

--- a/src/projects/providers/mpegts/mpegts_provider.h
+++ b/src/projects/providers/mpegts/mpegts_provider.h
@@ -59,6 +59,13 @@ namespace pvd
 			return _physical_port_list;
 		}
 
+		// Used by `MpegTsProvider::BindMpegTSPorts()` to attach `PhysicalPort`s to an item that
+		// was constructed with an empty list during `MpegTsProvider::Start()`.
+		void SetPhysicalPortList(const std::vector<std::shared_ptr<PhysicalPort>> &physical_port_list)
+		{
+			_physical_port_list = physical_port_list;
+		}
+
 		void AttachToApplication(const info::VHostAppName &vhost_app_name, const ov::String &stream_name)
 		{
 			_attached = true;
@@ -119,6 +126,7 @@ namespace pvd
 		~MpegTsProvider() override;
 
 		bool Start() override;
+		bool Bind() override;
 		bool Stop() override;
 
 		//--------------------------------------------------------------------
@@ -152,6 +160,8 @@ namespace pvd
 			ov::String stream_name;
 		};
 
+		// Creates physical ports for each item in `_stream_port_map` (populated by `Start()`)
+		// and starts listening. Called from `Bind()`.
 		bool BindMpegTSPorts();
 
 		//--------------------------------------------------------------------

--- a/src/projects/providers/mpegts/mpegts_provider.h
+++ b/src/projects/providers/mpegts/mpegts_provider.h
@@ -54,8 +54,9 @@ namespace pvd
 			return _stream_name;
 		}
 
-		const std::vector<std::shared_ptr<PhysicalPort>> &GetPhysicalPortList()
+		std::vector<std::shared_ptr<PhysicalPort>> GetPhysicalPortList()
 		{
+			std::scoped_lock lock(_physical_port_list_mutex);
 			return _physical_port_list;
 		}
 
@@ -63,6 +64,7 @@ namespace pvd
 		// was constructed with an empty list during `MpegTsProvider::Start()`.
 		void SetPhysicalPortList(const std::vector<std::shared_ptr<PhysicalPort>> &physical_port_list)
 		{
+			std::scoped_lock lock(_physical_port_list_mutex);
 			_physical_port_list = physical_port_list;
 		}
 
@@ -110,6 +112,7 @@ namespace pvd
 		uint16_t _port = 0;
 		info::VHostAppName _vhost_app_name = info::VHostAppName::InvalidVHostAppName();
 		ov::String _stream_name;
+		mutable std::mutex _physical_port_list_mutex;
 		std::vector<std::shared_ptr<PhysicalPort>> _physical_port_list;
 
 		std::atomic<bool> _attached = false;

--- a/src/projects/providers/rtmp/rtmp_provider.cpp
+++ b/src/projects/providers/rtmp/rtmp_provider.cpp
@@ -74,13 +74,9 @@ namespace pvd
 
 	bool RtmpProvider::Start()
 	{
-		if (_physical_port_list.empty() == false)
-		{
-			logtw("RTMP server is already running");
-			return false;
-		}
-
-		auto server = GetServerConfig();
+		// Infrastructure setup only. Listener binding is deferred to `Bind()` which `main.cpp`
+		// calls after `RestorePullStreams()` / `StartServer()`.
+		auto server				= GetServerConfig();
 		const auto &rtmp_config = server.GetBind().GetProviders().GetRtmp();
 
 		if (rtmp_config.IsParsed() == false)
@@ -89,9 +85,35 @@ namespace pvd
 			return true;
 		}
 
+		_is_ertmp_enabled = server.GetModules().GetERTMP().IsEnabled();
+
+		if (_is_ertmp_enabled)
+		{
+			logtw("E-RTMP is enabled, and this is an experimental feature");
+		}
+
+		return Provider::Start();
+	}
+
+	bool RtmpProvider::Bind()
+	{
+		if (_physical_port_list.empty() == false)
+		{
+			logtw("RTMP server is already running");
+			return false;
+		}
+
+		auto server				= GetServerConfig();
+		const auto &rtmp_config = server.GetBind().GetProviders().GetRtmp();
+
+		if (rtmp_config.IsParsed() == false)
+		{
+			return true;
+		}
+
 		bool is_configured;
-		auto worker_count = rtmp_config.GetWorkerCount(&is_configured);
-		worker_count = is_configured ? worker_count : PHYSICAL_PORT_USE_DEFAULT_COUNT;
+		auto worker_count	   = rtmp_config.GetWorkerCount(&is_configured);
+		worker_count		   = is_configured ? worker_count : PHYSICAL_PORT_USE_DEFAULT_COUNT;
 		auto thread_per_socket = rtmp_config.IsThreadPerSocket();
 
 		std::vector<ov::SocketAddress> rtmp_address_list;
@@ -140,13 +162,6 @@ namespace pvd
 
 			physical_port->AddObserver(this);
 			_physical_port_list.push_back(physical_port);
-		}
-
-		_is_ertmp_enabled = server.GetModules().GetERTMP().IsEnabled();
-
-		if (_is_ertmp_enabled)
-		{
-			logtw("E-RTMP is enabled, and this is an experimental feature");
 		}
 
 		logti("%s is listening on %s",

--- a/src/projects/providers/rtmp/rtmp_provider.cpp
+++ b/src/projects/providers/rtmp/rtmp_provider.cpp
@@ -76,7 +76,7 @@ namespace pvd
 	{
 		// Infrastructure setup only. Listener binding is deferred to `Bind()` which `main.cpp`
 		// calls after `RestorePullStreams()` / `StartServer()`.
-		auto server				= GetServerConfig();
+		const auto &server		= GetServerConfig();
 		const auto &rtmp_config = server.GetBind().GetProviders().GetRtmp();
 
 		if (rtmp_config.IsParsed() == false)
@@ -103,7 +103,7 @@ namespace pvd
 			return false;
 		}
 
-		auto server				= GetServerConfig();
+		const auto &server		= GetServerConfig();
 		const auto &rtmp_config = server.GetBind().GetProviders().GetRtmp();
 
 		if (rtmp_config.IsParsed() == false)

--- a/src/projects/providers/rtmp/rtmp_provider.h
+++ b/src/projects/providers/rtmp/rtmp_provider.h
@@ -31,6 +31,7 @@ namespace pvd
 		~RtmpProvider() override;
 
 		bool Start() override;
+		bool Bind() override;
 		bool Stop() override;
 
 		//--------------------------------------------------------------------

--- a/src/projects/providers/srt/srt_provider.cpp
+++ b/src/projects/providers/srt/srt_provider.cpp
@@ -42,7 +42,9 @@ namespace pvd
 
 	bool SrtProvider::Start()
 	{
-		auto &server_config = GetServerConfig();
+		// Infrastructure setup only - stream URL resolver. Listener binding is deferred to
+		// `Bind()` which `main.cpp` calls after `RestorePullStreams()` / `StartServer()`.
+		auto &server_config	  = GetServerConfig();
 		auto &srt_bind_config = server_config.GetBind().GetProviders().GetSrt();
 
 		if (srt_bind_config.IsParsed() == false)
@@ -51,8 +53,20 @@ namespace pvd
 			return true;
 		}
 
-		// Init StreamMap if exist
 		_stream_url_resolver.Initialize(srt_bind_config.GetStreamMap().GetStreamList());
+
+		return Provider::Start();
+	}
+
+	bool SrtProvider::Bind()
+	{
+		auto &server_config	  = GetServerConfig();
+		auto &srt_bind_config = server_config.GetBind().GetProviders().GetSrt();
+
+		if (srt_bind_config.IsParsed() == false)
+		{
+			return true;
+		}
 
 		bool is_configured;
 		bool is_port_configured;
@@ -81,9 +95,9 @@ namespace pvd
 
 		auto physical_port_manager = PhysicalPortManager::GetInstance();
 
-		auto worker_count = srt_bind_config.GetWorkerCount(&is_configured);
-		worker_count = is_configured ? worker_count : PHYSICAL_PORT_USE_DEFAULT_COUNT;
-		auto thread_per_socket = srt_bind_config.IsThreadPerSocket();
+		auto worker_count		   = srt_bind_config.GetWorkerCount(&is_configured);
+		worker_count			   = is_configured ? worker_count : PHYSICAL_PORT_USE_DEFAULT_COUNT;
+		auto thread_per_socket	   = srt_bind_config.IsThreadPerSocket();
 
 		for (const auto &address : address_list)
 		{

--- a/src/projects/providers/srt/srt_provider.h
+++ b/src/projects/providers/srt/srt_provider.h
@@ -33,6 +33,7 @@ namespace pvd
 		~SrtProvider() override;
 
 		bool Start() override;
+		bool Bind() override;
 		bool Stop() override;
 
 		//--------------------------------------------------------------------

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -45,6 +45,13 @@ namespace pvd
 
 	bool WebRTCProvider::StartSignallingServers(const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config)
 	{
+		if ((_signalling_server == nullptr) || (_whip_server == nullptr))
+		{
+			// `Start()` skipped signalling-server construction because no ports were configured.
+			logtw("%s is disabled - No port is configured", GetProviderName());
+			return true;
+		}
+
 		auto &signalling_config = webrtc_bind_config.GetSignalling();
 
 		bool is_configured;
@@ -56,24 +63,15 @@ namespace pvd
 		bool is_tls_port_configured;
 		auto &tls_port_config = signalling_config.GetTlsPort(&is_tls_port_configured);
 
-		if ((is_port_configured == false) && (is_tls_port_configured == false))
-		{
-			logtw("%s is disabled - No port is configured", GetProviderName());
-			return true;
-		}
-
-		auto rtc_signalling_server	 = std::make_shared<RtcSignallingServer>(server_config, webrtc_bind_config);
 		auto rtc_signalling_observer = RtcSignallingObserver::GetSharedPtr();
-
-		auto whip_server			 = std::make_shared<WhipServer>(webrtc_bind_config);
 
 		do
 		{
 			const auto &ip_list = server_config.GetIPList();
 
 			// Initialize WebSocket Server
-			rtc_signalling_server->AddObserver(rtc_signalling_observer);
-			if (rtc_signalling_server->Start(
+			_signalling_server->AddObserver(rtc_signalling_observer);
+			if (_signalling_server->Start(
 					GetProviderName(), "RtcSig",
 					ip_list,
 					is_port_configured, port_config.GetPort(),
@@ -84,7 +82,7 @@ namespace pvd
 			}
 
 			// Initialize WHIP Server
-			if (whip_server->Start(
+			if (_whip_server->Start(
 					WhipObserver::GetSharedPtr(),
 					GetProviderName(), "WhpSig",
 					ip_list,
@@ -95,50 +93,47 @@ namespace pvd
 				break;
 			}
 
-			_signalling_server = std::move(rtc_signalling_server);
-			_whip_server	   = std::move(whip_server);
-
 			return true;
 		} while (false);
 
-		OV_SAFE_RESET(
-			rtc_signalling_server, nullptr, {
-				rtc_signalling_server->RemoveObserver(rtc_signalling_observer);
-				rtc_signalling_server->Stop();
-			},
-			rtc_signalling_server);
-		OV_SAFE_RESET(whip_server, nullptr, whip_server->Stop(), whip_server);
+		if (_signalling_server != nullptr)
+		{
+			_signalling_server->RemoveObserver(rtc_signalling_observer);
+			_signalling_server->Stop();
+			_signalling_server.reset();
+		}
+		if (_whip_server != nullptr)
+		{
+			_whip_server->Stop();
+			_whip_server.reset();
+		}
 
 		return false;
 	}
 
 	bool WebRTCProvider::StartICEPorts(const cfg::Server &server_config, const cfg::bind::cmm::Webrtc &webrtc_bind_config)
 	{
-		auto ice_port = IcePortManager::GetInstance()->CreateTurnServers(
+		// `_ice_port` is created by `Start()` so back-fill callbacks can find it. Here we only
+		// bind the TURN listeners.
+		if (_ice_port == nullptr)
+		{
+			logte("ICE port was not initialized");
+			return false;
+		}
+
+		return IcePortManager::GetInstance()->BindTurnServers(
 			GetProviderName(),
+			_ice_port,
 			IcePortObserver::GetSharedPtr(),
 			server_config, webrtc_bind_config);
-
-		if (ice_port == nullptr)
-		{
-			return false;
-		}
-
-		_ice_port	 = ice_port;
-
-		_certificate = CreateCertificate();
-
-		if (_certificate == nullptr)
-		{
-			logte("Could not create certificate.");
-			return false;
-		}
-
-		return true;
 	}
 
 	bool WebRTCProvider::Start()
 	{
+		// Infrastructure setup only - no listener bind. Listeners are opened by `Bind()` which
+		// `main.cpp` calls explicitly after `RestorePullStreams()` (Enterprise) or after
+		// `StartServer()` (OSS). Back-fill notifications fired by the later normal
+		// `CreateVirtualHosts()` / `CreateApplication()` flow find every member non-null.
 		auto server_config		= GetServerConfig();
 		auto webrtc_bind_config = server_config.GetBind().GetProviders().GetWebrtc();
 
@@ -149,7 +144,57 @@ namespace pvd
 		}
 
 		_default_transport = webrtc_bind_config.GetIceCandidates().GetDefaultTransport().UpperCaseString();
-		_tcp_relay_force = webrtc_bind_config.GetIceCandidates().IsTcpRelayForce();
+		_tcp_relay_force   = webrtc_bind_config.GetIceCandidates().IsTcpRelayForce();
+
+		// Create ICE port (no TURN bind yet). `OnCreateProviderApplication()` needs `_ice_port`
+		// to be non-null when it constructs a `WebRTCApplication`.
+		_ice_port		   = IcePortManager::GetInstance()->CreatePort(IcePortObserver::GetSharedPtr());
+		if (_ice_port == nullptr)
+		{
+			logte("Could not initialize ICE port. Check your ICE configuration");
+			return false;
+		}
+
+		// Load certificate from disk.
+		_certificate = CreateCertificate();
+		if (_certificate == nullptr)
+		{
+			logte("Could not create certificate.");
+			IcePortManager::GetInstance()->Release(IcePortObserver::GetSharedPtr());
+			return false;
+		}
+
+		auto &signalling_config = webrtc_bind_config.GetSignalling();
+		bool is_port_configured;
+		signalling_config.GetPort(&is_port_configured);
+		bool is_tls_port_configured;
+		signalling_config.GetTlsPort(&is_tls_port_configured);
+
+		if (is_port_configured || is_tls_port_configured)
+		{
+			// Construct signalling/WHIP servers (no listener bind yet) so `OnCreateHost()` /
+			// `OnUpdateCertificate()` can insert certificates during the StartServer notification
+			// pass before `Bind()` opens the listeners.
+			_signalling_server = std::make_shared<RtcSignallingServer>(server_config, webrtc_bind_config);
+			_whip_server	   = std::make_shared<WhipServer>(webrtc_bind_config);
+		}
+
+		// Mark module available so the macro registers it. Base `Provider::Start()` does only
+		// `SetModuleAvailable(true)` + log; `PushProvider::Start()` (task runner thread) is
+		// deferred to `Bind()`.
+		return Provider::Start();
+	}
+
+	bool WebRTCProvider::Bind()
+	{
+		auto server_config		= GetServerConfig();
+		auto webrtc_bind_config = server_config.GetBind().GetProviders().GetWebrtc();
+
+		if (webrtc_bind_config.IsParsed() == false)
+		{
+			// `Start()` already logged the disabled state; nothing to bind.
+			return true;
+		}
 
 		if (StartSignallingServers(server_config, webrtc_bind_config) &&
 			StartICEPorts(server_config, webrtc_bind_config))
@@ -157,7 +202,7 @@ namespace pvd
 			return PushProvider::Start();
 		}
 
-		logte("An error occurred while initialize %s. Stopping RtcSignallingServer...", GetProviderName());
+		logte("An error occurred while binding %s listeners. Stopping RtcSignallingServer...", GetProviderName());
 
 		IcePortManager::GetInstance()->Release(IcePortObserver::GetSharedPtr());
 

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -160,6 +160,7 @@ namespace pvd
 		{
 			logte("Could not create certificate.");
 			IcePortManager::GetInstance()->Release(IcePortObserver::GetSharedPtr());
+			_ice_port = nullptr;
 			return false;
 		}
 

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -133,7 +133,7 @@ namespace pvd
 		// `main.cpp` calls explicitly after `RestorePullStreams()` (Enterprise) or after
 		// `StartServer()` (OSS). Back-fill notifications fired by the later normal
 		// `CreateVirtualHosts()` / `CreateApplication()` flow find every member non-null.
-		auto server_config		= GetServerConfig();
+		const auto &server_config = GetServerConfig();
 		auto webrtc_bind_config = server_config.GetBind().GetProviders().GetWebrtc();
 
 		if (webrtc_bind_config.IsParsed() == false)
@@ -186,7 +186,7 @@ namespace pvd
 
 	bool WebRTCProvider::Bind()
 	{
-		auto server_config		= GetServerConfig();
+		const auto &server_config = GetServerConfig();
 		auto webrtc_bind_config = server_config.GetBind().GetProviders().GetWebrtc();
 
 		if (webrtc_bind_config.IsParsed() == false)
@@ -204,6 +204,19 @@ namespace pvd
 		logte("An error occurred while binding %s listeners. Stopping RtcSignallingServer...", GetProviderName());
 
 		IcePortManager::GetInstance()->Release(IcePortObserver::GetSharedPtr());
+
+		if (_signalling_server != nullptr)
+		{
+			_signalling_server->RemoveObserver(RtcSignallingObserver::GetSharedPtr());
+			_signalling_server->Stop();
+			_signalling_server.reset();
+		}
+
+		if (_whip_server != nullptr)
+		{
+			_whip_server->Stop();
+			_whip_server.reset();
+		}
 
 		return false;
 	}

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -205,6 +205,7 @@ namespace pvd
 		logte("An error occurred while binding %s listeners. Stopping RtcSignallingServer...", GetProviderName());
 
 		IcePortManager::GetInstance()->Release(IcePortObserver::GetSharedPtr());
+		_ice_port = nullptr;
 
 		if (_signalling_server != nullptr)
 		{

--- a/src/projects/providers/webrtc/webrtc_provider.cpp
+++ b/src/projects/providers/webrtc/webrtc_provider.cpp
@@ -123,7 +123,6 @@ namespace pvd
 
 		return IcePortManager::GetInstance()->BindTurnServers(
 			GetProviderName(),
-			_ice_port,
 			IcePortObserver::GetSharedPtr(),
 			server_config, webrtc_bind_config);
 	}

--- a/src/projects/providers/webrtc/webrtc_provider.h
+++ b/src/projects/providers/webrtc/webrtc_provider.h
@@ -30,6 +30,7 @@ namespace pvd
 		~WebRTCProvider() override;
 
 		bool Start() override;
+		bool Bind() override;
 		bool Stop() override;
 
 		//--------------------------------------------------------------------

--- a/src/projects/publishers/file/file_publisher.h
+++ b/src/projects/publishers/file/file_publisher.h
@@ -19,11 +19,10 @@ namespace pub
 
 		FilePublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 		~FilePublisher() override;
+		bool Start() override;
 		bool Stop() override;
 
 	private:
-		bool Start() override;
-
 		//--------------------------------------------------------------------
 		// Implementation of Publisher
 		//--------------------------------------------------------------------

--- a/src/projects/publishers/hls/hls_publisher.h
+++ b/src/projects/publishers/hls/hls_publisher.h
@@ -22,6 +22,7 @@ public:
 
 	HlsPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 	~HlsPublisher() override;
+	bool Start() override;
 	bool Stop() override;
 
 protected:
@@ -32,8 +33,6 @@ protected:
 		const int worker_count);
 
 private:
-	bool Start() override;
-
 	//--------------------------------------------------------------------
 	// Implementation of Publisher
 	//--------------------------------------------------------------------

--- a/src/projects/publishers/llhls/llhls_publisher.h
+++ b/src/projects/publishers/llhls/llhls_publisher.h
@@ -22,6 +22,7 @@ public:
 
 	LLHlsPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 	~LLHlsPublisher() override;
+	bool Start() override;
 	bool Stop() override;
 
 protected:
@@ -32,8 +33,6 @@ protected:
 		const int worker_count);
 
 private:
-	bool Start() override;
-
 	//--------------------------------------------------------------------
 	// Implementation of Publisher
 	//--------------------------------------------------------------------

--- a/src/projects/publishers/ovt/ovt_publisher.h
+++ b/src/projects/publishers/ovt/ovt_publisher.h
@@ -17,11 +17,10 @@ public:
 
 	OvtPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 	~OvtPublisher() override;
+	bool Start() override;
 	bool Stop() override;
 
 private:
-	bool Start() override;
-
 	//--------------------------------------------------------------------
 	// Implementation of Publisher
 	//--------------------------------------------------------------------

--- a/src/projects/publishers/push/push_publisher.h
+++ b/src/projects/publishers/push/push_publisher.h
@@ -22,11 +22,10 @@ namespace pub
 
 		PushPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 		~PushPublisher() override;
+		bool Start() override;
 		bool Stop() override;
 
 	private:
-		bool Start() override;
-
 		//--------------------------------------------------------------------
 		// Implementation of Publisher
 		//--------------------------------------------------------------------

--- a/src/projects/publishers/srt/srt_publisher.h
+++ b/src/projects/publishers/srt/srt_publisher.h
@@ -28,11 +28,10 @@ namespace pub
 		SrtPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 		~SrtPublisher() override final;
 
+		bool Start() override;
 		bool Stop() override;
 
 	private:
-		bool Start() override;
-
 		//--------------------------------------------------------------------
 		// Implementation of Publisher
 		//--------------------------------------------------------------------

--- a/src/projects/publishers/thumbnail/thumbnail_publisher.h
+++ b/src/projects/publishers/thumbnail/thumbnail_publisher.h
@@ -18,6 +18,7 @@ public:
 
 	ThumbnailPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 	~ThumbnailPublisher() override;
+	bool Start() override;
 	bool Stop() override;
 
 protected:
@@ -28,8 +29,6 @@ protected:
 		const int worker_count);
 
 private:
-	bool Start() override;
-
 	//--------------------------------------------------------------------
 	// Implementation of Publisher
 	//--------------------------------------------------------------------

--- a/src/projects/publishers/webrtc/webrtc_publisher.h
+++ b/src/projects/publishers/webrtc/webrtc_publisher.h
@@ -27,6 +27,7 @@ public:
 	WebRtcPublisher(const cfg::Server &server_config, const std::shared_ptr<MediaRouterInterface> &router);
 	~WebRtcPublisher() override;
 
+	bool Start() override;
 	bool Stop() override;
 
 	// IcePortObserver Implementation
@@ -77,7 +78,6 @@ private:
 		transfer_completed,
 	};
 
-	bool Start() override;
 	bool DisconnectSessionInternal(const std::shared_ptr<RtcSession> &session);
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Allows provider modules to be registered after `Orchestrator::StartServer()`.
A new back-fill replays `OnCreateHost()` and `OnCreateApplication()` for existing virtual hosts and applications when a module registers late, serialized against vhost/app create/delete with a dedicated mutex. `main.cpp` uses this to defer push provider listener binding until after `StartServer()`.

## Changes

- `Orchestrator`:
  - `_server_started` flag flipped at the start of `StartServer()`, before `CreateVirtualHosts()` runs, so a concurrent late `RegisterModule()` takes the back-fill path instead of insert-only.
  - `RegisterModule()` late path replays `OnCreateHost()` then `OnCreateApplication()` for existing vhosts/apps before insertion; rolls back on any failure.
  - `_late_module_registration_mutex` serializes back-fill against `Create/DeleteVirtualHost()` and `Create/DeleteApplication()` so each module receives exactly one matched notification pair per vhost/app.
- `main.cpp` / `init_utilities.h`:
  - `INIT_MODULE` calls `Stop()` and resets the variable when `RegisterModule()` fails so the partially-created module is not leaked.
  - Push providers (`WebRTCProvider`, `MpegTsProvider`, `SrtProvider`, `RtmpProvider`) split `Start()` (infrastructure only) from a new `Bind()` (listener bind). `main.cpp` calls `Bind()` on each push provider after `StartServer()` so listeners only accept traffic once vhost/app state is fully populated.
- `Stream::Stop()`:
  - Fixes a TOCTOU where `Terminate()` racing with `Stop()` could be silently overwritten back to `STOPPED`. Switched to `compare_exchange_weak` on the atomic `_state`.
