### PR TITLE
feat: add ManagedQueue::InjectWakeup() to wake a blocked Dequeue()

### DIFF
--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -204,12 +204,12 @@ namespace ov
 			// queue stuck with expire == time_point::max()).
 			while (!_stop)
 			{
-				// Woken explicitly via Notify(): consume the flag and return nullopt
-				// so the caller can re-evaluate its state. Checked before the
+				// Woken by InjectWakeup(): consume the flag and return nullopt so
+				// the caller can re-evaluate its state. Checked before the
 				// readiness checks so a stale flag never leaks into a later call.
-				if (_notified)
+				if (_pending_wakeup)
 				{
-					_notified = false;
+					_pending_wakeup = false;
 					return {};
 				}
 
@@ -351,20 +351,20 @@ namespace ov
 			_condition.notify_all();
 		}
 
-		// Wakes Dequeue() so the caller can re-evaluate its own state.
-		//
-		// The next Dequeue() returns std::nullopt exactly once, even if the
-		// queue is non-empty and even if no consumer is waiting at the time
-		// (the wakeup is remembered, never lost). Queued items are preserved.
-		// A consumer on a queue that uses Notify() must treat std::nullopt as
-		// a "re-evaluate state" signal, not as "queue empty".
+		// Injects a one-shot wakeup so the consumer can re-evaluate its state.
+		// Behaves as if an empty item were injected into the queue: the next
+		// Dequeue() returns std::nullopt exactly once, even if the queue is
+		// non-empty and even if no consumer is waiting (the wakeup is
+		// remembered, never lost). Queued items are preserved. A consumer on a
+		// queue that uses InjectWakeup() must treat std::nullopt as a
+		// "re-evaluate state" signal, not as "queue empty".
 		//
 		// notify_all() keeps the wakeup reliable when Front()/Back() waiters coexist.
-		void Notify()
+		void InjectWakeup()
 		{
 			auto lock_guard = std::lock_guard(_mutex);
 
-			_notified = true;
+			_pending_wakeup = true;
 
 			_condition.notify_all();
 		}
@@ -650,9 +650,9 @@ namespace ov
 		// Stop flag
 		bool _stop;
 
-		// Notify flag: set by Notify() to wake a blocked Dequeue() so the caller
-		// can re-evaluate its own state. Unlike _stop, the queue stays usable.
-		bool _notified = false;
+		// Set by InjectWakeup(), consumed by Dequeue(). A pending one-shot
+		// wakeup. Unlike _stop, the queue stays usable.
+		bool _pending_wakeup = false;
 
 		// Use to print logs when the peak value of the queue is increased.
 		size_t _last_logged_peak = 0;

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -351,9 +351,15 @@ namespace ov
 			_condition.notify_all();
 		}
 
-		// Wakes threads blocked in Dequeue() so they return std::nullopt and the
-		// caller can re-evaluate its state. Unlike Stop(), the queue stays usable.
-		// notify_all() keeps it reliable when Front()/Back() waiters coexist.
+		// Wakes Dequeue() so the caller can re-evaluate its own state.
+		//
+		// The next Dequeue() returns std::nullopt exactly once, even if the
+		// queue is non-empty and even if no consumer is waiting at the time
+		// (the wakeup is remembered, never lost). Queued items are preserved.
+		// A consumer on a queue that uses Notify() must treat std::nullopt as
+		// a "re-evaluate state" signal, not as "queue empty".
+		//
+		// notify_all() keeps the wakeup reliable when Front()/Back() waiters coexist.
 		void Notify()
 		{
 			auto lock_guard = std::lock_guard(_mutex);

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -204,6 +204,15 @@ namespace ov
 			// queue stuck with expire == time_point::max()).
 			while (!_stop)
 			{
+				// Woken explicitly via Notify(): consume the flag and return nullopt
+				// so the caller can re-evaluate its state. Checked before the
+				// readiness checks so a stale flag never leaks into a later call.
+				if (_notified)
+				{
+					_notified = false;
+					return {};
+				}
+
 				// Check whether an item is ready to be dequeued.
 				if (_buffering_delay == 0)
 				{
@@ -222,14 +231,6 @@ namespace ov
 					{
 						break;
 					}
-				}
-
-				// Woken explicitly via Notify(): return nullopt so the caller can
-				// re-evaluate its state. The queue itself stays usable.
-				if (_notified)
-				{
-					_notified = false;
-					return {};
 				}
 
 				// Compute the next wakeup time: whichever comes first between
@@ -350,9 +351,9 @@ namespace ov
 			_condition.notify_all();
 		}
 
-		// Wakes a thread currently blocked in Dequeue(), making it return
-		// std::nullopt so the caller can re-evaluate its own state. Unlike Stop(),
-		// the queue stays fully usable afterwards.
+		// Wakes threads blocked in Dequeue() so they return std::nullopt and the
+		// caller can re-evaluate its state. Unlike Stop(), the queue stays usable.
+		// notify_all() keeps it reliable when Front()/Back() waiters coexist.
 		void Notify()
 		{
 			auto lock_guard = std::lock_guard(_mutex);

--- a/src/projects/modules/managed_queue/managed_queue.h
+++ b/src/projects/modules/managed_queue/managed_queue.h
@@ -218,10 +218,18 @@ namespace ov
 					{
 						break;
 					}
-					if (GetBufferedTimeMsInternal() >= _buffering_delay) 
+					if (GetBufferedTimeMsInternal() >= _buffering_delay)
 					{
 						break;
 					}
+				}
+
+				// Woken explicitly via Notify(): return nullopt so the caller can
+				// re-evaluate its state. The queue itself stays usable.
+				if (_notified)
+				{
+					_notified = false;
+					return {};
 				}
 
 				// Compute the next wakeup time: whichever comes first between
@@ -338,6 +346,18 @@ namespace ov
 			_stop = true;
 
 			ClearMetrics();
+
+			_condition.notify_all();
+		}
+
+		// Wakes a thread currently blocked in Dequeue(), making it return
+		// std::nullopt so the caller can re-evaluate its own state. Unlike Stop(),
+		// the queue stays fully usable afterwards.
+		void Notify()
+		{
+			auto lock_guard = std::lock_guard(_mutex);
+
+			_notified = true;
 
 			_condition.notify_all();
 		}
@@ -622,6 +642,10 @@ namespace ov
 
 		// Stop flag
 		bool _stop;
+
+		// Notify flag: set by Notify() to wake a blocked Dequeue() so the caller
+		// can re-evaluate its own state. Unlike _stop, the queue stays usable.
+		bool _notified = false;
 
 		// Use to print logs when the peak value of the queue is increased.
 		size_t _last_logged_peak = 0;


### PR DESCRIPTION
## Problem
A consumer blocked in an infinite `Dequeue()` wait cannot be woken on an external state change. The only options are enqueuing a real item, calling `Stop()` which terminates the queue, or polling with a timeout.

## Solution
Add `ManagedQueue::InjectWakeup()`. It makes the next `Dequeue()` return `std::nullopt` exactly once so the consumer re-evaluates its own state, and the queue stays usable afterwards.