### PR TITLE
build(stubs): add required CUDA stub functions

### DIFF
--- a/misc/stubs/libcuda_stub.c
+++ b/misc/stubs/libcuda_stub.c
@@ -6,7 +6,10 @@
 #define CUDAAPI
 typedef void* CUdevice;
 typedef void* CUdevice_attribute;
-typedef enum cudaError_enum { stub } CUresult;
+typedef enum cudaError_enum {
+	CUDA_SUCCESS                 = 0,
+	CUDA_ERROR_STUB_LIBRARY      = 34,
+} CUresult;
 
 typedef unsigned long long CUdeviceptr;
 typedef unsigned long long CUmemGenericAllocationHandle;
@@ -14,67 +17,68 @@ typedef int CUmemAllocationGranularity_flags;
 
 CUresult CUDAAPI cuDeviceGet(CUdevice *device, int ordinal)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuInit(unsigned int Flags)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuDeviceGetCount(int *count)
 {
-	return 0;
+	if (count) *count = 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr)
 {
-	if (pStr) *pStr = "_stub_";
-	return 0;
+	if (pStr) *pStr = "CUDA stub library: driver not available";
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment, CUdeviceptr addr, unsigned long long flags)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemAddressFree(CUdeviceptr ptr, size_t size)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size, const void *prop, unsigned long long flags)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemRelease(CUmemGenericAllocationHandle handle)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemMap(CUdeviceptr ptr, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemUnmap(CUdeviceptr ptr, size_t size)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemSetAccess(CUdeviceptr ptr, size_t size, const void *desc, size_t count)
 {
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }
 
 CUresult CUDAAPI cuMemGetAllocationGranularity(size_t *granularity, const void *prop, CUmemAllocationGranularity_flags option)
 {
 	if (granularity) *granularity = 0;
-	return 0;
+	return CUDA_ERROR_STUB_LIBRARY;
 }

--- a/misc/stubs/libcuda_stub.c
+++ b/misc/stubs/libcuda_stub.c
@@ -8,12 +8,16 @@ typedef void* CUdevice;
 typedef void* CUdevice_attribute;
 typedef enum cudaError_enum { stub } CUresult;
 
+typedef unsigned long long CUdeviceptr;
+typedef unsigned long long CUmemGenericAllocationHandle;
+typedef int CUmemAllocationGranularity_flags;
+
 CUresult CUDAAPI cuDeviceGet(CUdevice *device, int ordinal)
 {
 	return 0;
 }
 
-CUresult CUDAAPI cuInit(unsigned int Flags) 
+CUresult CUDAAPI cuInit(unsigned int Flags)
 {
 	return 0;
 }
@@ -25,5 +29,52 @@ CUresult CUDAAPI cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevi
 
 CUresult CUDAAPI cuDeviceGetCount(int *count)
 {
+	return 0;
+}
+
+CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr)
+{
+	if (pStr) *pStr = "_stub_";
+	return 0;
+}
+
+CUresult CUDAAPI cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment, CUdeviceptr addr, unsigned long long flags)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemAddressFree(CUdeviceptr ptr, size_t size)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size, const void *prop, unsigned long long flags)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemRelease(CUmemGenericAllocationHandle handle)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemMap(CUdeviceptr ptr, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemUnmap(CUdeviceptr ptr, size_t size)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemSetAccess(CUdeviceptr ptr, size_t size, const void *desc, size_t count)
+{
+	return 0;
+}
+
+CUresult CUDAAPI cuMemGetAllocationGranularity(size_t *granularity, const void *prop, CUmemAllocationGranularity_flags option)
+{
+	if (granularity) *granularity = 0;
 	return 0;
 }

--- a/misc/stubs/libcuda_stub.c
+++ b/misc/stubs/libcuda_stub.c
@@ -44,6 +44,7 @@ CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr)
 
 CUresult CUDAAPI cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment, CUdeviceptr addr, unsigned long long flags)
 {
+	if (ptr) *ptr = 0;
 	return CUDA_ERROR_STUB_LIBRARY;
 }
 
@@ -54,6 +55,7 @@ CUresult CUDAAPI cuMemAddressFree(CUdeviceptr ptr, size_t size)
 
 CUresult CUDAAPI cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size, const void *prop, unsigned long long flags)
 {
+	if (handle) *handle = 0;
 	return CUDA_ERROR_STUB_LIBRARY;
 }
 


### PR DESCRIPTION
### Summary
When Whisper is statically linked, it requires several CUDA driver API functions (cuMemAddressReserve, cuMemCreate, cuMemMap, etc.) that are not present in the existing stub. This caused a runtime crash on systems without an NVIDIA driver installed.

This PR adds no-op stub implementations for the missing functions to allow OvenMediaEngine to run correctly without an NVIDIA driver.