### PR TITLE
refactor: split `Orchestrator::DeleteApplication()` into wrapper and internal helper

### DIFF
--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -357,8 +357,8 @@ namespace ocst
 		// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
 		// `DeleteVirtualHost()` cannot remove the vhost and emit `OnDeleteHost()` between the
 		// lookup and the app-delete notifications below.
-		// `DeleteVirtualHost()` already holds this mutex and calls `DeleteApplicationInternal()`
-		// directly, so the actual delete logic lives there and this is just the locking wrapper.
+		// The actual application-delete logic lives in `DeleteApplicationInternal()`;
+		// this method is the locking wrapper for that path.
 		std::scoped_lock lock(_late_module_registration_mutex);
 
 		return DeleteApplicationInternal(vhost_name, app_id);

--- a/src/projects/orchestrator/orchestrator.cpp
+++ b/src/projects/orchestrator/orchestrator.cpp
@@ -295,13 +295,8 @@ namespace ocst
 		return result;
 	}
 
-	ocst::Result Orchestrator::DeleteApplication(const ov::String &vhost_name, info::application_id_t app_id)
+	ocst::Result Orchestrator::DeleteApplicationInternal(const ov::String &vhost_name, info::application_id_t app_id)
 	{
-		// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
-		// `DeleteVirtualHost()` cannot remove the vhost and emit `OnDeleteHost()` between the
-		// lookup and the app-delete notifications below.
-		std::scoped_lock lock(_late_module_registration_mutex);
-
 		auto vhost = GetVirtualHost(vhost_name);
 		if (vhost == nullptr)
 		{
@@ -355,6 +350,18 @@ namespace ocst
 		}
 
 		return Result::Succeeded;
+	}
+
+	ocst::Result Orchestrator::DeleteApplication(const ov::String &vhost_name, info::application_id_t app_id)
+	{
+		// Acquire `_late_module_registration_mutex` before the vhost lookup so a concurrent
+		// `DeleteVirtualHost()` cannot remove the vhost and emit `OnDeleteHost()` between the
+		// lookup and the app-delete notifications below.
+		// `DeleteVirtualHost()` already holds this mutex and calls `DeleteApplicationInternal()`
+		// directly, so the actual delete logic lives there and this is just the locking wrapper.
+		std::scoped_lock lock(_late_module_registration_mutex);
+
+		return DeleteApplicationInternal(vhost_name, app_id);
 	}
 
 	std::vector<std::shared_ptr<ocst::VirtualHost>> Orchestrator::GetVirtualHostList() const

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -260,10 +260,8 @@ namespace ocst
 
 		// Deletes the application and notifies the modules, without acquiring `_late_module_registration_mutex` itself.
 		// The caller MUST already hold `_late_module_registration_mutex`.
-		// This lets `DeleteVirtualHost()` delete every child application and remove the vhost
-		// inside a single critical section, so a concurrent `CreateApplication()`
-		// (which holds the same mutex for its whole flow) cannot add an application that the fan-out misses.
-		// `DeleteApplication()` is the locking wrapper for the standalone call path.
+		// This helper is intended for call paths that already execute inside that critical section,
+ 		// while `DeleteApplication()` is the locking wrapper for the standalone call path.
 		//
 		// @param vhost_name Name of the virtual host the application belongs to
 		// @param app_id Id of the application to delete

--- a/src/projects/orchestrator/orchestrator.h
+++ b/src/projects/orchestrator/orchestrator.h
@@ -258,6 +258,19 @@ namespace ocst
 		std::shared_ptr<PullProviderModuleInterface> GetProviderModuleForScheme(const ov::String &scheme);
 		std::shared_ptr<pvd::Provider> GetProviderForUrl(const ov::String &url);
 
+		// Deletes the application and notifies the modules, without acquiring `_late_module_registration_mutex` itself.
+		// The caller MUST already hold `_late_module_registration_mutex`.
+		// This lets `DeleteVirtualHost()` delete every child application and remove the vhost
+		// inside a single critical section, so a concurrent `CreateApplication()`
+		// (which holds the same mutex for its whole flow) cannot add an application that the fan-out misses.
+		// `DeleteApplication()` is the locking wrapper for the standalone call path.
+		//
+		// @param vhost_name Name of the virtual host the application belongs to
+		// @param app_id Id of the application to delete
+		//
+		// @return Deletion result
+		Result DeleteApplicationInternal(const ov::String &vhost_name, info::application_id_t app_id);
+
 		std::shared_ptr<VirtualHost> GetVirtualHost(const ov::String &vhost_name);
 		std::shared_ptr<const VirtualHost> GetVirtualHost(const ov::String &vhost_name) const;
 		std::shared_ptr<VirtualHost> GetVirtualHost(const info::VHostAppName &vhost_app_name);


### PR DESCRIPTION
## Summary
- split `Orchestrator::DeleteApplication()` into a locking wrapper and an internal helper
- preserve the current behavior
- prepare the delete flow for future extensibility

## Notes
This is a refactoring-only change. The current delete path still acquires `_late_module_registration_mutex` and runs the same deletion logic as before.